### PR TITLE
Remove Carthage/Checkouts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,8 @@ Package.resolved
 .build/
 
 # Carthage
+Carthage/Checkouts/*
+!Carthage/Checkouts/xcconfigs
 Carthage/Build
 
 # Codecov

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,0 @@
-[submodule "Carthage/Checkouts/xcconfigs"]
-	path = Carthage/Checkouts/xcconfigs
-	url = https://github.com/jspahrsummers/xcconfigs.git
-[submodule "Carthage/Checkouts/Quick"]
-	path = Carthage/Checkouts/Quick
-	url = https://github.com/Quick/Quick.git
-[submodule "Carthage/Checkouts/Nimble"]
-	path = Carthage/Checkouts/Nimble
-	url = https://github.com/Quick/Nimble.git

--- a/Carthage/Checkouts/xcconfigs/.gitignore
+++ b/Carthage/Checkouts/xcconfigs/.gitignore
@@ -1,0 +1,1 @@
+Carthage/Build

--- a/Carthage/Checkouts/xcconfigs/Base/Common.xcconfig
+++ b/Carthage/Checkouts/xcconfigs/Base/Common.xcconfig
@@ -1,0 +1,245 @@
+// 
+// This file defines common settings that should be enabled for every new
+// project. Typically, you want to use Debug, Release, or a similar variant
+// instead.
+//
+
+// Disable legacy-compatible header searching
+ALWAYS_SEARCH_USER_PATHS = NO
+
+// Architectures to build
+ARCHS = $(ARCHS_STANDARD)
+
+// Check for Grand Central Dispatch idioms that may lead to poor performance.
+CLANG_ANALYZER_GCD_PERFORMANCE = YES
+
+// Warn when a number object, such as an instance of `NSNumber`, `CFNumberRef`, `OSNumber`, or `OSBoolean` is compared or converted to a primitive value instead of another object.
+CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE
+
+// Whether to warn when a floating-point value is used as a loop counter
+CLANG_ANALYZER_SECURITY_FLOATLOOPCOUNTER = YES
+
+// Whether to warn about use of rand() and random() being used instead of arc4random()
+CLANG_ANALYZER_SECURITY_INSECUREAPI_RAND = YES
+
+// Whether to warn about strcpy() and strcat()
+CLANG_ANALYZER_SECURITY_INSECUREAPI_STRCPY = YES
+
+// Whether to enable module imports
+CLANG_ENABLE_MODULES = YES
+
+// Enable ARC
+CLANG_ENABLE_OBJC_ARC = YES
+
+// Warn when a source file does not end with a newline.
+GCC_WARN_ABOUT_MISSING_NEWLINE = YES
+
+// Warn about assigning integer constants to enum values that are out of the range of the enumerated type.
+CLANG_WARN_ASSIGN_ENUM = YES
+
+// Warns when an atomic is used with an implicitly sequentially-consistent memory order, instead of explicitly specifying memory order.
+CLANG_WARN_ATOMIC_IMPLICIT_SEQ_CST = YES
+
+// Warn about block captures of implicitly autoreleasing parameters.
+CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES
+
+// Warn about implicit conversions to boolean values that are suspicious.
+// For example, writing 'if (foo)' with 'foo' being the name a function will trigger a warning.
+CLANG_WARN_BOOL_CONVERSION = YES
+
+// Warn about suspicious uses of the comma operator.
+CLANG_WARN_COMMA = YES
+
+// Warn about implicit conversions of constant values that cause the constant value to change,
+// either through a loss of precision, or entirely in its meaning.
+CLANG_WARN_CONSTANT_CONVERSION = YES
+
+// Whether to warn when overriding deprecated methods
+CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES
+
+// Warn about direct accesses to the Objective-C 'isa' pointer instead of using a runtime API.
+CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR
+
+// Warns about issues in documentation comments (`doxygen`-style) such as missing or incorrect documentation tags.
+CLANG_WARN_DOCUMENTATION_COMMENTS = YES
+
+// Warn about declaring the same method more than once within the same @interface.
+CLANG_WARN__DUPLICATE_METHOD_MATCH = YES
+
+// Warn about loop bodies that are suspiciously empty.
+CLANG_WARN_EMPTY_BODY = YES
+
+// Warn about implicit conversions between different kinds of enum values.
+// For example, this can catch issues when using the wrong enum flag as an argument to a function or method.
+CLANG_WARN_ENUM_CONVERSION = YES
+
+// Whether to warn on implicit conversions between signed/unsigned types
+CLANG_WARN_IMPLICIT_SIGN_CONVERSION = NO
+
+// Warn about implicit conversions between pointers and integers.
+// For example, this can catch issues when one incorrectly intermixes using NSNumbers and raw integers.
+CLANG_WARN_INT_CONVERSION = YES
+
+// Warn about non-literal expressions that evaluate to zero being treated as a null pointer.
+CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES
+
+// Warn about implicit capture of self (e.g. direct ivar access)
+CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES
+
+// Warn about implicit conversions from Objective-C literals to values of incompatible type.
+CLANG_WARN_OBJC_LITERAL_CONVERSION = YES
+
+// Don't warn about repeatedly using a weak reference without assigning the weak reference to a strong reference. Too many false positives.
+CLANG_WARN_OBJC_REPEATED_USE_OF_WEAK = NO
+
+// Warn about classes that unintentionally do not subclass a root class (such as NSObject).
+CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR
+
+// Warn about implicit ownership types on Objective-C object references as out parameters. For example, declaring a parameter with type `NSObject**` will produce a warning because the compiler will assume that the out parameter's ownership type is `__autoreleasing`
+CLANG_WARN_OBJC_EXPLICIT_OWNERSHIP_TYPE = YES
+
+// Warns when a quoted include is used instead of a framework style include in a framework header.
+CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES
+
+// Warn about ranged-based for loops.
+CLANG_WARN_RANGE_LOOP_ANALYSIS = YES
+
+// Whether to warn on suspicious implicit conversions
+CLANG_WARN_SUSPICIOUS_IMPLICIT_CONVERSION = YES
+
+// Warn about non-prototype declarations.
+CLANG_WARN_STRICT_PROTOTYPES = YES
+
+// Warn if an API that is newer than the deployment target is used without "if (@available(...))" guards.
+CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE
+
+// Warn about incorrect uses of nullable values
+CLANG_WARN_NULLABLE_TO_NONNULL_CONVERSION = YES
+
+// Warn for missing nullability attributes
+CLANG_ANALYZER_NONNULL = YES
+
+// Warn when a non-localized string is passed to a user-interface method expecting a localized string
+CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES
+
+// Warn about potentially unreachable code
+CLANG_WARN_UNREACHABLE_CODE = YES
+
+// The format of debugging symbols
+DEBUG_INFORMATION_FORMAT = dwarf-with-dsym
+
+// Whether to compile assertions in
+ENABLE_NS_ASSERTIONS = YES
+
+// Whether to require objc_msgSend to be cast before invocation
+ENABLE_STRICT_OBJC_MSGSEND = YES
+
+// Which C variant to use. gnu11 is the default value when creating a Xcode project with version 10.1 (10B61)
+GCC_C_LANGUAGE_STANDARD = gnu11
+
+// Whether to enable exceptions for Objective-C
+GCC_ENABLE_OBJC_EXCEPTIONS = YES
+
+// Whether to generate debugging symbols
+GCC_GENERATE_DEBUGGING_SYMBOLS = YES
+
+// Whether to precompile the prefix header (if one is specified)
+GCC_PRECOMPILE_PREFIX_HEADER = YES
+
+// Whether to enable strict aliasing, meaning that two pointers of different
+// types (other than void * or any id type) cannot point to the same memory
+// location
+GCC_STRICT_ALIASING = YES
+
+// Whether symbols not explicitly exported are hidden by default (this primarily
+// only affects C++ code)
+GCC_SYMBOLS_PRIVATE_EXTERN = NO
+
+// Whether static variables are thread-safe by default
+GCC_THREADSAFE_STATICS = NO
+
+// Which compiler to use
+GCC_VERSION = com.apple.compilers.llvm.clang.1_0
+
+// Whether warnings are treated as errors
+GCC_TREAT_WARNINGS_AS_ERRORS = YES
+SWIFT_TREAT_WARNINGS_AS_ERRORS = YES
+
+// Whether to warn about 64-bit values being implicitly shortened to 32 bits
+GCC_WARN_64_TO_32_BIT_CONVERSION = YES
+
+// Whether to warn about fields missing from structure initializers (only if
+// designated initializers aren't used)
+GCC_WARN_ABOUT_MISSING_FIELD_INITIALIZERS = YES
+
+// Whether to warn about missing function prototypes
+GCC_WARN_ABOUT_MISSING_PROTOTYPES = NO
+
+// Whether to warn about implicit conversions in the signedness of the type
+// a pointer is pointing to (e.g., 'int *' getting converted to 'unsigned int *')
+GCC_WARN_ABOUT_POINTER_SIGNEDNESS = YES
+
+// Whether to warn when the value returned from a function/method/block does not
+// match its return type
+GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR
+
+// Whether to warn on a class not implementing all the required methods of
+// a protocol it declares conformance to
+GCC_WARN_ALLOW_INCOMPLETE_PROTOCOL = YES
+
+// Whether to warn when switching on an enum value, and all possibilities are
+// not accounted for
+GCC_WARN_CHECK_SWITCH_STATEMENTS = YES
+
+// Whether to warn about the use of four-character constants
+GCC_WARN_FOUR_CHARACTER_CONSTANTS = YES
+
+// Whether to warn about an aggregate data type's initializer not being fully
+// bracketed (e.g., array initializer syntax)
+GCC_WARN_INITIALIZER_NOT_FULLY_BRACKETED = YES
+
+// Whether to warn about missing braces or parentheses that make the meaning of
+// the code ambiguous
+GCC_WARN_MISSING_PARENTHESES = YES
+
+// Whether to warn about unsafe comparisons between values of different
+// signedness
+GCC_WARN_SIGN_COMPARE = YES
+
+// Whether to warn about the arguments to printf-style functions not matching
+// the format specifiers
+GCC_WARN_TYPECHECK_CALLS_TO_PRINTF = YES
+
+// Warn if a "@selector(...)" expression referring to an undeclared selector is found
+GCC_WARN_UNDECLARED_SELECTOR = YES
+
+// Warn if a variable might be clobbered by a `setjmp` call or if an automatic variable is used without prior initialization.
+GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE
+
+// Whether to warn about static functions that are unused
+GCC_WARN_UNUSED_FUNCTION = YES
+
+// Whether to warn about labels that are unused
+GCC_WARN_UNUSED_LABEL = YES
+
+// Whether to warn about variables that are never used
+GCC_WARN_UNUSED_VARIABLE = YES
+
+// Whether to run the static analyzer with every build
+RUN_CLANG_STATIC_ANALYZER = YES
+
+// Don't treat unknown warnings as errors, and disable GCC compatibility warnings and unused static const variable warnings
+WARNING_CFLAGS = -Wno-error=unknown-warning-option -Wno-gcc-compat -Wno-unused-const-variable
+
+// This setting is on for new projects as of Xcode ~6.3, though it is still not
+// the default. It warns if the same variable is declared in two binaries that
+// are linked together.
+GCC_NO_COMMON_BLOCKS = YES
+
+// This warnings detects when a function will recursively call itself on every
+// code path though that function. More information can be found here:
+// http://lists.llvm.org/pipermail/cfe-commits/Week-of-Mon-20131216/096004.html
+CLANG_WARN_INFINITE_RECURSION = YES
+
+// This warning detects suspicious uses of std::move.
+CLANG_WARN_SUSPICIOUS_MOVE = YES

--- a/Carthage/Checkouts/xcconfigs/Base/Configurations/Debug.xcconfig
+++ b/Carthage/Checkouts/xcconfigs/Base/Configurations/Debug.xcconfig
@@ -1,0 +1,51 @@
+// 
+// This file defines the base configuration for a Debug build of any project.
+// This should be set at the project level for the Debug configuration.
+//
+
+#include "../Common.xcconfig"
+
+// Whether to strip debugging symbols when copying resources (like included
+// binaries)
+COPY_PHASE_STRIP = NO
+
+// The optimization level (0, 1, 2, 3, s) for the produced binary
+GCC_OPTIMIZATION_LEVEL = 0
+
+// Preproccessor definitions to apply to each file compiled
+GCC_PREPROCESSOR_DEFINITIONS = DEBUG=1
+
+// Allow @testable imports
+ENABLE_TESTABILITY = YES
+
+// Whether to enable link-time optimizations (such as inlining across translation
+// units)
+LLVM_LTO = NO
+
+// Whether to only build the active architecture
+ONLY_ACTIVE_ARCH = YES
+
+// Other compiler flags
+// 
+// These settings catch some errors in integer arithmetic
+OTHER_CFLAGS = -ftrapv
+
+// Other flags to pass to the Swift compiler
+//
+// This enables conditional compilation with #if DEBUG
+OTHER_SWIFT_FLAGS = -D DEBUG
+
+// Xcode 8 introduced a new flag for conditional compilation
+//
+// This enables conditional compilation with #if DEBUG
+SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG
+
+// Whether to strip debugging symbols when copying the built product to its
+// final installation location
+STRIP_INSTALLED_PRODUCT = NO
+
+// The optimization level (-Onone, -O, -Osize) for the produced Swift binary
+SWIFT_OPTIMIZATION_LEVEL = -Onone
+
+// Disable Developer ID timestamping
+OTHER_CODE_SIGN_FLAGS = --timestamp=none

--- a/Carthage/Checkouts/xcconfigs/Base/Configurations/Profile.xcconfig
+++ b/Carthage/Checkouts/xcconfigs/Base/Configurations/Profile.xcconfig
@@ -1,0 +1,27 @@
+// 
+// This file defines the base configuration for an optional profiling-specific
+// build of any project. To use these settings, create a Profile configuration
+// in your project, and use this file at the project level for the new
+// configuration.
+//
+
+// based on the Release configuration, with some stuff related to debugging
+// symbols re-enabled
+#include "Release.xcconfig"
+
+// Whether to strip debugging symbols when copying resources (like included
+// binaries)
+COPY_PHASE_STRIP = NO
+
+// Whether to only build the active architecture
+ONLY_ACTIVE_ARCH = YES
+
+// Whether to strip debugging symbols when copying the built product to its
+// final installation location
+STRIP_INSTALLED_PRODUCT = NO
+
+// Whether to perform App Store validation checks
+VALIDATE_PRODUCT = NO
+
+// Disable Developer ID timestamping
+OTHER_CODE_SIGN_FLAGS = --timestamp=none

--- a/Carthage/Checkouts/xcconfigs/Base/Configurations/Release.xcconfig
+++ b/Carthage/Checkouts/xcconfigs/Base/Configurations/Release.xcconfig
@@ -1,0 +1,42 @@
+// 
+// This file defines the base configuration for a Release build of any project.
+// This should be set at the project level for the Release configuration.
+//
+
+#include "../Common.xcconfig"
+
+// Whether to strip debugging symbols when copying resources (like included
+// binaries)
+COPY_PHASE_STRIP = YES
+
+// Whether to compile assertions in. This value is set to YES in Common.xcconfig, 
+// but the release configuration is an exception: default value in Xcode 10.1 (10B61)
+// is YES for debug configuration and NO for release configuration
+ENABLE_NS_ASSERTIONS = NO
+
+// The optimization level (0, 1, 2, 3, s) for the produced binary
+GCC_OPTIMIZATION_LEVEL = s
+
+// Preproccessor definitions to apply to each file compiled
+GCC_PREPROCESSOR_DEFINITIONS = NDEBUG=1
+
+// Whether to enable link-time optimizations (such as inlining across translation
+// units)
+LLVM_LTO = NO
+
+// Whether to only build the active architecture
+ONLY_ACTIVE_ARCH = NO
+
+// Whether to strip debugging symbols when copying the built product to its
+// final installation location
+STRIP_INSTALLED_PRODUCT = YES
+
+// The optimization level (-Onone, -O, -Osize) for the produced Swift binary
+SWIFT_OPTIMIZATION_LEVEL = -O
+
+// Compilation mode (independent of optimization level)
+SWIFT_COMPILATION_MODE = wholemodule
+
+// Whether to perform App Store validation checks
+VALIDATE_PRODUCT = YES
+

--- a/Carthage/Checkouts/xcconfigs/Base/Configurations/Test.xcconfig
+++ b/Carthage/Checkouts/xcconfigs/Base/Configurations/Test.xcconfig
@@ -1,0 +1,13 @@
+// 
+// This file defines the base configuration for a Test build of any project.
+// This should be set at the project level for the Test configuration.
+//
+
+#include "Debug.xcconfig"
+
+// Sandboxed apps can't be unit tested since they can't load some random 
+// external bundle. So we disable sandboxing for testing.
+CODE_SIGN_ENTITLEMENTS = 
+
+// Allow @testable imports
+ENABLE_TESTABILITY = YES

--- a/Carthage/Checkouts/xcconfigs/Base/Targets/Application.xcconfig
+++ b/Carthage/Checkouts/xcconfigs/Base/Targets/Application.xcconfig
@@ -1,0 +1,12 @@
+//
+// This file defines additional configuration options that are appropriate only
+// for an application. Typically, you want to use a platform-specific variant
+// instead.
+//
+
+// Whether to strip out code that isn't called from anywhere
+DEAD_CODE_STRIPPING = NO
+
+// Sets the @rpath for the application such that it can include frameworks in
+// the application bundle (inside the "Frameworks" folder)
+LD_RUNPATH_SEARCH_PATHS = @executable_path/../Frameworks @loader_path/../Frameworks @executable_path/Frameworks

--- a/Carthage/Checkouts/xcconfigs/Base/Targets/Extension.xcconfig
+++ b/Carthage/Checkouts/xcconfigs/Base/Targets/Extension.xcconfig
@@ -1,0 +1,8 @@
+//
+// This file defines additional configuration options that are appropriate only
+// for an extension embedded within an application. Typically, you want to use a
+// platform-specific variant instead.
+//
+
+// Whether to strip out code that isn't called from anywhere
+DEAD_CODE_STRIPPING = NO

--- a/Carthage/Checkouts/xcconfigs/Base/Targets/Framework.xcconfig
+++ b/Carthage/Checkouts/xcconfigs/Base/Targets/Framework.xcconfig
@@ -1,0 +1,37 @@
+//
+// This file defines additional configuration options that are appropriate only
+// for a framework. Typically, you want to use a platform-specific variant
+// instead.
+//
+
+// Disable code signing for successful device builds with Xcode 8. Frameworks do
+// need to be signed, but they don't need to be signed at compile time because
+// they'll be re-signed when you include them in your app.
+CODE_SIGNING_REQUIRED = NO
+CODE_SIGN_IDENTITY = 
+
+// Whether to strip out code that isn't called from anywhere
+DEAD_CODE_STRIPPING = NO
+
+// Whether this framework should define an LLVM module
+DEFINES_MODULE = YES
+
+// Whether function calls should be position-dependent (should always be
+// disabled for library code)
+GCC_DYNAMIC_NO_PIC = NO
+
+// Default frameworks to the name of the project, instead of any
+// platform-specific target
+PRODUCT_NAME = $(PROJECT_NAME)
+
+// Enables the framework to be included from any location as long as the
+// loader’s runpath search paths includes it. For example from an application
+// bundle (inside the "Frameworks" folder) or shared folder
+INSTALL_PATH = @rpath
+LD_DYLIB_INSTALL_NAME = @rpath/$(PRODUCT_NAME).$(WRAPPER_EXTENSION)/$(PRODUCT_NAME)
+SKIP_INSTALL = YES
+
+// Disallows use of APIs that are not available
+// to app extensions and linking to frameworks
+// that have not been built with this setting enabled.
+APPLICATION_EXTENSION_API_ONLY = YES

--- a/Carthage/Checkouts/xcconfigs/Base/Targets/StaticLibrary.xcconfig
+++ b/Carthage/Checkouts/xcconfigs/Base/Targets/StaticLibrary.xcconfig
@@ -1,0 +1,32 @@
+//
+// This file defines additional configuration options that are appropriate only
+// for a static library. Typically, you want to use a platform-specific variant
+// instead.
+//
+
+// Whether to strip out code that isn't called from anywhere
+DEAD_CODE_STRIPPING = NO
+
+// Whether to strip debugging symbols when copying resources (like included
+// binaries).
+//
+// Overrides Release.xcconfig when used at the target level.
+COPY_PHASE_STRIP = NO
+
+// Whether function calls should be position-dependent (should always be
+// disabled for library code)
+GCC_DYNAMIC_NO_PIC = NO
+
+// Copy headers to "include/LibraryName" in the build folder by default. This
+// lets consumers use #import <LibraryName/LibraryName.h> syntax even for static
+// libraries
+PUBLIC_HEADERS_FOLDER_PATH = include/$PRODUCT_NAME
+
+// Don't include in an xcarchive
+SKIP_INSTALL = YES
+
+// Disallows use of APIs that are not available
+// to app extensions and linking to frameworks
+// that have not been built with this setting enabled.
+APPLICATION_EXTENSION_API_ONLY = YES
+

--- a/Carthage/Checkouts/xcconfigs/Mac OS X/Mac-Application.xcconfig
+++ b/Carthage/Checkouts/xcconfigs/Mac OS X/Mac-Application.xcconfig
@@ -1,0 +1,8 @@
+//
+// DEPRECATED: This configuration file is deprecated. Please use 'macOS/macOS-Application.xcconfig' instead.
+//
+
+#include "../macOS/macOS-Application.xcconfig"
+
+// The below #include is intended to fail, so that Xcode will include the deprecation notice in the error message shown to the user. 
+#include "This configuration file ('Mac OS X/Mac-Application.xcconfig') is deprecated. Please use 'macOS/macOS-Application.xcconfig' instead."

--- a/Carthage/Checkouts/xcconfigs/Mac OS X/Mac-Base.xcconfig
+++ b/Carthage/Checkouts/xcconfigs/Mac OS X/Mac-Base.xcconfig
@@ -1,0 +1,8 @@
+//
+// DEPRECATED: This configuration file is deprecated. Please use 'macOS/macOS-Base.xcconfig' instead.
+//
+
+#include "../macOS/macOS-Base.xcconfig"
+
+// The below #include is intended to fail, so that Xcode will include the deprecation notice in the error message shown to the user. 
+#include "This configuration file ('Mac OS X/Mac-Base.xcconfig') is deprecated. Please use 'macOS/macOS-Base.xcconfig' instead."

--- a/Carthage/Checkouts/xcconfigs/Mac OS X/Mac-DynamicLibrary.xcconfig
+++ b/Carthage/Checkouts/xcconfigs/Mac OS X/Mac-DynamicLibrary.xcconfig
@@ -1,0 +1,8 @@
+//
+// DEPRECATED: This configuration file is deprecated. Please use 'macOS/macOS-DynamicLibrary.xcconfig' instead.
+//
+
+#include "../macOS/macOS-DynamicLibrary.xcconfig"
+
+// The below #include is intended to fail, so that Xcode will include the deprecation notice in the error message shown to the user. 
+#include "This configuration file ('Mac OS X/Mac-DynamicLibrary.xcconfig') is deprecated. Please use 'macOS/macOS-DynamicLibrary.xcconfig' instead."

--- a/Carthage/Checkouts/xcconfigs/Mac OS X/Mac-Framework.xcconfig
+++ b/Carthage/Checkouts/xcconfigs/Mac OS X/Mac-Framework.xcconfig
@@ -1,0 +1,8 @@
+//
+// DEPRECATED: This configuration file is deprecated. Please use 'macOS/macOS-Framework.xcconfig' instead.
+//
+
+#include "../macOS/macOS-Framework.xcconfig"
+
+// The below #include is intended to fail, so that Xcode will include the deprecation notice in the error message shown to the user. 
+#include "This configuration file ('Mac OS X/Mac-Framework.xcconfig') is deprecated. Please use 'macOS/macOS-Framework.xcconfig' instead."

--- a/Carthage/Checkouts/xcconfigs/Mac OS X/Mac-StaticLibrary.xcconfig
+++ b/Carthage/Checkouts/xcconfigs/Mac OS X/Mac-StaticLibrary.xcconfig
@@ -1,0 +1,8 @@
+//
+// DEPRECATED: This configuration file is deprecated. Please use 'macOS/macOS-StaticLibrary.xcconfig' instead.
+//
+
+#include "../macOS/macOS-StaticLibrary.xcconfig"
+
+// The below #include is intended to fail, so that Xcode will include the deprecation notice in the error message shown to the user. 
+#include "This configuration file ('Mac OS X/Mac-StaticLibrary.xcconfig') is deprecated. Please use 'macOS/macOS-StaticLibrary.xcconfig' instead."

--- a/Carthage/Checkouts/xcconfigs/Mac OS X/Mac-XCTest.xcconfig
+++ b/Carthage/Checkouts/xcconfigs/Mac OS X/Mac-XCTest.xcconfig
@@ -1,0 +1,8 @@
+//
+// DEPRECATED: This configuration file is deprecated. Please use 'macOS/macOS-XCTest.xcconfig' instead.
+//
+
+#include "../macOS/macOS-XCTest.xcconfig"
+
+// The below #include is intended to fail, so that Xcode will include the deprecation notice in the error message shown to the user. 
+#include "This configuration file ('Mac OS X/Mac-XCTest.xcconfig') is deprecated. Please use 'macOS/macOS-XCTest.xcconfig' instead."

--- a/Carthage/Checkouts/xcconfigs/README.md
+++ b/Carthage/Checkouts/xcconfigs/README.md
@@ -1,0 +1,13 @@
+This project intends to aggregate common or universal Xcode configuration settings, keeping them in hierarchial Xcode configuration files for easy modification and reuse.
+
+## License
+
+This is free and unencumbered software released into the public domain.
+
+Anyone is free to copy, modify, publish, use, compile, sell, or distribute this software, either in source code form or as a compiled binary, for any purpose, commercial or non-commercial, and by any means.
+
+In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain. We make this dedication for the benefit of the public at large and to the detriment of our heirs and successors. We intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+For more information, please refer to [unlicense.org](http://unlicense.org).

--- a/Carthage/Checkouts/xcconfigs/iOS/iOS-Application.xcconfig
+++ b/Carthage/Checkouts/xcconfigs/iOS/iOS-Application.xcconfig
@@ -1,0 +1,11 @@
+//
+// This file defines additional configuration options that are appropriate only
+// for an application on iOS. This should be set at the target level for each
+// project configuration.
+//
+
+// Import base application settings
+#include "../Base/Targets/Application.xcconfig"
+
+// Apply common settings specific to iOS
+#include "iOS-Base.xcconfig"

--- a/Carthage/Checkouts/xcconfigs/iOS/iOS-Base.xcconfig
+++ b/Carthage/Checkouts/xcconfigs/iOS/iOS-Base.xcconfig
@@ -1,0 +1,18 @@
+//
+// This file defines additional configuration options that are appropriate only
+// for iOS. This file is not standalone -- it is meant to be included into
+// a configuration file for a specific type of target.
+//
+
+// Xcode needs this to find archived headers if SKIP_INSTALL is set
+HEADER_SEARCH_PATHS = $(OBJROOT)/UninstalledProducts/include
+
+// Where to find embedded frameworks
+LD_RUNPATH_SEARCH_PATHS = $(inherited) @executable_path/Frameworks @loader_path/Frameworks
+
+// The base SDK to use (if no version is specified, the latest version is
+// assumed)
+SDKROOT = iphoneos
+
+// Supported device families (1 is iPhone, 2 is iPad)
+TARGETED_DEVICE_FAMILY = 1,2

--- a/Carthage/Checkouts/xcconfigs/iOS/iOS-Extension.xcconfig
+++ b/Carthage/Checkouts/xcconfigs/iOS/iOS-Extension.xcconfig
@@ -1,0 +1,23 @@
+//
+// This file defines additional configuration options that are appropriate only
+// for an extension embedded within an application on iOS. This should be set at
+// the target level for each project configuration.
+//
+
+// Import base extension settings
+#include "../Base/Targets/Extension.xcconfig"
+
+// Apply common settings specific to iOS
+#include "iOS-Base.xcconfig"
+
+// Sets the @rpath for the application such that it can include frameworks in
+// the application bundle two levels up, inside the "Frameworks" folder.
+//
+// Does not search the frameworks folder at the same level as the extension
+// executable since extensions with their own embedded frameworks are rejected
+// with the following error:
+//
+// > Invalid Bundle. The bundle at 'App.app/PlugIns/Extension.appex' contains
+// > disallowed file 'Frameworks'
+//
+LD_RUNPATH_SEARCH_PATHS = $(inherited) @executable_path/../../Frameworks

--- a/Carthage/Checkouts/xcconfigs/iOS/iOS-Framework.xcconfig
+++ b/Carthage/Checkouts/xcconfigs/iOS/iOS-Framework.xcconfig
@@ -1,0 +1,11 @@
+//
+// This file defines additional configuration options that are appropriate only
+// for a framework on iOS. This should be set at the target level for each
+// project configuration.
+//
+
+// Import base framework settings
+#include "../Base/Targets/Framework.xcconfig"
+
+// Import common settings specific to iOS
+#include "iOS-Base.xcconfig"

--- a/Carthage/Checkouts/xcconfigs/iOS/iOS-StaticLibrary.xcconfig
+++ b/Carthage/Checkouts/xcconfigs/iOS/iOS-StaticLibrary.xcconfig
@@ -1,0 +1,11 @@
+//
+// This file defines additional configuration options that are appropriate only
+// for a static library on iOS. This should be set at the target level for each
+// project configuration.
+//
+
+// Import base static library settings
+#include "../Base/Targets/StaticLibrary.xcconfig"
+
+// Apply common settings specific to iOS
+#include "iOS-Base.xcconfig"

--- a/Carthage/Checkouts/xcconfigs/macOS/macOS-Application.xcconfig
+++ b/Carthage/Checkouts/xcconfigs/macOS/macOS-Application.xcconfig
@@ -1,0 +1,21 @@
+//
+// This file defines additional configuration options that are appropriate only
+// for an application on macOS. This should be set at the target level for each
+// project configuration.
+//
+
+// Import base application settings
+#include "../Base/Targets/Application.xcconfig"
+
+// Apply common settings specific to macOS
+#include "macOS-Base.xcconfig"
+
+// Whether function calls should be position-dependent (should always be
+// disabled for library code)
+GCC_DYNAMIC_NO_PIC = YES
+
+// Where to find embedded frameworks
+// Search `Frameworks` in the .app.
+// If app is cli at `/usr/local/bin/foo`, `@executable_path/../Frameworks`
+// means `/usr/local/Frameworks`.
+LD_RUNPATH_SEARCH_PATHS = $(inherited) @executable_path/../Frameworks

--- a/Carthage/Checkouts/xcconfigs/macOS/macOS-Base.xcconfig
+++ b/Carthage/Checkouts/xcconfigs/macOS/macOS-Base.xcconfig
@@ -1,0 +1,16 @@
+//
+// This file defines additional configuration options that are appropriate only
+// for macOS. This file is not standalone -- it is meant to be included into a
+// configuration file for a specific type of target.
+//
+
+// Whether to combine multiple image resolutions into a multirepresentational
+// TIFF
+COMBINE_HIDPI_IMAGES = YES
+
+// The base SDK to use (if no version is specified, the latest version is
+// assumed)
+SDKROOT = macosx
+
+// Supported build architectures
+VALID_ARCHS = x86_64

--- a/Carthage/Checkouts/xcconfigs/macOS/macOS-DynamicLibrary.xcconfig
+++ b/Carthage/Checkouts/xcconfigs/macOS/macOS-DynamicLibrary.xcconfig
@@ -1,0 +1,18 @@
+//
+// This file defines additional configuration options that are appropriate only
+// for a dynamic library on macOS. This should be set at the target level for
+// each project configuration.
+//
+
+// Import common settings specific to macOS
+#include "macOS-Base.xcconfig"
+
+// Whether to strip out code that isn't called from anywhere
+DEAD_CODE_STRIPPING = NO
+
+// Whether function calls should be position-dependent (should always be
+// disabled for library code)
+GCC_DYNAMIC_NO_PIC = NO
+
+// Don't include in an xcarchive
+SKIP_INSTALL = YES

--- a/Carthage/Checkouts/xcconfigs/macOS/macOS-Framework.xcconfig
+++ b/Carthage/Checkouts/xcconfigs/macOS/macOS-Framework.xcconfig
@@ -1,0 +1,17 @@
+//
+// This file defines additional configuration options that are appropriate only
+// for a framework on macOS. This should be set at the target level for each
+// project configuration.
+//
+
+// Import base framework settings
+#include "../Base/Targets/Framework.xcconfig"
+
+// Import common settings specific to macOS
+#include "macOS-Base.xcconfig"
+
+// Where to find embedded frameworks.
+// First search `Frameworks` in the .framework, then one in the .app.
+// If app is cli at `/usr/local/bin/foo`, `@executable_path/../Frameworks`
+// means `/usr/local/Frameworks`.
+LD_RUNPATH_SEARCH_PATHS = $(inherited) @loader_path/Frameworks @executable_path/../Frameworks

--- a/Carthage/Checkouts/xcconfigs/macOS/macOS-StaticLibrary.xcconfig
+++ b/Carthage/Checkouts/xcconfigs/macOS/macOS-StaticLibrary.xcconfig
@@ -1,0 +1,11 @@
+//
+// This file defines additional configuration options that are appropriate only
+// for a static library on macOS. This should be set at the target level for
+// each project configuration.
+//
+
+// Import base static library settings
+#include "../Base/Targets/StaticLibrary.xcconfig"
+
+// Apply common settings specific to macOS
+#include "macOS-Base.xcconfig"

--- a/Carthage/Checkouts/xcconfigs/macOS/macOS-XCTest.xcconfig
+++ b/Carthage/Checkouts/xcconfigs/macOS/macOS-XCTest.xcconfig
@@ -1,0 +1,16 @@
+//
+// This file defines additional configuration options that are appropriate only
+// for an application on macOS. This should be set at the target level for each
+// project configuration.
+//
+
+// Import base application settings
+#include "../Base/Targets/Application.xcconfig"
+
+// Apply common settings specific to macOS
+#include "macOS-Base.xcconfig"
+
+// Whether function calls should be position-dependent (should always be
+// disabled for library code)
+GCC_DYNAMIC_NO_PIC = YES
+

--- a/Carthage/Checkouts/xcconfigs/tvOS/tvOS-Application.xcconfig
+++ b/Carthage/Checkouts/xcconfigs/tvOS/tvOS-Application.xcconfig
@@ -1,0 +1,11 @@
+//
+// This file defines additional configuration options that are appropriate only
+// for an application on tvOS. This should be set at the target level for
+// each project configuration.
+//
+
+// Import base application settings
+#include "../Base/Targets/Application.xcconfig"
+
+// Apply common settings specific to tvOS
+#include "tvOS-Base.xcconfig"

--- a/Carthage/Checkouts/xcconfigs/tvOS/tvOS-Base.xcconfig
+++ b/Carthage/Checkouts/xcconfigs/tvOS/tvOS-Base.xcconfig
@@ -1,0 +1,15 @@
+//
+// This file defines additional configuration options that are appropriate only
+// for tvOS. This file is not standalone -- it is meant to be included into
+// a configuration file for a specific type of target.
+//
+
+// Where to find embedded frameworks
+LD_RUNPATH_SEARCH_PATHS = $(inherited) @executable_path/Frameworks @loader_path/Frameworks
+
+// The base SDK to use (if no version is specified, the latest version is
+// assumed)
+SDKROOT = appletvos
+
+// Supported device families
+TARGETED_DEVICE_FAMILY = 3

--- a/Carthage/Checkouts/xcconfigs/tvOS/tvOS-Framework.xcconfig
+++ b/Carthage/Checkouts/xcconfigs/tvOS/tvOS-Framework.xcconfig
@@ -1,0 +1,11 @@
+//
+// This file defines additional configuration options that are appropriate only
+// for a framework on tvOS. This should be set at the target level for each
+// project configuration.
+//
+
+// Import base framework settings
+#include "../Base/Targets/Framework.xcconfig"
+
+// Import common settings specific to iOS
+#include "tvOS-Base.xcconfig"

--- a/Carthage/Checkouts/xcconfigs/tvOS/tvOS-StaticLibrary.xcconfig
+++ b/Carthage/Checkouts/xcconfigs/tvOS/tvOS-StaticLibrary.xcconfig
@@ -1,0 +1,11 @@
+//
+// This file defines additional configuration options that are appropriate only
+// for a static library on tvOS. This should be set at the target level for
+// each project configuration.
+//
+
+// Import base static library settings
+#include "../Base/Targets/StaticLibrary.xcconfig"
+
+// Apply common settings specific to tvOS
+#include "tvOS-Base.xcconfig"

--- a/Carthage/Checkouts/xcconfigs/watchOS/watchOS-Application.xcconfig
+++ b/Carthage/Checkouts/xcconfigs/watchOS/watchOS-Application.xcconfig
@@ -1,0 +1,11 @@
+//
+// This file defines additional configuration options that are appropriate only
+// for an application on watchOS. This should be set at the target level for
+// each project configuration.
+//
+
+// Import base application settings
+#include "../Base/Targets/Application.xcconfig"
+
+// Apply common settings specific to watchOS
+#include "watchOS-Base.xcconfig"

--- a/Carthage/Checkouts/xcconfigs/watchOS/watchOS-Base.xcconfig
+++ b/Carthage/Checkouts/xcconfigs/watchOS/watchOS-Base.xcconfig
@@ -1,0 +1,15 @@
+//
+// This file defines additional configuration options that are appropriate only
+// for watchOS. This file is not standalone -- it is meant to be included into
+// a configuration file for a specific type of target.
+//
+
+// Where to find embedded frameworks
+LD_RUNPATH_SEARCH_PATHS = $(inherited) @executable_path/Frameworks @loader_path/Frameworks
+
+// The base SDK to use (if no version is specified, the latest version is
+// assumed)
+SDKROOT = watchos
+
+// Supported device families
+TARGETED_DEVICE_FAMILY = 4

--- a/Carthage/Checkouts/xcconfigs/watchOS/watchOS-Framework.xcconfig
+++ b/Carthage/Checkouts/xcconfigs/watchOS/watchOS-Framework.xcconfig
@@ -1,0 +1,11 @@
+//
+// This file defines additional configuration options that are appropriate only
+// for a framework on watchOS. This should be set at the target level for each
+// project configuration.
+//
+
+// Import base framework settings
+#include "../Base/Targets/Framework.xcconfig"
+
+// Import common settings specific to iOS
+#include "watchOS-Base.xcconfig"

--- a/Carthage/Checkouts/xcconfigs/watchOS/watchOS-StaticLibrary.xcconfig
+++ b/Carthage/Checkouts/xcconfigs/watchOS/watchOS-StaticLibrary.xcconfig
@@ -1,0 +1,11 @@
+//
+// This file defines additional configuration options that are appropriate only
+// for a static library on watchOS. This should be set at the target level for
+// each project configuration.
+//
+
+// Import base static library settings
+#include "../Base/Targets/StaticLibrary.xcconfig"
+
+// Apply common settings specific to watchOS
+#include "watchOS-Base.xcconfig"

--- a/Tools/helpers.sh
+++ b/Tools/helpers.sh
@@ -27,6 +27,6 @@ xcb() {
 
 do_carthage_bootstrap() {
   carthage bootstrap --platform iOS \
-    --use-submodules --cache-builds --no-use-binaries || \
+    --cache-builds --no-use-binaries || \
     fail "Carthage bootstrap failed"
 }


### PR DESCRIPTION
This PR removes the `Checkouts` folder and the `--use-submodules` flag when bootstrapping Carthage.