### PR TITLE
Remove public extension on NSRecursiveLock

### DIFF
--- a/Mobius.xcodeproj/project.pbxproj
+++ b/Mobius.xcodeproj/project.pbxproj
@@ -8,6 +8,8 @@
 
 /* Begin PBXBuildFile section */
 		02BED1BB21DD20D20093FB47 /* ConnectableContramap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B9CE80421197FE000DB79A7 /* ConnectableContramap.swift */; };
+		2D3A696D2355AED90053C95E /* Lock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BB287CA209995410043B530 /* Lock.swift */; };
+		2D3A696E2355AED90053C95E /* Lock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BB287CA209995410043B530 /* Lock.swift */; };
 		2D54D0F021C11362002AAC19 /* AtomicBool.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D54D0EF21C11362002AAC19 /* AtomicBool.swift */; };
 		2D54D0F121C1167C002AAC19 /* AtomicBool.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D54D0EF21C11362002AAC19 /* AtomicBool.swift */; };
 		2DDF54C0229BDB4800D05861 /* CompositeEventSourceBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DDF54BF229BDB4700D05861 /* CompositeEventSourceBuilder.swift */; };
@@ -31,7 +33,7 @@
 		2DF4C30B20DBDD5C00A4B6DE /* EventProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BB287C6209995410043B530 /* EventProcessor.swift */; };
 		2DF4C30C20DBDD5C00A4B6DE /* MobiusController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BB287C8209995410043B530 /* MobiusController.swift */; };
 		2DF4C30D20DBDD5C00A4B6DE /* MobiusLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BB287C9209995410043B530 /* MobiusLogger.swift */; };
-		2DF4C30E20DBDD5C00A4B6DE /* Locking.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BB287CA209995410043B530 /* Locking.swift */; };
+		2DF4C30E20DBDD5C00A4B6DE /* Lock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BB287CA209995410043B530 /* Lock.swift */; };
 		2DF4C42420DBDF1B00A4B6DE /* ConsoleLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BB287E8209995420043B530 /* ConsoleLogger.swift */; };
 		2DF4C53A20DBE04B00A4B6DE /* UpdateSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BB288A420999B750043B530 /* UpdateSpec.swift */; };
 		3EE5AF052110BF2E00CF8CA8 /* ConnectableClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BCF5F0020F3620700721C0D /* ConnectableClass.swift */; };
@@ -102,7 +104,7 @@
 		5BB28824209995810043B530 /* EventProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BB287C6209995410043B530 /* EventProcessor.swift */; };
 		5BB28826209995810043B530 /* MobiusController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BB287C8209995410043B530 /* MobiusController.swift */; };
 		5BB28827209995810043B530 /* MobiusLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BB287C9209995410043B530 /* MobiusLogger.swift */; };
-		5BB28828209995810043B530 /* Locking.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BB287CA209995410043B530 /* Locking.swift */; };
+		5BB28828209995810043B530 /* Lock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BB287CA209995410043B530 /* Lock.swift */; };
 		5BB28829209995860043B530 /* Disposable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BB287BD209995410043B530 /* Disposable.swift */; };
 		5BB2882A209995860043B530 /* CompositeDisposable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BB287BE209995410043B530 /* CompositeDisposable.swift */; };
 		5BB2882B209995860043B530 /* AnonymousDisposable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BB287BF209995410043B530 /* AnonymousDisposable.swift */; };
@@ -317,7 +319,7 @@
 		5BB287C6209995410043B530 /* EventProcessor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EventProcessor.swift; sourceTree = "<group>"; };
 		5BB287C8209995410043B530 /* MobiusController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MobiusController.swift; sourceTree = "<group>"; };
 		5BB287C9209995410043B530 /* MobiusLogger.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MobiusLogger.swift; sourceTree = "<group>"; };
-		5BB287CA209995410043B530 /* Locking.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Locking.swift; sourceTree = "<group>"; };
+		5BB287CA209995410043B530 /* Lock.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Lock.swift; sourceTree = "<group>"; };
 		5BB287E6209995420043B530 /* MobiusExtras-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "MobiusExtras-Info.plist"; sourceTree = "<group>"; };
 		5BB287E8209995420043B530 /* ConsoleLogger.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConsoleLogger.swift; sourceTree = "<group>"; };
 		5BB2882D2099964F0043B530 /* MobiusCore-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "MobiusCore-Info.plist"; sourceTree = "<group>"; };
@@ -617,7 +619,7 @@
 				5BB9346320D2A46A00A1FE3A /* EffectRouterBuilder.swift */,
 				5BB287C6209995410043B530 /* EventProcessor.swift */,
 				5BB287BB209995410043B530 /* First.swift */,
-				5BB287CA209995410043B530 /* Locking.swift */,
+				5BB287CA209995410043B530 /* Lock.swift */,
 				5BB287C3209995410043B530 /* Mobius.swift */,
 				5BB287C8209995410043B530 /* MobiusController.swift */,
 				5BB287B9209995410043B530 /* MobiusHooks.swift */,
