### PR TITLE
Set -UseNewBuildSystem=NO

### DIFF
--- a/Tools/helpers.sh
+++ b/Tools/helpers.sh
@@ -18,9 +18,11 @@ has_command() {
 }
 
 xcb() {
+  # TODO: use new build system in Xcode 10.2+
   export NSUnbufferedIO=YES
   set -o pipefail && xcodebuild \
     -UseSanitizedBuildSystemEnvironment=YES \
+    -UseNewBuildSystem=NO \
     CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY= \
     "$@" | xcpretty
 }


### PR DESCRIPTION
This repo has the same problem with NBS that some of our internal repos have:

https://travis-ci.org/spotify/Mobius.swift/builds/505944158
`error: unexpected service error: The Xcode build system has crashed. Please close and reopen your workspace.`

Add `-UseNewBuildSystem=NO` to the `xcodebuild` command until Xcode 10.2 has a proper release and support in travis. 10.2 seems to be a _lot_ less crashy.

@BalestraPatrick @jeppes 