### PR TITLE
Add an EffectAction class

### DIFF
--- a/Mobius.xcodeproj/project.pbxproj
+++ b/Mobius.xcodeproj/project.pbxproj
@@ -138,6 +138,9 @@
 		69C12F7D222F25DB00DC4F9E /* MobiusCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5B3AA33220975248003F35C3 /* MobiusCore.framework */; };
 		69C12F7E222F25F700DC4F9E /* MobiusCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5B3AA33220975248003F35C3 /* MobiusCore.framework */; };
 		69C12F7F222F260100DC4F9E /* MobiusTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5BB2888A20999B2E0043B530 /* MobiusTest.framework */; };
+		DA9442F3231946D3006B11D9 /* EffectAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA9442F2231946D3006B11D9 /* EffectAction.swift */; };
+		DA9442F623194A68006B11D9 /* EffectActionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA9442F423194A46006B11D9 /* EffectActionTests.swift */; };
+		DA9442F723194D45006B11D9 /* EffectAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA9442F2231946D3006B11D9 /* EffectAction.swift */; };
 		DD710DCA20A0BCEC0047A7EC /* Quick.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5B3AA3BB2097551D003F35C3 /* Quick.framework */; };
 		DD710DCB20A0BCEC0047A7EC /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5B3AA3B920975511003F35C3 /* Nimble.framework */; };
 		DD710DCC20A0BCEC0047A7EC /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5B3AA3C4209757AC003F35C3 /* Foundation.framework */; };
@@ -356,6 +359,8 @@
 		69C12F77222F223700DC4F9E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = Carthage/Checkouts/xcconfigs/Base/Configurations/Release.xcconfig; sourceTree = "<group>"; };
 		69C12F78222F225500DC4F9E /* iOS-Framework.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = "iOS-Framework.xcconfig"; path = "Carthage/Checkouts/xcconfigs/iOS/iOS-Framework.xcconfig"; sourceTree = "<group>"; };
 		69C12F79222F225500DC4F9E /* iOS-StaticLibrary.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = "iOS-StaticLibrary.xcconfig"; path = "Carthage/Checkouts/xcconfigs/iOS/iOS-StaticLibrary.xcconfig"; sourceTree = "<group>"; };
+		DA9442F2231946D3006B11D9 /* EffectAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EffectAction.swift; sourceTree = "<group>"; };
+		DA9442F423194A46006B11D9 /* EffectActionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EffectActionTests.swift; sourceTree = "<group>"; };
 		DD710DD320A0BCEC0047A7EC /* MobiusExtrasTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = MobiusExtrasTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		DD748322212DB525008EEECD /* Copyable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Copyable.swift; sourceTree = "<group>"; };
 		DD748324212DEEC1008EEECD /* CopyableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CopyableTests.swift; sourceTree = "<group>"; };
@@ -673,6 +678,7 @@
 				5BB287E8209995420043B530 /* ConsoleLogger.swift */,
 				DD748322212DB525008EEECD /* Copyable.swift */,
 				5B1F104C21105CAD0067193C /* EventSource+Extensions.swift */,
+				DA9442F2231946D3006B11D9 /* EffectAction.swift */,
 			);
 			path = Source;
 			sourceTree = "<group>";
@@ -762,6 +768,7 @@
 				5B9CE80621199D4400DB79A7 /* ConnectableContramapTests.swift */,
 				DD748324212DEEC1008EEECD /* CopyableTests.swift */,
 				5B1F104F21105CC00067193C /* EventSource+ExtensionsTests.swift */,
+				DA9442F423194A46006B11D9 /* EffectActionTests.swift */,
 			);
 			path = Test;
 			sourceTree = "<group>";
@@ -1214,6 +1221,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				DA9442F723194D45006B11D9 /* EffectAction.swift in Sources */,
 				DD748326212DEEC6008EEECD /* Copyable.swift in Sources */,
 				3EE5AF052110BF2E00CF8CA8 /* ConnectableClass.swift in Sources */,
 				2DF4C42420DBDF1B00A4B6DE /* ConsoleLogger.swift in Sources */,