@@ -1201,7 +1203,7 @@
 				2DF4C30420DBDD5C00A4B6DE /* Disposable.swift in Sources */,
 				2DF4C30920DBDD5C00A4B6DE /* Mobius.swift in Sources */,
 				2DF4C30320DBDD5800A4B6DE /* First.swift in Sources */,
-				2DF4C30E20DBDD5C00A4B6DE /* Locking.swift in Sources */,
+				2DF4C30E20DBDD5C00A4B6DE /* Lock.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1214,6 +1216,7 @@
 				2DF4C42420DBDF1B00A4B6DE /* ConsoleLogger.swift in Sources */,
 				02BED1BB21DD20D20093FB47 /* ConnectableContramap.swift in Sources */,
 				5B1F104E21105CB10067193C /* EventSource+Extensions.swift in Sources */,
+				2D3A696D2355AED90053C95E /* Lock.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1242,7 +1245,7 @@
 				5BB288192099957D0043B530 /* Consumer.swift in Sources */,
 				5BB28826209995810043B530 /* MobiusController.swift in Sources */,
 				5BB2882A209995860043B530 /* CompositeDisposable.swift in Sources */,
-				5BB28828209995810043B530 /* Locking.swift in Sources */,
+				5BB28828209995810043B530 /* Lock.swift in Sources */,
 				5BB2881D2099957D0043B530 /* First.swift in Sources */,
 				5BB28829209995860043B530 /* Disposable.swift in Sources */,
 				5BB288172099957D0043B530 /* Next.swift in Sources */,
@@ -1300,6 +1303,7 @@
 				5B1F104D21105CAD0067193C /* EventSource+Extensions.swift in Sources */,
 				DDA64A6720A0AD2D00150355 /* ConsoleLogger.swift in Sources */,
 				5BCF5F0120F3620700721C0D /* ConnectableClass.swift in Sources */,
+				2D3A696E2355AED90053C95E /* Lock.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/MobiusCore/Source/ConnectableConvenienceClasses/ClosureConnectable.swift
+++ b/MobiusCore/Source/ConnectableConvenienceClasses/ClosureConnectable.swift
@@ -26,7 +26,7 @@ class ClosureConnectable<Input, Output>: Connectable {
     private var queue: DispatchQueue?
     private var output: Consumer<OutputType>?
     private let closure: (Input) -> Output?
-    private let lock = NSRecursiveLock()
+    private let lock = Lock()
 
     // If the closure produces output, it will be passed to the consumer. If it doesnt, it wont (see `connect`).
     init(_ closure: @escaping (Input) -> Output?, queue: DispatchQueue? = nil) {

--- a/MobiusCore/Source/EffectRouterBuilder.swift
+++ b/MobiusCore/Source/EffectRouterBuilder.swift
@@ -129,7 +129,7 @@ private func createConnections<Input, Output>(_ connectables: [PredicatedConnect
 }
 
 private func mergedConnections<Input>(_ connections: [PredicatedConnection<Input>]) -> Connection<Input> {
-    let lock = NSRecursiveLock()
+    let lock = Lock()
 
     let connection = Connection<Input>(
         acceptClosure: { (input: Input) in

--- a/MobiusCore/Source/Lock.swift
+++ b/MobiusCore/Source/Lock.swift
@@ -19,12 +19,13 @@
 
 import Foundation
 
-public extension NSRecursiveLock {
-    @discardableResult
+struct Lock {
+    private let lock = NSRecursiveLock()
+
     func synchronized<R>(closure: () -> R) -> R {
-        lock()
+        lock.lock()
         defer {
-            self.unlock()
+            lock.unlock()
         }
 
         return closure()

--- a/MobiusCore/Source/MobiusController.swift
+++ b/MobiusCore/Source/MobiusController.swift
@@ -25,7 +25,7 @@ import Foundation
 /// one left off.
 public class MobiusController<Types: LoopTypes> {
     private let loopFactory: (Types.Model) -> MobiusLoop<Types>
-    private let lock = NSRecursiveLock()
+    private let lock = Lock()
 
     private var viewConnectable: ConnectClosure<Types.Model, Types.Event>?
     private var viewConnection: Connection<Types.Model>?

--- a/MobiusExtras/Source/ConnectableClass.swift
+++ b/MobiusExtras/Source/ConnectableClass.swift
@@ -36,7 +36,7 @@ import MobiusCore
 open class ConnectableClass<InputType, OutputType>: Connectable {
     private var consumer: Consumer<OutputType>?
 
-    private let lock = NSRecursiveLock()
+    private let lock = Lock()
     var handleError = { (message: String) -> Void in
         fatalError(message)
     }


### PR DESCRIPTION
Exporting this was a wart required by ObjC semantics, and a wrapping struct is a zero-cost abstraction.

@jeppes 