### PR TITLE
Use arrays of effects and remove Hashable conformance requirement

### DIFF
--- a/Mobius.xcodeproj/project.pbxproj
+++ b/Mobius.xcodeproj/project.pbxproj
@@ -10,6 +10,8 @@
 		02BED1BB21DD20D20093FB47 /* ConnectableContramap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B9CE80421197FE000DB79A7 /* ConnectableContramap.swift */; };
 		2D54D0F021C11362002AAC19 /* AtomicBool.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D54D0EF21C11362002AAC19 /* AtomicBool.swift */; };
 		2D54D0F121C1167C002AAC19 /* AtomicBool.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D54D0EF21C11362002AAC19 /* AtomicBool.swift */; };
+		2DC2C0A62350CEBE005FFFB2 /* BackwardsCompatibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DC2C0A52350CEBE005FFFB2 /* BackwardsCompatibility.swift */; };
+		2DC2C0A72350CEC1005FFFB2 /* BackwardsCompatibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DC2C0A52350CEBE005FFFB2 /* BackwardsCompatibility.swift */; };
 		2DDF54C0229BDB4800D05861 /* CompositeEventSourceBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DDF54BF229BDB4700D05861 /* CompositeEventSourceBuilder.swift */; };
 		2DDF54C1229BDB4800D05861 /* CompositeEventSourceBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DDF54BF229BDB4700D05861 /* CompositeEventSourceBuilder.swift */; };
 		2DDF54C3229BEEC400D05861 /* CompositeEventSourceBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DDF54C2229BEEC400D05861 /* CompositeEventSourceBuilderTests.swift */; };
