### PR TITLE
Add initial podspecs

### DIFF
--- a/MobiusCore.podspec.json
+++ b/MobiusCore.podspec.json
@@ -1,0 +1,22 @@
+{
+  "name": "MobiusCore",
+  "version": "0.1-alpha",
+  "summary": "A functional reactive framework for managing state evolution and side-effects",
+  "authors": "Spotify AB",
+  "homepage": "https://github.com/spotify/Mobius.swift",
+  "social_media_url": "https://twitter.com/spotifyeng",
+  "license": {
+    "type": "Apache 2.0",
+    "file": "LICENSE"
+  },
+  "source": {
+    "git": "https://github.com/spotify/Mobius.swift.git",
+    "tag": "v0.1-alpha"
+  },
+  "platforms": {
+    "ios": "10.0"
+  },
+  "swift_version": "4.2",
+  "module_name": "MobiusCore",
+  "source_files": "MobiusCore/Source/**/*.swift"
+}

--- a/MobiusExtras.podspec.json
+++ b/MobiusExtras.podspec.json
@@ -1,0 +1,27 @@
+{
+  "name": "MobiusExtras",
+  "version": "0.1-alpha",
+  "summary": "A functional reactive framework for managing state evolution and side-effects: Extra Helpers",
+  "authors": "Spotify AB",
+  "homepage": "https://github.com/spotify/Mobius.swift/tree/master/MobiusExtras",
+  "social_media_url": "https://twitter.com/spotifyeng",
+  "license": {
+    "type": "Apache 2.0",
+    "file": "LICENSE"
+  },
+  "source": {
+    "git": "https://github.com/spotify/Mobius.swift.git",
+    "tag": "v0.1-alpha"
+  },
+  "platforms": {
+    "ios": "10.0"
+  },
+  "swift_version": "4.2",
+  "module_name": "MobiusExtras",
+  "source_files": "MobiusExtras/Source/**/*.swift",
+  "dependencies": {
+    "MobiusCore": [
+      "0.1-alpha"
+    ]
+  }
+}

--- a/MobiusNimble.podspec.json
+++ b/MobiusNimble.podspec.json
@@ -1,0 +1,36 @@
+{
+  "name": "MobiusNimble",
+  "version": "0.1-alpha",
+  "summary": "A functional reactive framework for managing state evolution and side-effects: Nimble Helpers",
+  "authors": "Spotify AB",
+  "homepage": "https://github.com/spotify/Mobius.swift/tree/master/MobiusNimble",
+  "social_media_url": "https://twitter.com/spotifyeng",
+  "license": {
+    "type": "Apache 2.0",
+    "file": "LICENSE"
+  },
+  "source": {
+    "git": "https://github.com/spotify/Mobius.swift.git",
+    "tag": "v0.1-alpha"
+  },
+  "platforms": {
+    "ios": "10.0"
+  },
+  "swift_version": "4.2",
+  "module_name": "MobiusNimble",
+  "source_files": "MobiusNimble/Source/**/*.swift",
+  "frameworks": [
+    "XCTest"
+  ],
+  "dependencies": {
+    "MobiusCore": [
+      "0.1-alpha"
+    ],
+    "MobiusTest": [
+      "0.1-alpha"
+    ],
+    "Nimble": [
+      "~> 7.0"
+    ]
+  }
+}

--- a/MobiusTest.podspec.json
+++ b/MobiusTest.podspec.json
@@ -1,0 +1,30 @@
+{
+  "name": "MobiusTest",
+  "version": "0.1-alpha",
+  "summary": "A functional reactive framework for managing state evolution and side-effects: Test Helpers",
+  "authors": "Spotify AB",
+  "homepage": "https://github.com/spotify/Mobius.swift/tree/master/MobiusTest",
+  "social_media_url": "https://twitter.com/spotifyeng",
+  "license": {
+    "type": "Apache 2.0",
+    "file": "LICENSE"
+  },
+  "source": {
+    "git": "https://github.com/spotify/Mobius.swift.git",
+    "tag": "v0.1-alpha"
+  },
+  "platforms": {
+    "ios": "10.0"
+  },
+  "swift_version": "4.2",
+  "module_name": "MobiusTest",
+  "source_files": "MobiusTest/Source/**/*.swift",
+  "frameworks": [
+    "XCTest"
+  ],
+  "dependencies": {
+    "MobiusCore": [
+      "0.1-alpha"
+    ]
+  }
+}


### PR DESCRIPTION
Tested against a local specs repo. Spec lint checks passed. Shipped as four separate podspecs as you seemingly cannot have subspecs define their own module.

I'm also working on a script to generate these files and deploy them to the cocoapods trunk repo, which I can only really test once this is merged. When I get the script to a point where it works, I will submit it in a followup PR, along with a README section that explains how to integrate with cocoapods.

@BalestraPatrick @jeppes