### PR TITLE
Support Swift 5.1 toolchains

### DIFF
--- a/MobiusCore/Source/NoEffect.swift
+++ b/MobiusCore/Source/NoEffect.swift
@@ -26,7 +26,14 @@ import Foundation
 ///         conformance is just to allow the type to be used where required. Such as with the `First` and `Next` data
 ///         structures.
 public enum NoEffect: Equatable, Hashable {
-    public static func == (lhs: NoEffect, rhs: NoEffect) -> Bool { return true }
+    public static func == (lhs: NoEffect, rhs: NoEffect) -> Bool {
+        #if compiler(>=5.1)
+        // #if compiler(<5.1) doesn’t work in the Xcode 10.1 toolchain
+        #else
+        // This is required in earlier compiler versions, but a warning in newer ones
+        return true
+        #endif
+    }
     public var hashValue: Int { return 0 }
     public func hash(into hasher: inout Hasher) {}
 }


### PR DESCRIPTION
In older toolchains, `==` must have a dummy return statement. In newer ones, it must not. (Having one generates an unreachable code warning, and we treat warnings as errors.)

I’d like to formally deprecate `NoEffect` in favour of `Never`. Unfortunately, there is no way to make an availability attribute conditional on the version of Swift used by the _consumer_ of the library, so as long as we support Swift 4.x (where `Never` isn’t `Hashable` or `Equatable`) we can’t do this.

If such a deprecation isn’t controversial, I guess we can document it as soft-deprecated.