@@ -1302,6 +1310,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				DA9442F3231946D3006B11D9 /* EffectAction.swift in Sources */,
 				DD748323212DB525008EEECD /* Copyable.swift in Sources */,
 				5B9CE80521197FE000DB79A7 /* ConnectableContramap.swift in Sources */,
 				5B1F104D21105CAD0067193C /* EventSource+Extensions.swift in Sources */,
@@ -1370,6 +1379,7 @@
 				5B1F105121105CC50067193C /* EventSource+ExtensionsTests.swift in Sources */,
 				5BCF5F0420F3636800721C0D /* ConnectableClassTests.swift in Sources */,
 				5B9CE80721199D4400DB79A7 /* ConnectableContramapTests.swift in Sources */,
+				DA9442F623194A68006B11D9 /* EffectActionTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/MobiusExtras/Source/EffectAction.swift
+++ b/MobiusExtras/Source/EffectAction.swift
@@ -1,0 +1,47 @@
+// Copyright (c) 2019 Spotify AB.
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import MobiusCore
+
+/// A general implementation of the `ActionWithPredicate` protocol that takes an effect and a closure
+/// and triggers the closure when the effect is accepted and the action runs.
+public class EffectAction<EffectType>: ActionWithPredicate where EffectType: Equatable {
+    public typealias Effect = EffectType
+
+    private let acceptedEffect: Effect
+    private let action: () -> Void
+
+    /// Initializes an EffectAction
+    ///
+    /// - Parameters:
+    ///   - acceptedEffect: en effect that the EffectAction accepts.
+    ///   - action: a closure that gets triggered on the action run when the effect is accepted.
+    public init(_ acceptedEffect: Effect, action: @escaping () -> Void) {
+        self.acceptedEffect = acceptedEffect
+        self.action = action
+    }
+
+    public func canAccept(_ effect: Effect) -> Bool {
+        return effect == acceptedEffect
+    }
+
+    public func run() {
+        action()
+    }
+}

--- a/MobiusExtras/Source/EffectAction.swift
+++ b/MobiusExtras/Source/EffectAction.swift
@@ -20,7 +20,7 @@
 import MobiusCore
 
 /// A general implementation of the `ActionWithPredicate` protocol that takes a closure and triggers it when
-/// the provided effect or precidate is accepted and the action runs.
+/// the provided effect or predicate is accepted and the action runs.
 public class EffectAction<Effect>: ActionWithPredicate where Effect: Equatable {
     public typealias Predicate = (Effect) -> (Bool)
 
@@ -30,8 +30,8 @@ public class EffectAction<Effect>: ActionWithPredicate where Effect: Equatable {
     /// Initializes an EffectAction with a predicate.
     ///
     /// - Parameters:
-    ///   - predicate: a predicate whose accepting inputs the EffectAction accepts.
-    ///   - action: a closure that gets triggered on the action run when the effect is accepted.
+    ///   - predicate: a predicate selecting which Effects the EffectAction accepts.
+    ///   - action: a closure that gets executed when the EffectAction runs.
     public init(predicate: @escaping Predicate, action: @escaping () -> Void) {
         self.predicate = predicate
         self.action = action
@@ -41,7 +41,7 @@ public class EffectAction<Effect>: ActionWithPredicate where Effect: Equatable {
     ///
     /// - Parameters:
     ///   - acceptedEffect: en effect that the EffectAction accepts.
-    ///   - action: a closure that gets triggered on the action run when the effect is accepted.
+    ///   - action: a closure that gets executed when the EffectAction runs.
     public convenience init(_ acceptedEffect: Effect, action: @escaping () -> Void) {
         self.init(predicate: { effect in effect == acceptedEffect }, action: action)
     }

--- a/MobiusExtras/Source/EffectAction.swift
+++ b/MobiusExtras/Source/EffectAction.swift
@@ -19,26 +19,35 @@
 
 import MobiusCore
 
-/// A general implementation of the `ActionWithPredicate` protocol that takes an effect and a closure
-/// and triggers the closure when the effect is accepted and the action runs.
-public class EffectAction<EffectType>: ActionWithPredicate where EffectType: Equatable {
-    public typealias Effect = EffectType
+/// A general implementation of the `ActionWithPredicate` protocol that takes a closure and triggers it when
+/// the provided effect or precidate is accepted and the action runs.
+public class EffectAction<Effect>: ActionWithPredicate where Effect: Equatable {
+    public typealias Predicate = (Effect) -> (Bool)
 
-    private let acceptedEffect: Effect
+    private let predicate: Predicate
     private let action: () -> Void
 
-    /// Initializes an EffectAction
+    /// Initializes an EffectAction with a predicate.
+    ///
+    /// - Parameters:
+    ///   - predicate: a predicate whose accepting inputs the EffectAction accepts.
+    ///   - action: a closure that gets triggered on the action run when the effect is accepted.
+    public init(predicate: @escaping Predicate, action: @escaping () -> Void) {
+        self.predicate = predicate
+        self.action = action
+    }
+
+    /// Initializes an EffectAction with an accepted effect.
     ///
     /// - Parameters:
     ///   - acceptedEffect: en effect that the EffectAction accepts.
     ///   - action: a closure that gets triggered on the action run when the effect is accepted.
-    public init(_ acceptedEffect: Effect, action: @escaping () -> Void) {
-        self.acceptedEffect = acceptedEffect
-        self.action = action
+    public convenience init(_ acceptedEffect: Effect, action: @escaping () -> Void) {
+        self.init(predicate: { effect in effect == acceptedEffect }, action: action)
     }
 
     public func canAccept(_ effect: Effect) -> Bool {
-        return effect == acceptedEffect
+        return predicate(effect)
     }
 
     public func run() {

--- a/MobiusExtras/Test/EffectActionTests.swift
+++ b/MobiusExtras/Test/EffectActionTests.swift
@@ -23,6 +23,7 @@ import Nimble
 import Quick
 
 class EffectActionTests: QuickSpec {
+    // swiftlint:disable function_body_length
     override func spec() {
         describe("EffectAction") {
             enum Effect: Equatable {
@@ -67,12 +68,14 @@ class EffectActionTests: QuickSpec {
 
             context("when initializing with predicate") {
                 beforeEach {
-                    effectAction = EffectAction(predicate: { effect in
-                        if case .acceptedWith = effect {
-                            return true
-                        }
-                        return false
-                    }, action: actionClosure)
+                    effectAction = EffectAction(
+                        predicate: { effect in
+                            if case .acceptedWith = effect {
+                                return true
+                            }
+                            return false
+                        },
+                        action: actionClosure)
                     actionCalled = false
                 }
 

--- a/MobiusExtras/Test/EffectActionTests.swift
+++ b/MobiusExtras/Test/EffectActionTests.swift
@@ -1,0 +1,65 @@
+// Copyright (c) 2019 Spotify AB.
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import MobiusCore
+import MobiusExtras
+import Nimble
+import Quick
+
+class EffectActionTests: QuickSpec {
+    override func spec() {
+        describe("EffectAction") {
+            enum Effect {
+                case accepted
+                case rejected
+            }
+
+            var effectAction: EffectAction<Effect>!
+            var actionCalled = false
+            let actionClosure: () -> Void = {
+                actionCalled = true
+            }
+
+            beforeEach {
+                effectAction = EffectAction(.accepted, action: actionClosure)
+            }
+
+            context("when asking for effect acceptance on acceptable effect") {
+                it("is accepted") {
+                    expect(effectAction.canAccept(.accepted)).to(beTrue())
+                    expect(actionCalled).to(beFalse())
+                }
+            }
+
+            context("when asking for effect acceptance on non acceptable effect") {
+                it("is not accepted") {
+                    expect(effectAction.canAccept(.rejected)).to(beFalse())
+                    expect(actionCalled).to(beFalse())
+                }
+            }
+
+            context("when running the action") {
+                it("calls the action closure") {
+                    effectAction.run()
+                    expect(actionCalled).to(beTrue())
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR contains a general implementation of the `ActionWithPredicate` protocol that takes a closure and triggers it when the provided effect or precidate is accepted and the action runs.

We identified a common pattern in our codebase of repeating simple, single-purpose `Action` classes eg. to handle various navigation events. This class helped us to generalize them. 

Support for effect cases with associated values does not come out of the box because of the Swift limitations, but it can be done by providing a custom predicate. Example of such use case is in unit tests.