@@ -255,6 +257,7 @@
 /* Begin PBXFileReference section */
 		2D2FE60F20625E76002DFD69 /* Mobius.playground */ = {isa = PBXFileReference; lastKnownFileType = file.playground; path = Mobius.playground; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		2D54D0EF21C11362002AAC19 /* AtomicBool.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AtomicBool.swift; sourceTree = "<group>"; };
+		2DC2C0A52350CEBE005FFFB2 /* BackwardsCompatibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackwardsCompatibility.swift; sourceTree = "<group>"; };
 		2DDF54BF229BDB4700D05861 /* CompositeEventSourceBuilder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CompositeEventSourceBuilder.swift; sourceTree = "<group>"; };
 		2DDF54C2229BEEC400D05861 /* CompositeEventSourceBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompositeEventSourceBuilderTests.swift; sourceTree = "<group>"; };
 		2DF4C2F520DBDD4700A4B6DE /* libMobiusCore.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libMobiusCore.a; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -609,6 +612,7 @@
 				5B1F1038210F5E7D0067193C /* ConnectableConvenienceClasses */,
 				5BB287BC209995410043B530 /* Disposables */,
 				5B4A369821107D0E00279C7D /* EventSources */,
+				2DC2C0A52350CEBE005FFFB2 /* BackwardsCompatibility.swift */,
 				5BB287C1209995410043B530 /* BrokenConnection.swift */,
 				5B237EB9209C4F3C00764576 /* Connectable.swift */,
 				5BB287BA209995410043B530 /* ConnectablePublisher.swift */,
@@ -1182,6 +1186,7 @@
 				2DF4C30220DBDD5800A4B6DE /* ConnectablePublisher.swift in Sources */,
 				2DF4C2FF20DBDD5800A4B6DE /* Consumer.swift in Sources */,
 				2DF4C30A20DBDD5C00A4B6DE /* NoEffect.swift in Sources */,
+				2DC2C0A72350CEC1005FFFB2 /* BackwardsCompatibility.swift in Sources */,
 				2DF4C30B20DBDD5C00A4B6DE /* EventProcessor.swift in Sources */,
 				2DF4C2FC20DBDD5800A4B6DE /* Next.swift in Sources */,
 				2DF4C30D20DBDD5C00A4B6DE /* MobiusLogger.swift in Sources */,
@@ -1240,6 +1245,7 @@
 				5B4A369A21107D2600279C7D /* AnyEventSource.swift in Sources */,
 				5BB2881A2099957D0043B530 /* MobiusLoop.swift in Sources */,
 				5BB288192099957D0043B530 /* Consumer.swift in Sources */,
+				2DC2C0A62350CEBE005FFFB2 /* BackwardsCompatibility.swift in Sources */,
 				5BB28826209995810043B530 /* MobiusController.swift in Sources */,
 				5BB2882A209995860043B530 /* CompositeDisposable.swift in Sources */,
 				5BB28828209995810043B530 /* Locking.swift in Sources */,

--- a/MobiusCore/Source/BackwardsCompatibility.swift
+++ b/MobiusCore/Source/BackwardsCompatibility.swift
@@ -17,33 +17,10 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import MobiusCore
-
-public typealias AssertFirst<Model, Effect> = (First<Model, Effect>) -> Void
-
-public final class InitSpec<Types: LoopTypes> {
-    let initiator: Initiator<Types>
-
-    public init(_ initiator: @escaping Initiator<Types>) {
-        self.initiator = initiator
-    }
-
-    public func when(_ model: Types.Model) -> Then {
-        return Then(model, initiator: initiator)
-    }
-
-    public struct Then {
-        let model: Types.Model
-        let initiator: Initiator<Types>
-
-        public init(_ model: Types.Model, initiator: @escaping Initiator<Types>) {
-            self.model = model
-            self.initiator = initiator
-        }
-
-        public func then(_ assertion: AssertFirst<Types.Model, Types.Effect>) {
-            let first = initiator(model)
-            assertion(first)
-        }
+public extension First where Effect: Hashable {
+    @available(*, deprecated, message: "use array of effects instead")
+    init(model: Model, effects: Set<Effect>) {
+        self.model = model
+        self.effects = Array(effects)
     }
 }

--- a/MobiusCore/Source/BackwardsCompatibility.swift
+++ b/MobiusCore/Source/BackwardsCompatibility.swift
@@ -24,3 +24,15 @@ public extension First where Effect: Hashable {
         self.effects = Array(effects)
     }
 }
+
+public extension Next where Effect: Hashable {
+    @available(*, deprecated, message: "use array of effects instead")
+    static func next(_ model: Model, effects: Set<Effect>) -> Next<Model, Effect> {
+        return .next(model, effects: Array(effects))
+    }
+
+    @available(*, deprecated, message: "use array of effects instead")
+    static func dispatchEffects(_ effects: Set<Effect>) -> Next<Model, Effect> {
+        return .dispatchEffects(Array(effects))
+    }
+}

--- a/MobiusCore/Source/EventProcessor.swift
+++ b/MobiusCore/Source/EventProcessor.swift
@@ -54,7 +54,7 @@ class EventProcessor<Types: LoopTypes>: Disposable, CustomDebugStringConvertible
         queue.sync(flags: .barrier) {
             currentModel = first.model
 
-            publisher.post(Next.next(first.model, effects: first.effects))
+            publisher.post(Next.next(first.model, effects: Set(first.effects)))
 
             for event in queuedEvents {
                 accept(event)

--- a/MobiusCore/Source/EventProcessor.swift
+++ b/MobiusCore/Source/EventProcessor.swift
@@ -54,7 +54,7 @@ class EventProcessor<Types: LoopTypes>: Disposable, CustomDebugStringConvertible
         queue.sync(flags: .barrier) {
             currentModel = first.model
 
-            publisher.post(Next.next(first.model, effects: Set(first.effects)))
+            publisher.post(Next.next(first.model, effects: first.effects))
 
             for event in queuedEvents {
                 accept(event)

--- a/MobiusCore/Source/First.swift
+++ b/MobiusCore/Source/First.swift
@@ -20,20 +20,20 @@
 import Foundation
 
 /// The `First` structure defines the initial state of a Mobius loop.
-public struct First<Model, Effect> where Effect: Hashable {
+public struct First<Model, Effect> {
     /// The initial model object that should be used.
     public let model: Model
     /// An optional set of effects to initially dispatch.
     ///
     /// If empty, no effects will be dispatched.
-    public let effects: Set<Effect>
+    public let effects: [Effect]
 
     /// Initialize a `First` object with the given model and
     ///
     /// - Parameters:
     ///   - model: The initial model.
     ///   - effects: Any initial effects that should be dispatched.
-    public init(model: Model, effects: Set<Effect> = []) {
+    public init(model: Model, effects: [Effect] = []) {
         self.model = model
         self.effects = effects
     }

--- a/MobiusCore/Source/Mobius.swift
+++ b/MobiusCore/Source/Mobius.swift
@@ -22,7 +22,7 @@ import Foundation
 public protocol LoopTypes {
     associatedtype Model
     associatedtype Event
-    associatedtype Effect: Hashable
+    associatedtype Effect
 }
 
 public typealias Update<T: LoopTypes> = (T.Model, T.Event) -> Next<T.Model, T.Effect>

--- a/MobiusCore/Source/Next.swift
+++ b/MobiusCore/Source/Next.swift
@@ -28,40 +28,40 @@ import Foundation
 ///
 /// A `Next` instance can either be created using the the initializer or the convenience factory methods. It’s
 /// **recommended to use the convenience factory methods** as it helps with readability in update functions.
-public struct Next<Model, Effect> where Effect: Hashable {
+public struct Next<Model, Effect> {
     /// The model that should be used next.
     public let model: Model?
 
-    /// A set of effects that should be dispatched next.
+    /// A list of effects that should be dispatched next.
     ///
     /// Can be empty in which case no side-effects should be dispatched.
-    public let effects: Set<Effect>
+    public let effects: [Effect]
 }
 
 public extension Next {
-    /// Create a `Next` that updates the model and dispatches the supplied set of effects.
+    /// Create a `Next` that updates the model and dispatches the supplied effects.
     ///
     /// If `effects` is empty no side-effects will be dispatched.
     ///
     /// - Parameters:
     ///   - model: The model that should be used next.
-    ///   - effects: The effects that should be dispatched next. Defaults to an empty set (no effects).
-    /// - Returns: A `Next` that updates the model and an, optionally empty, set of effects.
-    static func next(_ model: Model, effects: Set<Effect> = []) -> Next<Model, Effect> {
+    ///   - effects: The effects that should be dispatched next. Defaults to an empty array (no effects).
+    /// - Returns: A `Next` that updates the model and an, optionally empty, list of effects.
+    static func next(_ model: Model, effects: [Effect] = []) -> Next<Model, Effect> {
         return self.init(model: model, effects: effects)
     }
 
-    /// Create a `Next` that doesn’t update the model but dispatches a set of effects.
+    /// Create a `Next` that doesn’t update the model but dispatches a list of effects.
     ///
     /// - Parameter effects: The effects that should be dispatched next.
-    /// - Returns: A `Next` that doesn’t update the model but dispatches a set of effects.
-    static func dispatchEffects(_ effects: Set<Effect>) -> Next<Model, Effect> {
+    /// - Returns: A `Next` that doesn’t update the model but dispatches a list of effects.
+    static func dispatchEffects(_ effects: [Effect]) -> Next<Model, Effect> {
         return self.init(model: nil, effects: effects)
     }
 
     /// Creates an empty `Next` that doesn’t update the model or dispatch effects.
     ///
-    /// The `model` property will be `nil`, and the `effects` set will be empty.
+    /// The `model` property will be `nil`, and the `effects` will be empty.
     static var noChange: Next<Model, Effect> {
         return Next(model: nil, effects: [])
     }
@@ -72,7 +72,7 @@ public extension Next {
     var hasEffects: Bool { return !effects.isEmpty }
 }
 
-extension Next: Equatable where Model: Equatable {
+extension Next: Equatable where Model: Equatable, Effect: Equatable {
     public static func == (lhs: Next<Model, Effect>, rhs: Next<Model, Effect>) -> Bool {
         return lhs.model == rhs.model && lhs.effects == rhs.effects
     }

--- a/MobiusCore/Test/AnyMobiusLoggerTests.swift
+++ b/MobiusCore/Test/AnyMobiusLoggerTests.swift
@@ -42,7 +42,7 @@ class AnyMobiusLoggerTests: QuickSpec {
                 logger.didInitiate(model: "did start it", first: First(model: "the first model"))
 
                 expect(delegate.logMessages).to(equal([
-                    "didInitiate(did start it, First<String, String>(model: \"the first model\", effects: Set([])))",
+                    "didInitiate(did start it, First<String, String>(model: \"the first model\", effects: []))",
                 ]))
             }
 

--- a/MobiusCore/Test/LoggingInitTests.swift
+++ b/MobiusCore/Test/LoggingInitTests.swift
@@ -35,7 +35,7 @@ class LoggingInitiatorTests: QuickSpec {
             it("should log willInitiate and didInitiate for each initiate attempt") {
                 _ = loggingInitiator.initiate("from this")
 
-                expect(logger.logMessages).to(equal(["willInitiate(from this)", "didInitiate(from this, First<String, String>(model: \"from this\", effects: Set([])))"]))
+                expect(logger.logMessages).to(equal(["willInitiate(from this)", "didInitiate(from this, First<String, String>(model: \"from this\", effects: []))"]))
             }
 
             it("should return init from delegate") {

--- a/MobiusCore/Test/MobiusLoopTests.swift
+++ b/MobiusCore/Test/MobiusLoopTests.swift
@@ -200,7 +200,7 @@ class MobiusLoopTests: QuickSpec {
                 }
 
                 it("should log startup") {
-                    expect(logger.logMessages).toEventually(equal(["willInitiate(begin)", "didInitiate(begin, First<String, String>(model: \"begin\", effects: Set([])))"]))
+                    expect(logger.logMessages).toEventually(equal(["willInitiate(begin)", "didInitiate(begin, First<String, String>(model: \"begin\", effects: []))"]))
                 }
 
                 it("should log updates") {

--- a/MobiusCore/Test/NextTests.swift
+++ b/MobiusCore/Test/NextTests.swift
@@ -201,7 +201,7 @@ class NextTests: QuickSpec {
             describe("debug description") {
                 context("when containing a model") {
                     it("should produce the appropriate description") {
-                        let next = Next<Int, Int>(model: 3, effects: Set([1]))
+                        let next = Next<Int, Int>(model: 3, effects: [1])
                         let description = String(describing: next)
                         expect(description).to(equal("(3, [1])"))
                     }
@@ -209,7 +209,7 @@ class NextTests: QuickSpec {
 
                 context("when no model") {
                     it("should produce the appropriate description") {
-                        let next = Next<Int, Int>(model: nil, effects: Set([1]))
+                        let next = Next<Int, Int>(model: nil, effects: [1])
                         let description = String(describing: next)
                         expect(description).to(equal("(nil, [1])"))
                     }

--- a/MobiusNimble/Source/NimbleFirstMatchers.swift
+++ b/MobiusNimble/Source/NimbleFirstMatchers.swift
@@ -72,7 +72,7 @@ public func haveNoEffects<Model, Effect>() -> Nimble.Predicate<First<Model, Effe
 ///
 /// - Parameter effects: the effects to match (possibly empty)
 /// - Returns: a `Predicate` that matches `First` instances that include all the supplied effects
-public func haveEffects<Model, Effect: Equatable>(_ effects: Set<Effect>) -> Nimble.Predicate<First<Model, Effect>> {
+public func haveEffects<Model, Effect: Equatable>(_ effects: [Effect]) -> Nimble.Predicate<First<Model, Effect>> {
     return Nimble.Predicate<First<Model, Effect>>.define(matcher: { actualExpression -> Nimble.PredicateResult in
         guard let first = try actualExpression.evaluate() else {
             return unexpectedNilParameterPredicateResult
@@ -80,6 +80,11 @@ public func haveEffects<Model, Effect: Equatable>(_ effects: Set<Effect>) -> Nim
 
         let expectedDescription = String(describing: effects)
         let actualDescription = String(describing: first.effects)
-        return PredicateResult(bool: first.effects.isSuperset(of: effects), message: .expectedCustomValueTo("contain <\(expectedDescription)>", "<\(actualDescription)> (order doesn't matter)"))
+        return PredicateResult(bool: effects.allSatisfy(first.effects.contains), message: .expectedCustomValueTo("contain <\(expectedDescription)>", "<\(actualDescription)> (order doesn't matter)"))
     })
+}
+
+@available(*, deprecated, message: "use array of effects instead")
+public func haveEffects<Model, Effect: Equatable>(_ effects: Set<Effect>) -> Nimble.Predicate<First<Model, Effect>> {
+    return haveEffects(Array(effects))
 }

--- a/MobiusNimble/Source/NimbleNextMatchers.swift
+++ b/MobiusNimble/Source/NimbleNextMatchers.swift
@@ -102,7 +102,7 @@ public func haveNoEffects<Model, Effect>() -> Nimble.Predicate<Next<Model, Effec
 ///
 /// - Parameter expected: the effects to match (possibly empty)
 /// - Returns: a `Predicate` that matches `Next` instances that include all the supplied effects
-public func haveEffects<Model, Effect: Hashable>(_ expected: Set<Effect>) -> Nimble.Predicate<Next<Model, Effect>> {
+public func haveEffects<Model, Effect: Hashable>(_ expected: [Effect]) -> Nimble.Predicate<Next<Model, Effect>> {
     return Nimble.Predicate<Next<Model, Effect>>.define(matcher: { actualExpression in
         guard let next = try actualExpression.evaluate() else {
             return unexpectedNilParameterPredicate
@@ -111,8 +111,13 @@ public func haveEffects<Model, Effect: Hashable>(_ expected: Set<Effect>) -> Nim
         let expectedDescription = String(describing: expected)
         let actualDescription = String(describing: next.effects)
         return Nimble.PredicateResult(
-            bool: next.effects.isSuperset(of: expected),
+            bool: expected.allSatisfy(next.effects.contains),
             message: .expectedCustomValueTo("contain <\(expectedDescription)>", "<\(actualDescription)> (order doesn't matter)")
         )
     })
+}
+
+@available(*, deprecated, message: "use array of effects instead")
+public func haveEffects<Model, Effect: Hashable>(_ expected: Set<Effect>) -> Nimble.Predicate<Next<Model, Effect>> {
+    return haveEffects(Array(expected))
 }

--- a/MobiusNimble/Test/NimbleFirstMatchersTests.swift
+++ b/MobiusNimble/Test/NimbleFirstMatchersTests.swift
@@ -45,7 +45,7 @@ class NimbleFirstMatchersTests: QuickSpec {
 
             let model = "3"
             func testInitiator(model: String) -> First<String, String> {
-                return First<String, String>(model: model, effects: Set(["2", "4"]))
+                return First<String, String>(model: model, effects: ["2", "4"])
             }
 
             // Testing through proxy: UpdateSpec
@@ -135,7 +135,7 @@ class NimbleFirstMatchersTests: QuickSpec {
                 context("when the First has effects") {
                     let effects = [4]
                     beforeEach {
-                        let first = First<Int, Int>(model: 3, effects: Set(effects))
+                        let first = First<Int, Int>(model: 3, effects: effects)
                         expect(first).to(haveNoEffects())
                     }
 
@@ -168,8 +168,8 @@ class NimbleFirstMatchersTests: QuickSpec {
                 context("when the First has those effects") {
                     let expectedEffects = [4, 7, 0]
                     beforeEach {
-                        let first = First<Int, Int>(model: 3, effects: Set(expectedEffects))
-                        expect(first).to(haveEffects(Set(expectedEffects)))
+                        let first = First<Int, Int>(model: 3, effects: expectedEffects)
+                        expect(first).to(haveEffects(expectedEffects))
                     }
 
                     it("should not match") {
@@ -181,8 +181,8 @@ class NimbleFirstMatchersTests: QuickSpec {
                     let expectedEffects = [4, 7, 0]
                     let actualEffects = [1, 4, 7, 0]
                     beforeEach {
-                        let first = First<Int, Int>(model: 3, effects: Set(actualEffects))
-                        expect(first).to(haveEffects(Set(expectedEffects)))
+                        let first = First<Int, Int>(model: 3, effects: actualEffects)
+                        expect(first).to(haveEffects(expectedEffects))
                     }
 
                     it("should match") {
@@ -194,8 +194,8 @@ class NimbleFirstMatchersTests: QuickSpec {
                     let expectedEffects = [4]
                     let actualEffects = [1]
                     beforeEach {
-                        let first = First<Int, Int>(model: 3, effects: Set(actualEffects))
-                        expect(first).to(haveEffects(Set(expectedEffects)))
+                        let first = First<Int, Int>(model: 3, effects: actualEffects)
+                        expect(first).to(haveEffects(expectedEffects))
                     }
 
                     it("should produce an appropriate error message") {

--- a/MobiusNimble/Test/NimbleNextMatchersTests.swift
+++ b/MobiusNimble/Test/NimbleNextMatchersTests.swift
@@ -49,7 +49,7 @@ class NimbleNextMatchersTests: QuickSpec {
             }
 
             func testUpdate(model: String, event: String) -> Next<String, String> {
-                return .next("some model", effects: Set(["some effect"]))
+                return .next("some model", effects: ["some effect"])
             }
 
             // Testing through proxy: UpdateSpec
@@ -108,7 +108,7 @@ class NimbleNextMatchersTests: QuickSpec {
 
                 context("when matching a Next that has effects but no model") {
                     beforeEach {
-                        let next = Next<Int, Int>.dispatchEffects(Set(effects))
+                        let next = Next<Int, Int>.dispatchEffects(effects)
                         expect(next).to(haveNothing())
                     }
 
@@ -119,7 +119,7 @@ class NimbleNextMatchersTests: QuickSpec {
 
                 context("when matching a Next that has model and effects") {
                     beforeEach {
-                        let next = Next<Int, Int>.next(model, effects: Set(effects))
+                        let next = Next<Int, Int>.next(model, effects: effects)
                         expect(next).to(haveNothing())
                     }
 
@@ -338,9 +338,9 @@ class NimbleNextMatchersTests: QuickSpec {
             }
 
             context("when creating a matcher verifying that a Next has specific effects") {
-                var expected: Set<Int>!
+                var expected: [Int]!
                 beforeEach {
-                    expected = Set([4])
+                    expected = [4]
                 }
                 context("when the effects are the same") {
                     beforeEach {
@@ -356,7 +356,7 @@ class NimbleNextMatchersTests: QuickSpec {
                 context("when the Next contains the expected effects and a few more") {
                     let actual = [1, 2, 3, 4, 5, 0]
                     beforeEach {
-                        let next = Next<String, Int>.dispatchEffects(Set(actual))
+                        let next = Next<String, Int>.dispatchEffects(actual)
                         expect(next).to(haveEffects(expected))
                     }
 
@@ -366,10 +366,10 @@ class NimbleNextMatchersTests: QuickSpec {
                 }
 
                 context("when the Next does not contain one or more of the expected effects") {
-                    var actual: Set<Int>!
+                    var actual: [Int]!
                     beforeEach {
-                        actual = Set([1])
-                        let next = Next<String, Int>.dispatchEffects(Set(actual))
+                        actual = [1]
+                        let next = Next<String, Int>.dispatchEffects(actual)
                         expect(next).to(haveEffects(expected))
                     }
 
@@ -386,7 +386,7 @@ class NimbleNextMatchersTests: QuickSpec {
                     context("when not expecting effects") {
                         beforeEach {
                             let next = Next<String, Int>.noChange
-                            expect(next).to(haveEffects(Set<Int>()))
+                            expect(next).to(haveEffects([]))
                         }
 
                         it("should match") {

--- a/MobiusTest/Source/FirstMatchers.swift
+++ b/MobiusTest/Source/FirstMatchers.swift
@@ -92,7 +92,7 @@ public func hasEffects<Model, Effect: Equatable>(
     line: UInt = #line
 ) -> FirstPredicate<Model, Effect> {
     return { (first: First<Model, Effect>) in
-        if !first.effects.isSuperset(of: expected) {
+        if !expected.allSatisfy(first.effects.contains) {
             return .failure(
                 message: "Expected effects <\(first.effects)> to contain <\(expected)>",
                 file: file,

--- a/MobiusTest/Source/NextMatchers.swift
+++ b/MobiusTest/Source/NextMatchers.swift
@@ -125,7 +125,7 @@ public func hasEffects<Model, Effect>(
 ) -> NextPredicate<Model, Effect> {
     return { (next: Next<Model, Effect>) in
         let actual = next.effects
-        if !actual.isSuperset(of: expected) {
+        if !expected.allSatisfy(actual.contains) {
             return .failure(message: "Expected <\(actual)> to contain <\(expected)>", file: file, line: line)
         }
         return .success

--- a/MobiusTest/Test/FirstMatchersTests.swift
+++ b/MobiusTest/Test/FirstMatchersTests.swift
@@ -30,7 +30,7 @@ class FirstMatchersTests: QuickSpec {
             let model = "3"
 
             func testInitiator(model: String) -> First<String, String> {
-                return First<String, String>(model: model, effects: Set(["2", "4"]))
+                return First<String, String>(model: model, effects: ["2", "4"])
             }
 
             func failureDetector(message: String, file: StaticString, line: UInt) {
@@ -110,7 +110,7 @@ class FirstMatchersTests: QuickSpec {
                 context("when the First has effects") {
                     let effects = [4]
                     beforeEach {
-                        let first = First<Int, Int>(model: 3, effects: Set(effects))
+                        let first = First<Int, Int>(model: 3, effects: effects)
                         let sut: FirstPredicate<Int, Int> = hasNoEffects()
                         result = sut(first)
                     }
@@ -125,7 +125,7 @@ class FirstMatchersTests: QuickSpec {
                 context("when the First has those effects") {
                     let expectedEffects = [4, 7, 0]
                     beforeEach {
-                        let first = First<Int, Int>(model: 3, effects: Set(expectedEffects))
+                        let first = First<Int, Int>(model: 3, effects: expectedEffects)
                         let sut: FirstPredicate<Int, Int> = hasEffects(expectedEffects)
                         result = sut(first)
                     }
@@ -139,7 +139,7 @@ class FirstMatchersTests: QuickSpec {
                     let expectedEffects = [4, 7, 0]
                     let actualEffects = [1, 4, 7, 0]
                     beforeEach {
-                        let first = First<Int, Int>(model: 3, effects: Set(actualEffects))
+                        let first = First<Int, Int>(model: 3, effects: actualEffects)
                         let sut: FirstPredicate<Int, Int> = hasEffects(expectedEffects)
                         result = sut(first)
                     }
@@ -153,7 +153,7 @@ class FirstMatchersTests: QuickSpec {
                     let expectedEffects = [10]
                     let actualEffects = [4]
                     beforeEach {
-                        let first = First<Int, Int>(model: 3, effects: Set(actualEffects))
+                        let first = First<Int, Int>(model: 3, effects: actualEffects)
                         let sut: FirstPredicate<Int, Int> = hasEffects(expectedEffects)
                         result = sut(first)
                     }

--- a/MobiusTest/Test/InitSpecTests.swift
+++ b/MobiusTest/Test/InitSpecTests.swift
@@ -30,12 +30,12 @@ class InitSpecTests: QuickSpec {
                 var initiator: Initiator<AllStrings>!
                 var spec: InitSpec<AllStrings>!
                 var testModel: String!
-                var testEffects: Set<String>!
+                var testEffects: [String]!
                 var assertionClosureCalled = false
 
                 beforeEach {
                     testModel = UUID().uuidString
-                    testEffects = Set(["1", "2", "3"])
+                    testEffects = ["1", "2", "3"]
                     initiator = { (model: String) in
                         First<String, String>(model: model + model, effects: testEffects)
                     }

--- a/MobiusTest/Test/NextMatchersTests.swift
+++ b/MobiusTest/Test/NextMatchersTests.swift
@@ -43,7 +43,7 @@ class XCTestNextMatchersTests: QuickSpec {
             }
 
             func testUpdate(model: String, event: String) -> Next<String, String> {
-                return .next("some model", effects: Set(["some effect"]))
+                return .next("some model", effects: ["some effect"])
             }
 
             // Testing through proxy: UpdateSpec
@@ -101,7 +101,7 @@ class XCTestNextMatchersTests: QuickSpec {
 
                 context("when matching a Next that has effects but no model") {
                     beforeEach {
-                        let next = Next<String, String>.dispatchEffects(Set(effects))
+                        let next = Next<String, String>.dispatchEffects(effects)
                         result = sut(next)
                     }
 
@@ -112,7 +112,7 @@ class XCTestNextMatchersTests: QuickSpec {
 
                 context("when matching a Next that has model and effects") {
                     beforeEach {
-                        let next = Next<String, String>.next(model, effects: Set(effects))
+                        let next = Next<String, String>.next(model, effects: effects)
                         result = sut(next)
                     }
 
@@ -251,7 +251,7 @@ class XCTestNextMatchersTests: QuickSpec {
                 context("when matching a Next that has effects") {
                     let actual = ["grapefruit"]
                     beforeEach {
-                        let next = Next<String, String>.dispatchEffects(Set(actual))
+                        let next = Next<String, String>.dispatchEffects(actual)
                         result = sut(next)
                     }
 
@@ -272,7 +272,7 @@ class XCTestNextMatchersTests: QuickSpec {
                 context("when the effects are the same") {
                     context("when the effects are in order") {
                         beforeEach {
-                            let next = Next<String, Int>.dispatchEffects(Set(expected))
+                            let next = Next<String, Int>.dispatchEffects(expected)
                             result = sut(next)
                         }
 
@@ -285,7 +285,7 @@ class XCTestNextMatchersTests: QuickSpec {
                         beforeEach {
                             var actual = expected
                             actual.append(actual.removeFirst())
-                            let next = Next<String, Int>.dispatchEffects(Set(actual))
+                            let next = Next<String, Int>.dispatchEffects(actual)
                             result = sut(next)
                         }
 
@@ -298,7 +298,7 @@ class XCTestNextMatchersTests: QuickSpec {
                 context("when the Next contains the expected effects and a few more") {
                     let actual = [1, 2, 3, 4, 5, 0]
                     beforeEach {
-                        let next = Next<String, Int>.dispatchEffects(Set(actual))
+                        let next = Next<String, Int>.dispatchEffects(actual)
                         result = sut(next)
                     }
 
@@ -311,7 +311,7 @@ class XCTestNextMatchersTests: QuickSpec {
                     let actual = [1]
                     let expected = [3]
                     beforeEach {
-                        let next = Next<String, Int>.dispatchEffects(Set(actual))
+                        let next = Next<String, Int>.dispatchEffects(actual)
                         sut = hasEffects(Set(expected))
                         result = sut(next)
                     }


### PR DESCRIPTION
Effects are now specified as arrays, and have no conformance requirements. This modestly reduces boilerplate and avoids the need to synthesize those conformances for most practical Effects.