### PR TITLE
Bump xcconfigs for Xcode 10.2 support

### DIFF
--- a/Cartfile.private
+++ b/Cartfile.private
@@ -1,2 +1,2 @@
 github "Quick/Quick" ~> 2.0
-github "jspahrsummers/xcconfigs" == 0.12
+github "jspahrsummers/xcconfigs" == 1.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,3 +1,3 @@
 github "Quick/Nimble" "v8.0.1"
 github "Quick/Quick" "v2.0.0"
-github "jspahrsummers/xcconfigs" "0.12"
+github "jspahrsummers/xcconfigs" "1.0"


### PR DESCRIPTION
This PR bumps our xcconfigs to version 1.0 from 0.12 ([changelog](https://github.com/jspahrsummers/xcconfigs/compare/0.12...1.0)) to bring better Xcode 10.2 support.

I’ve tested it locally with Xcode 10.1 and everything works as intended with no new warnings. Since I don‘t yet have macOS 10.14.4 I can’t run Xcode 10.2 so I’ll let CI do that for now. Once I’ve upgraded later today I’ll run it locally as well and fix any new warnings.