### PR TITLE
Update to Swift 5

### DIFF
--- a/Mobius.xcodeproj/project.pbxproj
+++ b/Mobius.xcodeproj/project.pbxproj
@@ -1056,6 +1056,7 @@
 					};
 					5B3AA33A20975248003F35C3 = {
 						CreatedOnToolsVersion = 9.3;
+						LastSwiftMigration = 1100;
 						ProvisioningStyle = Automatic;
 					};
 					5B3AA3CE20975802003F35C3 = {
@@ -1064,10 +1065,12 @@
 					};
 					5B80EDCE2125A18800F87129 = {
 						CreatedOnToolsVersion = 9.4.1;
+						LastSwiftMigration = 1100;
 						ProvisioningStyle = Automatic;
 					};
 					5B80EDD62125A18800F87129 = {
 						CreatedOnToolsVersion = 9.4.1;
+						LastSwiftMigration = 1100;
 						ProvisioningStyle = Automatic;
 					};
 					5B80EDF42125A32200F87129 = {
@@ -1435,7 +1438,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
 				SWIFT_INSTALL_OBJC_HEADER = NO;
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -1450,7 +1453,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
 				SWIFT_INSTALL_OBJC_HEADER = NO;
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};
@@ -1522,7 +1525,6 @@
 				INFOPLIST_FILE = "$(SRCROOT)/MobiusCore/BuildSystem/MobiusCore-Info.plist";
 				PRODUCT_BUNDLE_IDENTIFIER = com.spotify.MobiusCore;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
-				SWIFT_VERSION = 5.0;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -1540,7 +1542,6 @@
 				INFOPLIST_FILE = "$(SRCROOT)/MobiusCore/BuildSystem/MobiusCore-Info.plist";
 				PRODUCT_BUNDLE_IDENTIFIER = com.spotify.MobiusCore;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
-				SWIFT_VERSION = 5.0;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -1730,7 +1731,6 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks $(PROJECT_DIR)/Carthage/Build/iOS";
 				PRODUCT_BUNDLE_IDENTIFIER = com.spotify.MobiusTest;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
-				SWIFT_VERSION = 5.0;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -1756,7 +1756,6 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks $(PROJECT_DIR)/Carthage/Build/iOS";
 				PRODUCT_BUNDLE_IDENTIFIER = com.spotify.MobiusTest;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
-				SWIFT_VERSION = 5.0;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -1773,7 +1772,6 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks $(PROJECT_DIR)/Carthage/Build/iOS";
 				PRODUCT_BUNDLE_IDENTIFIER = com.spotify.MobiusTestTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -1788,7 +1786,6 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks $(PROJECT_DIR)/Carthage/Build/iOS";
 				PRODUCT_BUNDLE_IDENTIFIER = com.spotify.MobiusTestTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};

--- a/MobiusCore/Source/NoEffect.swift
+++ b/MobiusCore/Source/NoEffect.swift
@@ -20,20 +20,5 @@
 import Foundation
 
 /// The `NoEffect` type can be used to signal that some data passing through a Mobius loop cannot have any effects.
-/// This is checked by the type system since the `NoEffect` enum does not have any cases.
-///
-/// - Note: The `Equatable` and `Hashable` implementations always returns `true` and `0`, respectively. The
-///         conformance is just to allow the type to be used where required. Such as with the `First` and `Next` data
-///         structures.
-public enum NoEffect: Equatable, Hashable {
-    public static func == (lhs: NoEffect, rhs: NoEffect) -> Bool {
-        #if compiler(>=5.1)
-        // #if compiler(<5.1) doesn’t work in the Xcode 10.1 toolchain
-        #else
-        // This is required in earlier compiler versions, but a warning in newer ones
-        return true
-        #endif
-    }
-    public var hashValue: Int { return 0 }
-    public func hash(into hasher: inout Hasher) {}
-}
+@available(*, deprecated, message: "use Never instead")
+typealias NoEffect = Never

--- a/MobiusCore/Test/NextTests.swift
+++ b/MobiusCore/Test/NextTests.swift
@@ -116,7 +116,7 @@ class NextTests: QuickSpec {
 
                 describe("noChange") {
                     it("should not have a model") {
-                        expect(Next<Int, NoEffect>.noChange.model).to(beNil())
+                        expect(Next<Int, Never>.noChange.model).to(beNil())
                     }
 
                     it("should not have any effects") {
@@ -161,7 +161,6 @@ class NextTests: QuickSpec {
                 }
             }
 
-            #if swift(>=4.1)
             describe("Equatable") {
                 context("when the model type is equatable") {
                     let model1 = "some text"
@@ -198,7 +197,6 @@ class NextTests: QuickSpec {
                     }
                 }
             }
-            #endif
 
             describe("debug description") {
                 context("when containing a model") {


### PR DESCRIPTION
Also deprecates `NoEffect` since `Never` is `Hashable` in Swift 5 and is idiomatic for this kind of use case.