### PR TITLE
Fix base internationalization warning in Xcode 10.2

### DIFF
--- a/Mobius.xcodeproj/project.pbxproj
+++ b/Mobius.xcodeproj/project.pbxproj
@@ -1096,6 +1096,7 @@
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
+				Base,
 			);
 			mainGroup = 2D9A2FAB205C06FA00B1A332;
 			productRefGroup = 5B3AA33320975248003F35C3 /* Products */;


### PR DESCRIPTION
From the [Xcode 10.2 release notes](https://developer.apple.com/documentation/xcode_release_notes/xcode_10_2_release_notes?language=objc):
>Enabling Base Internationalization is recommended for all projects, and any projects that don’t currently use Base Internationalization are offered an upgrade even if they only have a single localization. The upgraded projects are backward-compatible with previous releases of Xcode.