### PR TITLE
Replace getMostRecentModel with non-optional latestModel

### DIFF
--- a/MobiusCore/Source/BackwardsCompatibility.swift
+++ b/MobiusCore/Source/BackwardsCompatibility.swift
@@ -36,3 +36,10 @@ public extension Next where Effect: Hashable {
         return .dispatchEffects(Array(effects))
     }
 }
+
+public extension MobiusLoop {
+    @available(*, deprecated, message: "use latestModel of effects instead")
+    func getMostRecentModel() -> Types.Model? {
+        return latestModel
+    }
+}

--- a/MobiusCore/Source/EventProcessor.swift
+++ b/MobiusCore/Source/EventProcessor.swift
@@ -87,4 +87,11 @@ class EventProcessor<Types: LoopTypes>: Disposable, CustomDebugStringConvertible
     func readCurrentModel() -> Types.Model? {
         return queue.sync { currentModel }
     }
+
+    var latestModel: Types.Model {
+        guard let model = readCurrentModel() else {
+            preconditionFailure("latestModel may only be invoked after start()")
+        }
+        return model
+    }
 }

--- a/MobiusCore/Source/MobiusController.swift
+++ b/MobiusCore/Source/MobiusController.swift
@@ -112,17 +112,17 @@ public class MobiusController<Types: LoopTypes> {
     /// - Attention: fails via `MobiusHooks.onError` if the loop isn't running
     public func stop() {
         lock.synchronized {
-            guard loop != nil else {
+            guard let loop = loop else {
                 MobiusHooks.onError("cannot stop a controller that isn't running")
                 return
             }
 
-            modelToStartFrom = loop!.getMostRecentModel() ?? modelToStartFrom
+            modelToStartFrom = loop.latestModel
 
-            loop!.dispose()
+            loop.dispose()
             viewConnection?.dispose()
 
-            loop = nil
+            self.loop = nil
         }
     }
 
@@ -147,7 +147,7 @@ public class MobiusController<Types: LoopTypes> {
     /// - Returns: a model with the state of the controller
     public func getModel() -> Types.Model {
         return lock.synchronized {
-            loop?.getMostRecentModel() ?? modelToStartFrom
+            loop?.latestModel ?? modelToStartFrom
         }
     }
 }

--- a/MobiusCore/Source/MobiusLoop.swift
+++ b/MobiusCore/Source/MobiusLoop.swift
@@ -72,8 +72,8 @@ public final class MobiusLoop<Types: LoopTypes>: Disposable, CustomDebugStringCo
         dispose()
     }
 
-    public func getMostRecentModel() -> Types.Model? {
-        return eventProcessor.readCurrentModel()
+    public var latestModel: Types.Model {
+        return eventProcessor.latestModel
     }
 
     public func dispatchEvent(_ event: Types.Event) {

--- a/MobiusCore/Test/MobiusLoopTests.swift
+++ b/MobiusCore/Test/MobiusLoopTests.swift
@@ -122,12 +122,12 @@ class MobiusLoopTests: QuickSpec {
                 it("should track the most recent model") {
                     loop = builder.start(from: "the first model")
 
-                    expect(loop.getMostRecentModel()).to(equal("the first model"))
+                    expect(loop.latestModel).to(equal("the first model"))
 
                     loop.dispatchEvent("two")
 
                     queue.waitForOutstandingTasks()
-                    expect(loop.getMostRecentModel()).to(equal("two"))
+                    expect(loop.latestModel).to(equal("two"))
                 }
             }
 


### PR DESCRIPTION
The most recent model of a loop can only be nil before `eventProcessor.start` is called, and a loop is always inited with an event processor that has already been started. Exposing it as an optional is just confusing (and also, it’s semantically a property).

@jeppes 