### PR TITLE
 Use full names for generic type arguments

### DIFF
--- a/MobiusCore/Source/EventProcessor.swift
+++ b/MobiusCore/Source/EventProcessor.swift
@@ -21,14 +21,14 @@ import Foundation
 
 /// Internal class that manages the atomic state updates and notifications of model changes when processing of events via
 /// the Update function.
-class EventProcessor<T: LoopTypes>: Disposable, CustomDebugStringConvertible {
-    let update: Update<T>
-    let publisher: ConnectablePublisher<Next<T.Model, T.Effect>>
+class EventProcessor<Types: LoopTypes>: Disposable, CustomDebugStringConvertible {
+    let update: Update<Types>
+    let publisher: ConnectablePublisher<Next<Types.Model, Types.Effect>>
 
     private let queue: DispatchQueue
 
-    private var currentModel: T.Model?
-    private var queuedEvents = [T.Event]()
+    private var currentModel: Types.Model?
+    private var queuedEvents = [Types.Event]()
 
     public var debugDescription: String {
         let modelDescription: String
@@ -41,8 +41,8 @@ class EventProcessor<T: LoopTypes>: Disposable, CustomDebugStringConvertible {
     }
 
     init(
-        update: @escaping Update<T>,
-        publisher: ConnectablePublisher<Next<T.Model, T.Effect>>,
+        update: @escaping Update<Types>,
+        publisher: ConnectablePublisher<Next<Types.Model, Types.Effect>>,
         queue: DispatchQueue
     ) {
         self.update = update
@@ -50,7 +50,7 @@ class EventProcessor<T: LoopTypes>: Disposable, CustomDebugStringConvertible {
         self.queue = queue
     }
 
-    func start(from first: First<T.Model, T.Effect>) {
+    func start(from first: First<Types.Model, Types.Effect>) {
         queue.sync(flags: .barrier) {
             currentModel = first.model
 
@@ -64,7 +64,7 @@ class EventProcessor<T: LoopTypes>: Disposable, CustomDebugStringConvertible {
         }
     }
 
-    func accept(_ event: T.Event) {
+    func accept(_ event: Types.Event) {
         queue.async(flags: .barrier) {
             if let current = self.currentModel {
                 let next = self.update(current, event)
@@ -84,7 +84,7 @@ class EventProcessor<T: LoopTypes>: Disposable, CustomDebugStringConvertible {
         publisher.dispose()
     }
 
-    func readCurrentModel() -> T.Model? {
+    func readCurrentModel() -> Types.Model? {
         return queue.sync { currentModel }
     }
 }

--- a/MobiusCore/Source/EventSources/AnyEventSource.swift
+++ b/MobiusCore/Source/EventSources/AnyEventSource.swift
@@ -20,20 +20,20 @@
 import Foundation
 
 /// The `AnyEventSource` class implements a `EventSource` type that sends events to subscribers.
-public class AnyEventSource<E>: EventSource {
-    public typealias Event = E
+public class AnyEventSource<AnEvent>: EventSource {
+    public typealias Event = AnEvent
 
-    private let subscribeClosure: (@escaping Consumer<E>) -> Disposable
+    private let subscribeClosure: (@escaping Consumer<Event>) -> Disposable
 
-    public init<ES: EventSource>(_ base: ES) where ES.Event == E {
+    public init<Source: EventSource>(_ base: Source) where Source.Event == Event {
         subscribeClosure = base.subscribe
     }
 
-    public init(_ closure: @escaping (@escaping Consumer<E>) -> Disposable) {
+    public init(_ closure: @escaping (@escaping Consumer<Event>) -> Disposable) {
         subscribeClosure = closure
     }
 
-    public func subscribe(consumer eventConsumer: @escaping Consumer<E>) -> Disposable {
+    public func subscribe(consumer eventConsumer: @escaping Consumer<Event>) -> Disposable {
         return subscribeClosure(eventConsumer)
     }
 }

--- a/MobiusCore/Source/EventSources/MergedEventSource.swift
+++ b/MobiusCore/Source/EventSources/MergedEventSource.swift
@@ -28,8 +28,8 @@ public final class MergedEventSource<Event>: EventSource {
     /// Initialises a MergedEventSource
     ///
     /// - Parameter eventSources: an array of `EventSource` with matching `Events`
-    public init<ES: EventSource>(eventSources: [ES]) where ES.Event == Event {
-        self.eventSources = eventSources.map({ (eventSource: ES) -> AnyEventSource<Event> in
+    public init<Source: EventSource>(eventSources: [Source]) where Source.Event == Event {
+        self.eventSources = eventSources.map({ (eventSource: Source) -> AnyEventSource<Event> in
             AnyEventSource<Event>(eventSource)
         })
     }

--- a/MobiusCore/Source/Mobius.swift
+++ b/MobiusCore/Source/Mobius.swift
@@ -57,24 +57,24 @@ public extension Mobius {
         )
     }
 
-    struct Builder<T: LoopTypes> {
-        private let update: Update<T>
-        private let effectHandler: AnyConnectable<T.Effect, T.Event>
-        private let initiator: Initiator<T>
-        private let eventSource: AnyEventSource<T.Event>
+    struct Builder<Types: LoopTypes> {
+        private let update: Update<Types>
+        private let effectHandler: AnyConnectable<Types.Effect, Types.Event>
+        private let initiator: Initiator<Types>
+        private let eventSource: AnyEventSource<Types.Event>
         private let eventQueue: DispatchQueue
         private let effectQueue: DispatchQueue
-        private let logger: AnyMobiusLogger<T>
+        private let logger: AnyMobiusLogger<Types>
 
         fileprivate init<C: Connectable>(
-            update: @escaping Update<T>,
+            update: @escaping Update<Types>,
             effectHandler: C,
-            initiator: @escaping Initiator<T>,
-            eventSource: AnyEventSource<T.Event>,
+            initiator: @escaping Initiator<Types>,
+            eventSource: AnyEventSource<Types.Event>,
             eventQueue: DispatchQueue,
             effectQueue: DispatchQueue,
-            logger: AnyMobiusLogger<T>
-        ) where C.InputType == T.Effect, C.OutputType == T.Event {
+            logger: AnyMobiusLogger<Types>
+        ) where C.InputType == Types.Effect, C.OutputType == Types.Event {
             self.update = update
             self.effectHandler = AnyConnectable(effectHandler)
             self.initiator = initiator
@@ -84,8 +84,8 @@ public extension Mobius {
             self.logger = logger
         }
 
-        public func withEventSource<ES: EventSource>(_ eventSource: ES) -> Builder<T> where ES.Event == T.Event {
-            return Builder<T>(
+        public func withEventSource<ES: EventSource>(_ eventSource: ES) -> Builder<Types> where ES.Event == Types.Event {
+            return Builder<Types>(
                 update: update,
                 effectHandler: effectHandler,
                 initiator: initiator,
@@ -96,8 +96,8 @@ public extension Mobius {
             )
         }
 
-        public func withInitiator(_ initiator: @escaping Initiator<T>) -> Builder<T> {
-            return Builder<T>(
+        public func withInitiator(_ initiator: @escaping Initiator<Types>) -> Builder<Types> {
+            return Builder<Types>(
                 update: update,
                 effectHandler: effectHandler,
                 initiator: initiator,
@@ -108,8 +108,8 @@ public extension Mobius {
             )
         }
 
-        public func withEventQueue(_ eventQueue: DispatchQueue) -> Builder<T> {
-            return Builder<T>(
+        public func withEventQueue(_ eventQueue: DispatchQueue) -> Builder<Types> {
+            return Builder<Types>(
                 update: update,
                 effectHandler: effectHandler,
                 initiator: initiator,
@@ -120,8 +120,8 @@ public extension Mobius {
             )
         }
 
-        public func withEffectQueue(_ effectQueue: DispatchQueue) -> Builder<T> {
-            return Builder<T>(
+        public func withEffectQueue(_ effectQueue: DispatchQueue) -> Builder<Types> {
+            return Builder<Types>(
                 update: update,
                 effectHandler: effectHandler,
                 initiator: initiator,
@@ -132,8 +132,8 @@ public extension Mobius {
             )
         }
 
-        public func withLogger<L: MobiusLogger>(_ logger: L) -> Builder<T> where L.Model == T.Model, L.Event == T.Event, L.Effect == T.Effect {
-            return Builder<T>(
+        public func withLogger<L: MobiusLogger>(_ logger: L) -> Builder<Types> where L.Model == Types.Model, L.Event == Types.Event, L.Effect == Types.Effect {
+            return Builder<Types>(
                 update: update,
                 effectHandler: effectHandler,
                 initiator: initiator,
@@ -145,11 +145,11 @@ public extension Mobius {
         }
 
         @available(*, deprecated, message: "use withLogger instead")
-        public func logger<L: MobiusLogger>(_ logger: L) -> Builder<T> where L.Model == T.Model, L.Event == T.Event, L.Effect == T.Effect {
+        public func logger<L: MobiusLogger>(_ logger: L) -> Builder<Types> where L.Model == Types.Model, L.Event == Types.Event, L.Effect == Types.Effect {
             return withLogger(logger)
         }
 
-        public func start(from initialModel: T.Model) -> MobiusLoop<T> {
+        public func start(from initialModel: Types.Model) -> MobiusLoop<Types> {
             return MobiusLoop.createLoop(
                 update: update,
                 effectHandler: effectHandler,
@@ -164,18 +164,18 @@ public extension Mobius {
     }
 }
 
-class LoggingInitiator<T: LoopTypes> {
-    private let realInit: Initiator<T>
-    private let willInit: (T.Model) -> Void
-    private let didInit: (T.Model, First<T.Model, T.Effect>) -> Void
+class LoggingInitiator<Types: LoopTypes> {
+    private let realInit: Initiator<Types>
+    private let willInit: (Types.Model) -> Void
+    private let didInit: (Types.Model, First<Types.Model, Types.Effect>) -> Void
 
-    init<L: MobiusLogger>(_ realInit: @escaping Initiator<T>, _ logger: L) where L.Model == T.Model, L.Event == T.Event, L.Effect == T.Effect {
+    init<L: MobiusLogger>(_ realInit: @escaping Initiator<Types>, _ logger: L) where L.Model == Types.Model, L.Event == Types.Event, L.Effect == Types.Effect {
         self.realInit = realInit
         willInit = logger.willInitiate
         didInit = logger.didInitiate
     }
 
-    func initiate(_ model: T.Model) -> First<T.Model, T.Effect> {
+    func initiate(_ model: Types.Model) -> First<Types.Model, Types.Effect> {
         willInit(model)
         let result = realInit(model)
         didInit(model, result)
@@ -184,18 +184,18 @@ class LoggingInitiator<T: LoopTypes> {
     }
 }
 
-class LoggingUpdate<T: LoopTypes> {
-    private let realUpdate: Update<T>
-    private let willUpdate: (T.Model, T.Event) -> Void
-    private let didUpdate: (T.Model, T.Event, Next<T.Model, T.Effect>) -> Void
+class LoggingUpdate<Types: LoopTypes> {
+    private let realUpdate: Update<Types>
+    private let willUpdate: (Types.Model, Types.Event) -> Void
+    private let didUpdate: (Types.Model, Types.Event, Next<Types.Model, Types.Effect>) -> Void
 
-    init<L: MobiusLogger>(_ realUpdate: @escaping Update<T>, _ logger: L) where L.Model == T.Model, L.Event == T.Event, L.Effect == T.Effect {
+    init<L: MobiusLogger>(_ realUpdate: @escaping Update<Types>, _ logger: L) where L.Model == Types.Model, L.Event == Types.Event, L.Effect == Types.Effect {
         self.realUpdate = realUpdate
         willUpdate = logger.willUpdate
         didUpdate = logger.didUpdate
     }
 
-    func update(_ model: T.Model, _ event: T.Event) -> Next<T.Model, T.Effect> {
+    func update(_ model: Types.Model, _ event: Types.Event) -> Next<Types.Model, Types.Effect> {
         willUpdate(model, event)
         let result = realUpdate(model, event)
         didUpdate(model, event, result)

--- a/MobiusCore/Source/MobiusController.swift
+++ b/MobiusCore/Source/MobiusController.swift
@@ -23,14 +23,14 @@ import Foundation
 ///
 /// If a loop is stopped and then started again, the new loop will continue from where the last
 /// one left off.
-public class MobiusController<T: LoopTypes> {
-    private let loopFactory: (T.Model) -> MobiusLoop<T>
+public class MobiusController<Types: LoopTypes> {
+    private let loopFactory: (Types.Model) -> MobiusLoop<Types>
     private let lock = NSRecursiveLock()
 
-    private var viewConnectable: ConnectClosure<T.Model, T.Event>?
-    private var viewConnection: Connection<T.Model>?
-    private var loop: MobiusLoop<T>?
-    private var modelToStartFrom: T.Model
+    private var viewConnectable: ConnectClosure<Types.Model, Types.Event>?
+    private var viewConnection: Connection<Types.Model>?
+    private var loop: MobiusLoop<Types>?
+    private var modelToStartFrom: Types.Model
 
     /// A Boolean indicating whether the MobiusLoop is running or not.
     public var isRunning: Bool {
@@ -39,7 +39,7 @@ public class MobiusController<T: LoopTypes> {
         }
     }
 
-    public init(builder: Mobius.Builder<T>, defaultModel: T.Model) {
+    public init(builder: Mobius.Builder<Types>, defaultModel: Types.Model) {
         loopFactory = builder.start
         modelToStartFrom = defaultModel
     }
@@ -53,7 +53,7 @@ public class MobiusController<T: LoopTypes> {
     /// models and renders them. Disposing the connection should make the view stop emitting events.
     ///
     /// - Attention: fails via `MobiusHooks.onError` if the loop is running or if the controller already is connected
-    public func connectView<C: Connectable>(_ connectable: C) where C.InputType == T.Model, C.OutputType == T.Event {
+    public func connectView<C: Connectable>(_ connectable: C) where C.InputType == Types.Model, C.OutputType == Types.Event {
         lock.synchronized {
             guard viewConnectable == nil else {
                 MobiusHooks.onError("controller only supports connecting one view")
@@ -130,7 +130,7 @@ public class MobiusController<T: LoopTypes> {
     ///
     /// - Parameter model: the model with the state the controller should start from
     /// - Attention: fails via `MobiusHooks.onError` if the loop is running
-    public func replaceModel(_ model: T.Model) {
+    public func replaceModel(_ model: Types.Model) {
         lock.synchronized {
             guard loop == nil else {
                 MobiusHooks.onError("cannot replace the model of a running loop")
@@ -145,7 +145,7 @@ public class MobiusController<T: LoopTypes> {
     /// if it's not running.
     ///
     /// - Returns: a model with the state of the controller
-    public func getModel() -> T.Model {
+    public func getModel() -> Types.Model {
         return lock.synchronized {
             loop?.getMostRecentModel() ?? modelToStartFrom
         }

--- a/MobiusCore/Source/MobiusLogger.swift
+++ b/MobiusCore/Source/MobiusLogger.swift
@@ -61,33 +61,33 @@ public protocol MobiusLogger: LoopTypes {
     func didUpdate(model: Model, event: Event, next: Next<Model, Effect>)
 }
 
-class NoopLogger<T: LoopTypes>: MobiusLogger {
-    typealias Model = T.Model
-    typealias Event = T.Event
-    typealias Effect = T.Effect
+class NoopLogger<Types: LoopTypes>: MobiusLogger {
+    typealias Model = Types.Model
+    typealias Event = Types.Event
+    typealias Effect = Types.Effect
 
-    func willInitiate(model: T.Model) {
+    func willInitiate(model: Model) {
         // empty
     }
 
-    func didInitiate(model: T.Model, first: First<T.Model, T.Effect>) {
+    func didInitiate(model: Model, first: First<Model, Effect>) {
         // empty
     }
 
-    func willUpdate(model: T.Model, event: T.Event) {
+    func willUpdate(model: Model, event: Event) {
         // empty
     }
 
-    func didUpdate(model: T.Model, event: T.Event, next: Next<T.Model, T.Effect>) {
+    func didUpdate(model: Model, event: Event, next: Next<Model, Effect>) {
         // empty
     }
 }
 
 /// Type-erased `MobiusLogger`.
-public class AnyMobiusLogger<T: LoopTypes>: MobiusLogger {
-    public typealias Model = T.Model
-    public typealias Event = T.Event
-    public typealias Effect = T.Effect
+public class AnyMobiusLogger<Types: LoopTypes>: MobiusLogger {
+    public typealias Model = Types.Model
+    public typealias Event = Types.Event
+    public typealias Effect = Types.Effect
 
     private let willInitiateClosure: (Model) -> Void
     private let didInitiateClosure: (Model, First<Model, Effect>) -> Void
@@ -101,19 +101,19 @@ public class AnyMobiusLogger<T: LoopTypes>: MobiusLogger {
         didUpdateClosure = base.didUpdate
     }
 
-    public func willInitiate(model: T.Model) {
+    public func willInitiate(model: Model) {
         willInitiateClosure(model)
     }
 
-    public func didInitiate(model: T.Model, first: First<T.Model, T.Effect>) {
+    public func didInitiate(model: Model, first: First<Model, Effect>) {
         didInitiateClosure(model, first)
     }
 
-    public func willUpdate(model: T.Model, event: T.Event) {
+    public func willUpdate(model: Model, event: Event) {
         willUpdateClosure(model, event)
     }
 
-    public func didUpdate(model: T.Model, event: T.Event, next: Next<T.Model, T.Effect>) {
+    public func didUpdate(model: Model, event: Event, next: Next<Model, Effect>) {
         didUpdateClosure(model, event, next)
     }
 }

--- a/MobiusCore/Source/Next.swift
+++ b/MobiusCore/Source/Next.swift
@@ -72,13 +72,11 @@ public extension Next {
     var hasEffects: Bool { return !effects.isEmpty }
 }
 
-#if swift(>=4.1)
 extension Next: Equatable where Model: Equatable {
     public static func == (lhs: Next<Model, Effect>, rhs: Next<Model, Effect>) -> Bool {
         return lhs.model == rhs.model && lhs.effects == rhs.effects
     }
 }
-#endif
 
 extension Next: CustomDebugStringConvertible {
     public var debugDescription: String {

--- a/MobiusExtras/Source/ConsoleLogger.swift
+++ b/MobiusExtras/Source/ConsoleLogger.swift
@@ -20,10 +20,10 @@
 import Foundation
 import MobiusCore
 
-public class ConsoleLogger<T: LoopTypes>: MobiusLogger {
-    public typealias Model = T.Model
-    public typealias Event = T.Event
-    public typealias Effect = T.Effect
+public class ConsoleLogger<Types: LoopTypes>: MobiusLogger {
+    public typealias Model = Types.Model
+    public typealias Event = Types.Event
+    public typealias Effect = Types.Effect
 
     private let prefix: String
 
@@ -31,28 +31,28 @@ public class ConsoleLogger<T: LoopTypes>: MobiusLogger {
         prefix = tag + ": "
     }
 
-    public func willInitiate(model: T.Model) {
+    public func willInitiate(model: Model) {
         print(prefix + "Initializing loop")
     }
 
-    public func didInitiate(model: T.Model, first: First<T.Model, T.Effect>) {
+    public func didInitiate(model: Model, first: First<Model, Effect>) {
         print(prefix + "Loop initialized, starting from model: \(first.model)")
 
-        first.effects.forEach { (effect: T.Effect) in
+        first.effects.forEach { (effect: Effect) in
             print(prefix + "Effect dispatched: \(effect)")
         }
     }
 
-    public func willUpdate(model: T.Model, event: T.Event) {
+    public func willUpdate(model: Model, event: Event) {
         print(prefix + "Event received: \(event)")
     }
 
-    public func didUpdate(model: T.Model, event: T.Event, next: Next<T.Model, T.Effect>) {
+    public func didUpdate(model: Model, event: Event, next: Next<Model, Effect>) {
         if let nextModel = next.model {
             print(prefix + "Model updated: \(nextModel)")
         }
 
-        next.effects.forEach { (effect: T.Effect) in
+        next.effects.forEach { (effect: Effect) in
             print(prefix + "Effect dispatched: \(effect)")
         }
     }

--- a/MobiusExtras/Source/EventSource+Extensions.swift
+++ b/MobiusExtras/Source/EventSource+Extensions.swift
@@ -26,7 +26,7 @@ public extension EventSource {
     /// - Parameters:
     ///   - map: Translation function to apply to the forwarded events.
     /// - Returns: An `EventSource` that translates and forwards event from the receiver.
-    func map<U>(_ map: @escaping (Event) -> U) -> AnyEventSource<U> {
+    func map<T>(_ map: @escaping (Event) -> T) -> AnyEventSource<T> {
         return AnyEventSource { mappedEventConsumer in
             self.subscribe { originalEvent in
                 let mappedEvent = map(originalEvent)

--- a/MobiusTest/Source/FirstMatchers.swift
+++ b/MobiusTest/Source/FirstMatchers.swift
@@ -21,17 +21,17 @@ import Foundation
 import MobiusCore
 import XCTest
 
-public typealias FirstPredicate<M, E: Hashable> = Predicate<First<M, E>>
+public typealias FirstPredicate<Model, Effect: Hashable> = Predicate<First<Model, Effect>>
 
 /// Function to produce an `AssertFirst` function to be used with the `InitSpec`
 ///
 /// - Parameter predicates: Nimble `Predicate` that verifies a first. Can be produced through `FirstMatchers`
 /// - Returns: An `AssertFirst` function to be used with the `InitSpec`
-public func assertThatFirst<M, E>(
-    _ predicates: FirstPredicate<M, E>...,
+public func assertThatFirst<Model, Effect>(
+    _ predicates: FirstPredicate<Model, Effect>...,
     failFunction: @escaping AssertionFailure = XCTFail
-) -> AssertFirst<M, E> {
-    return { (result: First<M, E>) in
+) -> AssertFirst<Model, Effect> {
+    return { (result: First<Model, Effect>) in
         predicates.forEach({ predicate in
             let predicateResult = predicate(result)
             if case let .failure(message, file, line) = predicateResult {
@@ -45,12 +45,12 @@ public func assertThatFirst<M, E>(
 ///
 /// - Parameter expected: the expected M
 /// - Returns: a `Predicate` determening if a `First` contains the expected M
-public func hasModel<M: Equatable, E>(
-    _ expected: M,
+public func hasModel<Model: Equatable, Effect>(
+    _ expected: Model,
     file: StaticString = #file,
     line: UInt = #line
-) -> FirstPredicate<M, E> {
-    return { (first: First<M, E>) in
+) -> FirstPredicate<Model, Effect> {
+    return { (first: First<Model, Effect>) in
         if first.model != expected {
             return .failure(
                 message: "Expected model to be <\(expected)>, got <\(first.model)>",
@@ -65,11 +65,11 @@ public func hasModel<M: Equatable, E>(
 /// Returns a `Predicate` that matches `First` instances with no Es.
 ///
 /// - Returns: a `Predicate` determening if a `First` contains no Es
-public func hasNoEffects<M, E>(
+public func hasNoEffects<Model, Effect>(
     file: StaticString = #file,
     line: UInt = #line
-) -> FirstPredicate<M, E> {
-    return { (first: First<M, E>) in
+) -> FirstPredicate<Model, Effect> {
+    return { (first: First<Model, Effect>) in
         if first.hasEffects {
             return .failure(
                 message: "Expected no effects, got <\(first.effects)>",
@@ -86,12 +86,12 @@ public func hasNoEffects<M, E>(
 ///
 /// - Parameter Es: the Es to match (possibly empty)
 /// - Returns: a `Predicate` that matches `First` instances that include all the supplied Es
-public func hasEffects<M, E: Equatable>(
-    _ expected: [E],
+public func hasEffects<Model, Effect: Equatable>(
+    _ expected: [Effect],
     file: StaticString = #file,
     line: UInt = #line
-) -> FirstPredicate<M, E> {
-    return { (first: First<M, E>) in
+) -> FirstPredicate<Model, Effect> {
+    return { (first: First<Model, Effect>) in
         if !first.effects.isSuperset(of: expected) {
             return .failure(
                 message: "Expected effects <\(first.effects)> to contain <\(expected)>",

--- a/MobiusTest/Source/InitSpec.swift
+++ b/MobiusTest/Source/InitSpec.swift
@@ -21,27 +21,27 @@ import MobiusCore
 
 public typealias AssertFirst<Model, Effect: Hashable> = (First<Model, Effect>) -> Void
 
-public final class InitSpec<T: LoopTypes> {
-    let initiator: Initiator<T>
+public final class InitSpec<Types: LoopTypes> {
+    let initiator: Initiator<Types>
 
-    public init(_ initiator: @escaping Initiator<T>) {
+    public init(_ initiator: @escaping Initiator<Types>) {
         self.initiator = initiator
     }
 
-    public func when(_ model: T.Model) -> Then {
+    public func when(_ model: Types.Model) -> Then {
         return Then(model, initiator: initiator)
     }
 
     public struct Then {
-        let model: T.Model
-        let initiator: Initiator<T>
+        let model: Types.Model
+        let initiator: Initiator<Types>
 
-        public init(_ model: T.Model, initiator: @escaping Initiator<T>) {
+        public init(_ model: Types.Model, initiator: @escaping Initiator<Types>) {
             self.model = model
             self.initiator = initiator
         }
 
-        public func then(_ assertion: AssertFirst<T.Model, T.Effect>) {
+        public func then(_ assertion: AssertFirst<Types.Model, Types.Effect>) {
             let first = initiator(model)
             assertion(first)
         }

--- a/MobiusTest/Source/NextMatchers.swift
+++ b/MobiusTest/Source/NextMatchers.swift
@@ -28,11 +28,11 @@ public typealias NextPredicate<Model, Effect: Hashable> = Predicate<Next<Model, 
 ///   - predicate: a list of predicates to test
 ///   - failFunction: a function which is called when the predicate fails. Defaults to XCTFail
 /// - Returns: An `UpdateSpec` `Assert` that uses the assert to verify the result passed in to the `Assert`
-public func assertThatNext<T: LoopTypes>(
-    _ predicates: NextPredicate<T.Model, T.Effect>...,
+public func assertThatNext<Types: LoopTypes>(
+    _ predicates: NextPredicate<Types.Model, Types.Effect>...,
     failFunction: @escaping AssertionFailure = XCTFail
-) -> UpdateSpec<T>.Assert {
-    return { (result: UpdateSpec<T>.Result) in
+) -> UpdateSpec<Types>.Assert {
+    return { (result: UpdateSpec<Types>.Result) in
         predicates.forEach({ predicate in
             let assertionResult = predicate(result.lastNext)
             if case let .failure(message, file, line) = assertionResult {
@@ -43,8 +43,8 @@ public func assertThatNext<T: LoopTypes>(
 }
 
 /// - Returns: a `Predicate` that matches `Next` instances with no model and no effects.
-public func hasNothing<M, E>(file: StaticString = #file, line: UInt = #line) -> NextPredicate<M, E> {
-    return { (next: Next<M, E>) in
+public func hasNothing<Model, Effect>(file: StaticString = #file, line: UInt = #line) -> NextPredicate<Model, Effect> {
+    return { (next: Next<Model, Effect>) in
         let noModelResult = hasNoModel(file: file, line: line)(next)
         if case .success = noModelResult {
             return hasNoEffects(file: file, line: line)(next)
@@ -54,8 +54,8 @@ public func hasNothing<M, E>(file: StaticString = #file, line: UInt = #line) -> 
 }
 
 /// - Returns: a `Predicate` that matches `Next` instances without a model.
-public func hasNoModel<M, E>(file: StaticString = #file, line: UInt = #line) -> NextPredicate<M, E> {
-    return { (next: Next<M, E>) in
+public func hasNoModel<Model, Effect>(file: StaticString = #file, line: UInt = #line) -> NextPredicate<Model, Effect> {
+    return { (next: Next<Model, Effect>) in
         let model = next.model
         if model != nil {
             return .failure(
@@ -69,8 +69,8 @@ public func hasNoModel<M, E>(file: StaticString = #file, line: UInt = #line) -> 
 }
 
 /// - Returns:  a `Predicate` that matches `Next` instances with a model.
-public func hasModel<M, E>(file: StaticString = #file, line: UInt = #line) -> NextPredicate<M, E> {
-    return { (next: Next<M, E>) in
+public func hasModel<Model, Effect>(file: StaticString = #file, line: UInt = #line) -> NextPredicate<Model, Effect> {
+    return { (next: Next<Model, Effect>) in
         let model = next.model
         if model == nil {
             return .failure(
@@ -85,8 +85,8 @@ public func hasModel<M, E>(file: StaticString = #file, line: UInt = #line) -> Ne
 
 /// - Parameter expected: the expected model
 /// - Returns: a `Predicate` that matches `Next` instances with a model that is equal to the supplied one.
-public func hasModel<M: Equatable, E>(_ expected: M, file: StaticString = #file, line: UInt = #line) -> NextPredicate<M, E> {
-    return { (next: Next<M, E>) in
+public func hasModel<Model: Equatable, Effect>(_ expected: Model, file: StaticString = #file, line: UInt = #line) -> NextPredicate<Model, Effect> {
+    return { (next: Next<Model, Effect>) in
         let actual = next.model
         if actual != expected {
             return .failure(
@@ -100,8 +100,8 @@ public func hasModel<M: Equatable, E>(_ expected: M, file: StaticString = #file,
 }
 
 /// - Returns: a `Predicate` that matches `Next` instances with no effects.
-public func hasNoEffects<M, E>(file: StaticString = #file, line: UInt = #line) -> NextPredicate<M, E> {
-    return { (next: Next<M, E>) in
+public func hasNoEffects<Model, Effect>(file: StaticString = #file, line: UInt = #line) -> NextPredicate<Model, Effect> {
+    return { (next: Next<Model, Effect>) in
         if next.hasEffects {
             return .failure(
                 message: "Expected no effects. Got: <\(next.effects)>",
@@ -118,12 +118,12 @@ public func hasNoEffects<M, E>(file: StaticString = #file, line: UInt = #line) -
 ///
 /// - Parameter expected: the effects to match (possibly empty)
 /// - Returns: a `Predicate` that matches `Next` instances that include all the supplied effects
-public func hasEffects<M, E>(
-    _ expected: Set<E>,
+public func hasEffects<Model, Effect>(
+    _ expected: Set<Effect>,
     file: StaticString = #file,
     line: UInt = #line
-) -> NextPredicate<M, E> {
-    return { (next: Next<M, E>) in
+) -> NextPredicate<Model, Effect> {
+    return { (next: Next<Model, Effect>) in
         let actual = next.effects
         if !actual.isSuperset(of: expected) {
             return .failure(message: "Expected <\(actual)> to contain <\(expected)>", file: file, line: line)

--- a/MobiusTest/Source/UpdateSpec.swift
+++ b/MobiusTest/Source/UpdateSpec.swift
@@ -19,46 +19,50 @@
 
 import MobiusCore
 
-public struct UpdateSpec<T: LoopTypes> {
+public struct UpdateSpec<Types: LoopTypes> {
+    public typealias Model = Types.Model
+    public typealias Event = Types.Event
+    public typealias Effect = Types.Effect
+
     public typealias Assert = (Result) -> Void
 
-    private let update: Update<T>
+    private let update: Update<Types>
 
-    public init(_ update: @escaping Update<T>) {
+    public init(_ update: @escaping Update<Types>) {
         self.update = update
     }
 
-    public func given(_ model: T.Model) -> When {
+    public func given(_ model: Model) -> When {
         return When(update, model)
     }
 
     public struct When {
-        private let update: Update<T>
-        private let model: T.Model
+        private let update: Update<Types>
+        private let model: Model
 
-        init(_ update: @escaping Update<T>, _ model: T.Model) {
+        init(_ update: @escaping Update<Types>, _ model: Model) {
             self.update = update
             self.model = model
         }
 
-        public func when(_ event: T.Event, _ moreEvents: T.Event...) -> Then {
+        public func when(_ event: Event, _ moreEvents: Event...) -> Then {
             return Then(update, model, [event] + moreEvents)
         }
     }
 
     public struct Then {
-        private let update: Update<T>
-        private let model: T.Model
-        private let events: [T.Event]
+        private let update: Update<Types>
+        private let model: Model
+        private let events: [Event]
 
-        init(_ update: @escaping Update<T>, _ model: T.Model, _ events: [T.Event]) {
+        init(_ update: @escaping Update<Types>, _ model: Model, _ events: [Event]) {
             self.update = update
             self.model = model
             self.events = events
         }
 
         public func then(_ expression: Assert) {
-            var lastNext: Next<T.Model, T.Effect>?
+            var lastNext: Next<Model, Effect>?
             var lastModel = model
 
             for event in events {
@@ -72,7 +76,7 @@ public struct UpdateSpec<T: LoopTypes> {
     }
 
     public struct Result {
-        public let model: T.Model
-        public let lastNext: Next<T.Model, T.Effect>
+        public let model: Model
+        public let lastNext: Next<Model, Effect>
     }
 }


### PR DESCRIPTION
Type parameters like `<T: LoopTypes>` where `T` is constrained and has semantics are unidiomatic in Swift. This PR cleans up all the cases on parameters of generic types (there are still many function parameters like `addThing<T: Thing>()`).