### PR TITLE
Make NoEffect typealias public

### DIFF
--- a/MobiusCore/Source/NoEffect.swift
+++ b/MobiusCore/Source/NoEffect.swift
@@ -21,4 +21,4 @@ import Foundation
 
 /// The `NoEffect` type can be used to signal that some data passing through a Mobius loop cannot have any effects.
 @available(*, deprecated, message: "use Never instead")
-typealias NoEffect = Never
+public typealias NoEffect = Never


### PR DESCRIPTION
In https://github.com/spotify/Mobius.swift/pull/41 I replaced the custom `enum NoEffect` with a `typedef` and marked it deprecated, and also accidentally made it `internal`. Obviously it should be either public or deleted, nothing is using it internally