### PR TITLE
Fix improper use of NSRecursiveLock in generic disposables

### DIFF
--- a/MobiusCore/Source/Disposables/AnonymousDisposable.swift
+++ b/MobiusCore/Source/Disposables/AnonymousDisposable.swift
@@ -23,7 +23,7 @@ import Foundation
 public class AnonymousDisposable: MobiusCore.Disposable {
     /// The closure which disposes of the object.
     private var disposer: (() -> Void)?
-    private let lock = NSRecursiveLock()
+    private let lock = DispatchQueue(label: "Mobius.AnonymousDisposable")
 
     /// Initialize the `DisposableClosure` with the given code to run on disposing the resources.
     ///
@@ -35,11 +35,13 @@ public class AnonymousDisposable: MobiusCore.Disposable {
     }
 
     public func dispose() {
-        lock.synchronized {
-            guard let disposer = disposer else { return }
+        var disposer: (() -> Void)?
 
-            disposer()
+        lock.sync {
+            disposer = self.disposer
             self.disposer = nil
         }
+
+        disposer?()
     }
 }

--- a/MobiusCore/Source/Disposables/CompositeDisposable.swift
+++ b/MobiusCore/Source/Disposables/CompositeDisposable.swift
@@ -22,8 +22,8 @@ import Foundation
 /// A CompositeDisposable holds onto the provided disposables and disposes
 /// all of them once its dispose() method is called.
 public class CompositeDisposable {
-    private let disposables: [Disposable]
-    let lock = NSRecursiveLock()
+    private var disposables: [Disposable]
+    private let lock = DispatchQueue(label: "Mobius.CompositeDisposable")
 
     /// Initialises a CompositeDisposable
     ///
@@ -36,10 +36,15 @@ public class CompositeDisposable {
 extension CompositeDisposable: MobiusCore.Disposable {
     /// Dispose function disposes all of the internal disposables
     public func dispose() {
-        lock.synchronized {
-            for disposable in disposables {
-                disposable.dispose()
-            }
+        var disposables = [Disposable]()
+
+        lock.sync {
+            disposables = self.disposables
+            self.disposables.removeAll()
+        }
+
+        for disposable in disposables {
+            disposable.dispose()
         }
     }
 }


### PR DESCRIPTION
These two classes used `NSRecursiveLock`, but the implementations were not reentrant, so the recursive property of the lock is unused.

The new implementations only lock over the actual critical section – reading and clearing state – and don’t call out while holding a lock, so lock recursion cannot happen. Reentering on another thread or the same thread is always safe and dispose functions will never be called more than once.

I also used `DispatchQueue` for locking instead of `NSLock`. This is part of a larger effort to get rid of the `.synchronized` helper which is inappropriate to export from Mobius.