### PR TITLE
Change tag to use semantic versioning

### DIFF
--- a/MobiusCore.podspec.json
+++ b/MobiusCore.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "MobiusCore",
-  "version": "0.1-alpha",
+  "version": "0.1.0-alpha",
   "summary": "A functional reactive framework for managing state evolution and side-effects",
   "authors": "Spotify AB",
   "homepage": "https://github.com/spotify/Mobius.swift",
@@ -11,7 +11,7 @@
   },
   "source": {
     "git": "https://github.com/spotify/Mobius.swift.git",
-    "tag": "v0.1-alpha"
+    "tag": "0.1.0-alpha"
   },
   "platforms": {
     "ios": "10.0"

--- a/MobiusExtras.podspec.json
+++ b/MobiusExtras.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "MobiusExtras",
-  "version": "0.1-alpha",
+  "version": "0.1.0-alpha",
   "summary": "A functional reactive framework for managing state evolution and side-effects: Extra Helpers",
   "authors": "Spotify AB",
   "homepage": "https://github.com/spotify/Mobius.swift/tree/master/MobiusExtras",
@@ -11,7 +11,7 @@
   },
   "source": {
     "git": "https://github.com/spotify/Mobius.swift.git",
-    "tag": "v0.1-alpha"
+    "tag": "0.1.0-alpha"
   },
   "platforms": {
     "ios": "10.0"
@@ -21,7 +21,7 @@
   "source_files": "MobiusExtras/Source/**/*.swift",
   "dependencies": {
     "MobiusCore": [
-      "0.1-alpha"
+      "0.1.0-alpha"
     ]
   }
 }

--- a/MobiusNimble.podspec.json
+++ b/MobiusNimble.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "MobiusNimble",
-  "version": "0.1-alpha",
+  "version": "0.1.0-alpha",
   "summary": "A functional reactive framework for managing state evolution and side-effects: Nimble Helpers",
   "authors": "Spotify AB",
   "homepage": "https://github.com/spotify/Mobius.swift/tree/master/MobiusNimble",
@@ -11,7 +11,7 @@
   },
   "source": {
     "git": "https://github.com/spotify/Mobius.swift.git",
-    "tag": "v0.1-alpha"
+    "tag": "0.1.0-alpha"
   },
   "platforms": {
     "ios": "10.0"
@@ -24,10 +24,10 @@
   ],
   "dependencies": {
     "MobiusCore": [
-      "0.1-alpha"
+      "0.1.0-alpha"
     ],
     "MobiusTest": [
-      "0.1-alpha"
+      "0.1.0-alpha"
     ],
     "Nimble": [
       "~> 7.0"

--- a/MobiusTest.podspec.json
+++ b/MobiusTest.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "MobiusTest",
-  "version": "0.1-alpha",
+  "version": "0.1.0-alpha",
   "summary": "A functional reactive framework for managing state evolution and side-effects: Test Helpers",
   "authors": "Spotify AB",
   "homepage": "https://github.com/spotify/Mobius.swift/tree/master/MobiusTest",
@@ -11,7 +11,7 @@
   },
   "source": {
     "git": "https://github.com/spotify/Mobius.swift.git",
-    "tag": "v0.1-alpha"
+    "tag": "0.1.0-alpha"
   },
   "platforms": {
     "ios": "10.0"
@@ -24,7 +24,7 @@
   ],
   "dependencies": {
     "MobiusCore": [
-      "0.1-alpha"
+      "0.1.0-alpha"
     ]
   }
 }

--- a/Tools/cocoapods.rb
+++ b/Tools/cocoapods.rb
@@ -23,7 +23,7 @@ end
 SWIFT_VERSION = '4.2'
 IOS_DEPLOYMENT_TARGET = '10.0'
 NIMBLE_VERSION = begin
-  ver = `cat Cartfile.private | grep Nimble | grep -o '~.*'`.strip
+  ver = `cat Cartfile | grep Nimble | grep -o '~.*'`.strip
   if !$?.success? || ver.empty?
     raise Exception.new('could not parse nimble version from Cartfile')
   end
@@ -129,7 +129,7 @@ def generate_podspec(name:, source_files:, summary:, dependencies: [], framework
     },
     'source' => {
       'git' => 'https://github.com/spotify/Mobius.swift.git',
-      'tag' => "v#{VERSION}",
+      'tag' => VERSION,
     },
     'platforms' => {
       'ios' => IOS_DEPLOYMENT_TARGET,


### PR DESCRIPTION
This should make all dependency managers happy. Once this is merged, we can push a new version to the CocoaPods trunk.