### PR TITLE
[request for comment] Remove LoopTypes protocol

### DIFF
--- a/MobiusCore/Source/BackwardsCompatibility.swift
+++ b/MobiusCore/Source/BackwardsCompatibility.swift
@@ -39,7 +39,7 @@ public extension Next where Effect: Hashable {
 
 public extension MobiusLoop {
     @available(*, deprecated, message: "use latestModel of effects instead")
-    func getMostRecentModel() -> Types.Model? {
+    func getMostRecentModel() -> Model? {
         return latestModel
     }
 }

--- a/MobiusCore/Source/EventProcessor.swift
+++ b/MobiusCore/Source/EventProcessor.swift
@@ -21,14 +21,14 @@ import Foundation
 
 /// Internal class that manages the atomic state updates and notifications of model changes when processing of events via
 /// the Update function.
-class EventProcessor<Types: LoopTypes>: Disposable, CustomDebugStringConvertible {
-    let update: Update<Types>
-    let publisher: ConnectablePublisher<Next<Types.Model, Types.Effect>>
+class EventProcessor<Model, Event, Effect>: Disposable, CustomDebugStringConvertible {
+    let update: Update<Model, Event, Effect>
+    let publisher: ConnectablePublisher<Next<Model, Effect>>
 
     private let queue: DispatchQueue
 
-    private var currentModel: Types.Model?
-    private var queuedEvents = [Types.Event]()
+    private var currentModel: Model?
+    private var queuedEvents = [Event]()
 
     public var debugDescription: String {
         let modelDescription: String
@@ -41,8 +41,8 @@ class EventProcessor<Types: LoopTypes>: Disposable, CustomDebugStringConvertible
     }
 
     init(
-        update: @escaping Update<Types>,
-        publisher: ConnectablePublisher<Next<Types.Model, Types.Effect>>,
+        update: @escaping Update<Model, Event, Effect>,
+        publisher: ConnectablePublisher<Next<Model, Effect>>,
         queue: DispatchQueue
     ) {
         self.update = update
@@ -50,7 +50,7 @@ class EventProcessor<Types: LoopTypes>: Disposable, CustomDebugStringConvertible
         self.queue = queue
     }
 
-    func start(from first: First<Types.Model, Types.Effect>) {
+    func start(from first: First<Model, Effect>) {
         queue.sync(flags: .barrier) {
             currentModel = first.model
 
@@ -64,7 +64,7 @@ class EventProcessor<Types: LoopTypes>: Disposable, CustomDebugStringConvertible
         }
     }
 
-    func accept(_ event: Types.Event) {
+    func accept(_ event: Event) {
         queue.async(flags: .barrier) {
             if let current = self.currentModel {
                 let next = self.update(current, event)
@@ -84,11 +84,11 @@ class EventProcessor<Types: LoopTypes>: Disposable, CustomDebugStringConvertible
         publisher.dispose()
     }
 
-    func readCurrentModel() -> Types.Model? {
+    func readCurrentModel() -> Model? {
         return queue.sync { currentModel }
     }
 
-    var latestModel: Types.Model {
+    var latestModel: Model {
         guard let model = readCurrentModel() else {
             preconditionFailure("latestModel may only be invoked after start()")
         }

--- a/MobiusCore/Source/Mobius.swift
+++ b/MobiusCore/Source/Mobius.swift
@@ -78,8 +78,8 @@ public extension Mobius {
             self.logger = logger
         }
 
-        public func withEventSource<ES: EventSource>(_ eventSource: ES) -> Builder<Model, Event, Effect> where ES.Event == Event {
-            return Builder<Model, Event, Effect>(
+        public func withEventSource<ES: EventSource>(_ eventSource: ES) -> Builder where ES.Event == Event {
+            return Builder(
                 update: update,
                 effectHandler: effectHandler,
                 initiator: initiator,
@@ -90,8 +90,8 @@ public extension Mobius {
             )
         }
 
-        public func withInitiator(_ initiator: @escaping Initiator<Model, Effect>) -> Builder<Model, Event, Effect> {
-            return Builder<Model, Event, Effect>(
+        public func withInitiator(_ initiator: @escaping Initiator<Model, Effect>) -> Builder {
+            return Builder(
                 update: update,
                 effectHandler: effectHandler,
                 initiator: initiator,
@@ -102,8 +102,8 @@ public extension Mobius {
             )
         }
 
-        public func withEventQueue(_ eventQueue: DispatchQueue) -> Builder<Model, Event, Effect> {
-            return Builder<Model, Event, Effect>(
+        public func withEventQueue(_ eventQueue: DispatchQueue) -> Builder {
+            return Builder(
                 update: update,
                 effectHandler: effectHandler,
                 initiator: initiator,
@@ -114,8 +114,8 @@ public extension Mobius {
             )
         }
 
-        public func withEffectQueue(_ effectQueue: DispatchQueue) -> Builder<Model, Event, Effect> {
-            return Builder<Model, Event, Effect>(
+        public func withEffectQueue(_ effectQueue: DispatchQueue) -> Builder {
+            return Builder(
                 update: update,
                 effectHandler: effectHandler,
                 initiator: initiator,
@@ -126,8 +126,8 @@ public extension Mobius {
             )
         }
 
-        public func withLogger<L: MobiusLogger>(_ logger: L) -> Builder<Model, Event, Effect> where L.Model == Model, L.Event == Event, L.Effect == Effect {
-            return Builder<Model, Event, Effect>(
+        public func withLogger<L: MobiusLogger>(_ logger: L) -> Builder where L.Model == Model, L.Event == Event, L.Effect == Effect {
+            return Builder(
                 update: update,
                 effectHandler: effectHandler,
                 initiator: initiator,

--- a/MobiusCore/Source/MobiusLogger.swift
+++ b/MobiusCore/Source/MobiusLogger.swift
@@ -20,7 +20,11 @@
 import Foundation
 
 /// Protocol for logging init and update calls.
-public protocol MobiusLogger: LoopTypes {
+public protocol MobiusLogger {
+    associatedtype Model
+    associatedtype Event
+    associatedtype Effect
+
     ///  Called right before the `Initiator` function is called.
     ///
     ///  This method mustn't block, as it'll hinder the loop from running. It will be called on the
@@ -61,10 +65,7 @@ public protocol MobiusLogger: LoopTypes {
     func didUpdate(model: Model, event: Event, next: Next<Model, Effect>)
 }
 
-class NoopLogger<Types: LoopTypes>: MobiusLogger {
-    typealias Model = Types.Model
-    typealias Event = Types.Event
-    typealias Effect = Types.Effect
+class NoopLogger<Model, Event, Effect>: MobiusLogger {
 
     func willInitiate(model: Model) {
         // empty
@@ -84,11 +85,7 @@ class NoopLogger<Types: LoopTypes>: MobiusLogger {
 }
 
 /// Type-erased `MobiusLogger`.
-public class AnyMobiusLogger<Types: LoopTypes>: MobiusLogger {
-    public typealias Model = Types.Model
-    public typealias Event = Types.Event
-    public typealias Effect = Types.Effect
-
+public class AnyMobiusLogger<Model, Event, Effect>: MobiusLogger {
     private let willInitiateClosure: (Model) -> Void
     private let didInitiateClosure: (Model, First<Model, Effect>) -> Void
     private let willUpdateClosure: (Model, Event) -> Void

--- a/MobiusCore/Source/MobiusLoop.swift
+++ b/MobiusCore/Source/MobiusLoop.swift
@@ -96,16 +96,16 @@ public final class MobiusLoop<Model, Event, Effect>: Disposable, CustomDebugStri
         eventQueue: DispatchQueue,
         effectQueue: DispatchQueue,
         logger: AnyMobiusLogger<Model, Event, Effect>
-    ) -> MobiusLoop<Model, Event, Effect> where C.InputType == Effect, C.OutputType == Event {
-        let loggingInitiator = LoggingInitiator<Model, Effect>(initiator, logger)
-        let loggingUpdate = LoggingUpdate<Model, Event, Effect>(update, logger)
+    ) -> MobiusLoop where C.InputType == Effect, C.OutputType == Event {
+        let loggingInitiator = LoggingInitiator(initiator, logger)
+        let loggingUpdate = LoggingUpdate(update, logger)
 
         // create somewhere for the event processor to push nexts to; later, we'll observe these nexts and
         // dispatch models and effects to the right places
         let nextPublisher = ConnectablePublisher<Next<Model, Effect>>()
 
         // event processor: process events, publish Next:s, retain current model
-        let eventProcessor = EventProcessor<Model, Event, Effect>(update: loggingUpdate.update, publisher: nextPublisher, queue: eventQueue)
+        let eventProcessor = EventProcessor(update: loggingUpdate.update, publisher: nextPublisher, queue: eventQueue)
 
         // effect handler: handle effects, push events to the event processor
         let effectHandlerConnection = effectHandler.connect(eventProcessor.accept)
@@ -116,7 +116,7 @@ public final class MobiusLoop<Model, Event, Effect>: Disposable, CustomDebugStri
         let modelPublisher = ConnectablePublisher<Model>()
 
         // ensure model updates get published and effects dispatched to the effect handler
-        let nextConsumer: Consumer<Next<Model, Effect>> = { (next: Next<Model, Effect>) in
+        let nextConsumer: Consumer<Next<Model, Effect>> = { next in
             if let model = next.model {
                 modelPublisher.post(model)
             }

--- a/MobiusCore/Test/AnyMobiusLoggerTests.swift
+++ b/MobiusCore/Test/AnyMobiusLoggerTests.swift
@@ -25,7 +25,7 @@ class AnyMobiusLoggerTests: QuickSpec {
     override func spec() {
         describe("AnyMobiusLogger") {
             var delegate: TestMobiusLogger!
-            var logger: AnyMobiusLogger<AllStrings>!
+            var logger: AnyMobiusLogger<String, String, String>!
 
             beforeEach {
                 delegate = TestMobiusLogger()

--- a/MobiusCore/Test/EventProcessorTests.swift
+++ b/MobiusCore/Test/EventProcessorTests.swift
@@ -26,13 +26,7 @@ class EventProcessorTests: QuickSpec {
     // swiftlint:disable function_body_length
     override func spec() {
         describe("EventProcessor") {
-            struct IntTypes: LoopTypes {
-                typealias Model = Int
-                typealias Event = Int
-                typealias Effect = Int
-            }
-
-            var eventProcessor: EventProcessor<IntTypes>!
+            var eventProcessor: EventProcessor<Int, Int, Int>!
             var nextPublisher: ConnectablePublisher<Next<Int, Int>>!
             var consumer: Consumer<Next<Int, Int>>!
             var receivedModels: [Int]!

--- a/MobiusCore/Test/LoggingInitTests.swift
+++ b/MobiusCore/Test/LoggingInitTests.swift
@@ -25,7 +25,7 @@ class LoggingInitiatorTests: QuickSpec {
     override func spec() {
         describe("LoggingInitiator") {
             var logger: TestMobiusLogger!
-            var loggingInitiator: LoggingInitiator<AllStrings>!
+            var loggingInitiator: LoggingInitiator<String, String>!
 
             beforeEach {
                 logger = TestMobiusLogger()

--- a/MobiusCore/Test/LoggingUpdateTests.swift
+++ b/MobiusCore/Test/LoggingUpdateTests.swift
@@ -25,7 +25,7 @@ class LoggingUpdateTests: QuickSpec {
     override func spec() {
         describe("LoggingUpdate") {
             var logger: TestMobiusLogger!
-            var loggingUpdate: LoggingUpdate<AllStrings>!
+            var loggingUpdate: LoggingUpdate<String, String, String>!
 
             beforeEach {
                 logger = TestMobiusLogger()

--- a/MobiusCore/Test/MobiusControllerTests.swift
+++ b/MobiusCore/Test/MobiusControllerTests.swift
@@ -40,7 +40,7 @@ class MobiusControllerTests: QuickSpec {
                     .next("\(model)-\(event)")
                 }
 
-                var builder: Mobius.Builder<String, String, String> = Mobius.loop(
+                var builder = Mobius.loop(
                     update: updateFunction,
                     effectHandler: SimpleTestConnectable()
                 )
@@ -124,7 +124,7 @@ class MobiusControllerTests: QuickSpec {
                         modelObserver = MockConnectable()
                         effectObserver = MockConnectable()
                         let builder: Mobius.Builder<String, String, String> = Mobius.loop(update: { _, _ in .noChange }, effectHandler: effectObserver)
-                        controller = MobiusController<String, String, String>(builder: builder, defaultModel: "")
+                        controller = MobiusController(builder: builder, defaultModel: "")
                         controller.connectView(modelObserver)
                         controller.start()
                     }

--- a/MobiusCore/Test/MobiusControllerTests.swift
+++ b/MobiusCore/Test/MobiusControllerTests.swift
@@ -29,7 +29,7 @@ class MobiusControllerTests: QuickSpec {
     // swiftlint:disable function_body_length
     override func spec() {
         describe("MobiusController") {
-            var controller: MobiusController<AllStrings>!
+            var controller: MobiusController<String, String, String>!
             var view: RecordingTestConnectable!
             var errorThrown: Bool!
 
@@ -40,7 +40,7 @@ class MobiusControllerTests: QuickSpec {
                     .next("\(model)-\(event)")
                 }
 
-                var builder: Mobius.Builder<AllStrings> = Mobius.loop(
+                var builder: Mobius.Builder<String, String, String> = Mobius.loop(
                     update: updateFunction,
                     effectHandler: SimpleTestConnectable()
                 )
@@ -118,13 +118,13 @@ class MobiusControllerTests: QuickSpec {
                 describe("disposing connections") {
                     var modelObserver: MockConnectable!
                     var effectObserver: MockConnectable!
-                    var controller: MobiusController<AllStrings>!
+                    var controller: MobiusController<String, String, String>!
 
                     beforeEach {
                         modelObserver = MockConnectable()
                         effectObserver = MockConnectable()
-                        let builder: Mobius.Builder<AllStrings> = Mobius.loop(update: { _, _ in .noChange }, effectHandler: effectObserver)
-                        controller = MobiusController<AllStrings>(builder: builder, defaultModel: "")
+                        let builder: Mobius.Builder<String, String, String> = Mobius.loop(update: { _, _ in .noChange }, effectHandler: effectObserver)
+                        controller = MobiusController<String, String, String>(builder: builder, defaultModel: "")
                         controller.connectView(modelObserver)
                         controller.start()
                     }

--- a/MobiusCore/Test/MobiusIntegrationTests.swift
+++ b/MobiusCore/Test/MobiusIntegrationTests.swift
@@ -27,12 +27,8 @@ class MobiusIntegrationTests: QuickSpec {
     // swiftlint:disable function_body_length
     override func spec() {
         describe("Mobius integration tests") {
-            struct TestLogic: LoopTypes {
-                typealias Model = String
-                typealias Event = String
-                typealias Effect = String
-
-                func initiate(model: Model) -> First<Model, Effect> {
+            struct TestLogic {
+                func initiate(model: String) -> First<String, String> {
                     switch model {
                     case "start":
                         return First(model: "init", effects: ["trigger loading"])
@@ -41,7 +37,7 @@ class MobiusIntegrationTests: QuickSpec {
                     }
                 }
 
-                func update(model: Model, event: Event) -> Next<Model, Effect> {
+                func update(model: String, event: String) -> Next<String, String> {
                     switch event {
                     case "button pushed":
                         return Next.next("pushed")
@@ -58,8 +54,8 @@ class MobiusIntegrationTests: QuickSpec {
             }
 
             var receivedModels: [String]!
-            var builder: Mobius.Builder<TestLogic>!
-            var loop: MobiusLoop<TestLogic>!
+            var builder: Mobius.Builder<String, String, String>!
+            var loop: MobiusLoop<String, String, String>!
             var queue: DispatchQueue!
 
             var eventSourceEventConsumer: Consumer<String>!

--- a/MobiusCore/Test/MobiusLoopTests.swift
+++ b/MobiusCore/Test/MobiusLoopTests.swift
@@ -26,8 +26,8 @@ class MobiusLoopTests: QuickSpec {
     // swiftlint:disable function_body_length
     override func spec() {
         describe("MobiusLoop") {
-            var builder: Mobius.Builder<AllStrings>!
-            var loop: MobiusLoop<AllStrings>!
+            var builder: Mobius.Builder<String, String, String>!
+            var loop: MobiusLoop<String, String, String>!
             var receivedModels: [String]!
             var effectHandler: SimpleTestConnectable!
             var queue: DispatchQueue!
@@ -38,7 +38,7 @@ class MobiusLoopTests: QuickSpec {
 
                 modelObserver = { receivedModels.append($0) }
 
-                let update: Update<AllStrings> = { _, event in Next.next(event) }
+                let update: Update<String, String, String> = { _, event in Next.next(event) }
 
                 effectHandler = SimpleTestConnectable()
 
@@ -104,7 +104,7 @@ class MobiusLoopTests: QuickSpec {
                 }
 
                 it("should queue up events dispatched before start to support racy initialisations") {
-                    let update: Update<AllStrings> = { model, event in Next.next(model + "-" + event) }
+                    let update: Update<String, String, String> = { model, event in Next.next(model + "-" + event) }
 
                     loop = Mobius.loop(update: update, effectHandler: EagerEffectHandler())
                         .withEventQueue(queue)
@@ -160,12 +160,12 @@ class MobiusLoopTests: QuickSpec {
             }
 
             describe("dispose dependencies") {
-                var eventProcessor: TestEventProcessor<AllStrings>!
+                var eventProcessor: TestEventProcessor<String, String, String>!
                 var modelPublisher: ConnectablePublisher<String>!
                 var disposable: ConnectablePublisher<String>!
 
                 beforeEach {
-                    eventProcessor = TestEventProcessor<AllStrings>(
+                    eventProcessor = TestEventProcessor<String, String, String>(
                         update: { _, _ in .noChange },
                         publisher: ConnectablePublisher<Next<String, String>>(),
                         queue: DispatchQueue(label: "dispose test queue")
@@ -173,7 +173,7 @@ class MobiusLoopTests: QuickSpec {
                     modelPublisher = ConnectablePublisher<String>()
                     disposable = ConnectablePublisher<String>()
 
-                    loop = MobiusLoop<AllStrings>(
+                    loop = MobiusLoop<String, String, String>(
                         eventProcessor: eventProcessor,
                         modelPublisher: modelPublisher,
                         disposable: disposable
@@ -245,20 +245,20 @@ class MobiusLoopTests: QuickSpec {
                 let eventProcessorDebugDescription = "blah"
                 beforeEach {
                     let publisher = ConnectablePublisher<String>()
-                    let eventProcessor = TestEventProcessor<AllStrings>(
+                    let eventProcessor = TestEventProcessor<String, String, String>(
                         update: { _, _ in .noChange },
                         publisher: ConnectablePublisher<Next<String, String>>(),
                         queue: DispatchQueue(label: "dispose test queue")
                     )
                     eventProcessor.desiredDebugDescription = eventProcessorDebugDescription
 
-                    loop = MobiusLoop<AllStrings>(eventProcessor: eventProcessor, modelPublisher: publisher, disposable: publisher)
+                    loop = MobiusLoop<String, String, String>(eventProcessor: eventProcessor, modelPublisher: publisher, disposable: publisher)
                 }
 
                 context("when not disposed") {
                     it("should describe the loop and the event processor") {
                         let description = String(describing: loop)
-                        expect(description).to(equal("Optional(MobiusLoop<AllStrings> \(eventProcessorDebugDescription))"))
+                        expect(description).to(equal("Optional(MobiusLoop<String, String, String> \(eventProcessorDebugDescription))"))
                     }
                 }
 
@@ -287,7 +287,7 @@ private class EagerEffectHandler: Connectable {
     }
 }
 
-private class TestEventProcessor<T: LoopTypes>: EventProcessor<T> {
+private class TestEventProcessor<Model, Event, Effect>: EventProcessor<Model, Event, Effect> {
     var disposed = false
     override func dispose() {
         disposed = true

--- a/MobiusCore/Test/MobiusLoopTests.swift
+++ b/MobiusCore/Test/MobiusLoopTests.swift
@@ -104,9 +104,7 @@ class MobiusLoopTests: QuickSpec {
                 }
 
                 it("should queue up events dispatched before start to support racy initialisations") {
-                    let update: Update<String, String, String> = { model, event in Next.next(model + "-" + event) }
-
-                    loop = Mobius.loop(update: update, effectHandler: EagerEffectHandler())
+                    loop = Mobius.loop(update: { model, event in .next(model + "-" + event) }, effectHandler: EagerEffectHandler())
                         .withEventQueue(queue)
                         .start(from: "the beginning")
 
@@ -165,15 +163,15 @@ class MobiusLoopTests: QuickSpec {
                 var disposable: ConnectablePublisher<String>!
 
                 beforeEach {
-                    eventProcessor = TestEventProcessor<String, String, String>(
+                    eventProcessor = TestEventProcessor(
                         update: { _, _ in .noChange },
-                        publisher: ConnectablePublisher<Next<String, String>>(),
+                        publisher: ConnectablePublisher(),
                         queue: DispatchQueue(label: "dispose test queue")
                     )
                     modelPublisher = ConnectablePublisher<String>()
                     disposable = ConnectablePublisher<String>()
 
-                    loop = MobiusLoop<String, String, String>(
+                    loop = MobiusLoop(
                         eventProcessor: eventProcessor,
                         modelPublisher: modelPublisher,
                         disposable: disposable
@@ -252,7 +250,7 @@ class MobiusLoopTests: QuickSpec {
                     )
                     eventProcessor.desiredDebugDescription = eventProcessorDebugDescription
 
-                    loop = MobiusLoop<String, String, String>(eventProcessor: eventProcessor, modelPublisher: publisher, disposable: publisher)
+                    loop = MobiusLoop(eventProcessor: eventProcessor, modelPublisher: publisher, disposable: publisher)
                 }
 
                 context("when not disposed") {

--- a/MobiusCore/Test/TestingUtil.swift
+++ b/MobiusCore/Test/TestingUtil.swift
@@ -87,17 +87,7 @@ extension DispatchQueue {
     }
 }
 
-class AllStrings: LoopTypes {
-    typealias Model = String
-    typealias Event = String
-    typealias Effect = String
-}
-
 class TestMobiusLogger: MobiusLogger {
-    typealias Model = String
-    typealias Event = String
-    typealias Effect = String
-
     var logMessages = [String]()
 
     func willInitiate(model: String) {

--- a/MobiusExtras/Source/ConsoleLogger.swift
+++ b/MobiusExtras/Source/ConsoleLogger.swift
@@ -20,11 +20,7 @@
 import Foundation
 import MobiusCore
 
-public class ConsoleLogger<Types: LoopTypes>: MobiusLogger {
-    public typealias Model = Types.Model
-    public typealias Event = Types.Event
-    public typealias Effect = Types.Effect
-
+public class ConsoleLogger<Model, Event, Effect>: MobiusLogger {
     private let prefix: String
 
     public init(tag: String = "Mobius") {

--- a/MobiusNimble/Source/NimbleNextMatchers.swift
+++ b/MobiusNimble/Source/NimbleNextMatchers.swift
@@ -27,7 +27,7 @@ import Nimble
 /// - Parameter predicates: matchers an array of `Predicate`, all of which must match
 /// - Returns: an `Assert` that applies all the matchers
 public func assertThatNext<Model, Event, Effect>(_ predicates: Nimble.Predicate<Next<Model, Effect>>...) -> UpdateSpec<Model, Event, Effect>.Assert {
-    return { (result: UpdateSpec<Model, Event, Effect>.Result) in
+    return { (result: UpdateSpec.Result) in
         predicates.forEach({ predicate in
             expect(result.lastNext).to(predicate)
         })

--- a/MobiusNimble/Source/NimbleNextMatchers.swift
+++ b/MobiusNimble/Source/NimbleNextMatchers.swift
@@ -26,8 +26,8 @@ import Nimble
 ///
 /// - Parameter predicates: matchers an array of `Predicate`, all of which must match
 /// - Returns: an `Assert` that applies all the matchers
-public func assertThatNext<T: LoopTypes>(_ predicates: Nimble.Predicate<Next<T.Model, T.Effect>>...) -> UpdateSpec<T>.Assert {
-    return { (result: UpdateSpec<T>.Result) in
+public func assertThatNext<Model, Event, Effect>(_ predicates: Nimble.Predicate<Next<Model, Effect>>...) -> UpdateSpec<Model, Event, Effect>.Assert {
+    return { (result: UpdateSpec<Model, Event, Effect>.Result) in
         predicates.forEach({ predicate in
             expect(result.lastNext).to(predicate)
         })

--- a/MobiusNimble/Test/NimbleFirstMatchersTests.swift
+++ b/MobiusNimble/Test/NimbleFirstMatchersTests.swift
@@ -51,7 +51,7 @@ class NimbleFirstMatchersTests: QuickSpec {
             // Testing through proxy: UpdateSpec
             context("when asserting through predicates that fail") {
                 beforeEach {
-                    InitSpec<String, String>(testInitiator)
+                    InitSpec(testInitiator)
                         .when("a model")
                         .then(assertThatFirst(haveModel(model + "1"), haveNoEffects()))
                 }

--- a/MobiusNimble/Test/NimbleFirstMatchersTests.swift
+++ b/MobiusNimble/Test/NimbleFirstMatchersTests.swift
@@ -51,7 +51,7 @@ class NimbleFirstMatchersTests: QuickSpec {
             // Testing through proxy: UpdateSpec
             context("when asserting through predicates that fail") {
                 beforeEach {
-                    InitSpec<AllStrings>(testInitiator)
+                    InitSpec<String, String>(testInitiator)
                         .when("a model")
                         .then(assertThatFirst(haveModel(model + "1"), haveNoEffects()))
                 }

--- a/MobiusNimble/Test/NimbleNextMatchersTests.swift
+++ b/MobiusNimble/Test/NimbleNextMatchersTests.swift
@@ -55,7 +55,7 @@ class NimbleNextMatchersTests: QuickSpec {
             // Testing through proxy: UpdateSpec
             context("when asserting through predicates that fail") {
                 beforeEach {
-                    UpdateSpec<AllStrings>(testUpdate)
+                    UpdateSpec<String, String, String>(testUpdate)
                         .given("a model")
                         .when("")
                         .then(assertThatNext(haveNoModel(), haveNoEffects()))

--- a/MobiusNimble/Test/TestUtil.swift
+++ b/MobiusNimble/Test/TestUtil.swift
@@ -52,9 +52,3 @@ extension AssertionRecorder {
         XCTAssert(lastMessage.contains(string), errorDescription, file: file, line: line)
     }
 }
-
-class AllStrings: LoopTypes {
-    typealias Model = String
-    typealias Event = String
-    typealias Effect = String
-}

--- a/MobiusTest/Source/InitSpec.swift
+++ b/MobiusTest/Source/InitSpec.swift
@@ -21,27 +21,27 @@ import MobiusCore
 
 public typealias AssertFirst<Model, Effect> = (First<Model, Effect>) -> Void
 
-public final class InitSpec<Types: LoopTypes> {
-    let initiator: Initiator<Types>
+public final class InitSpec<Model, Effect> {
+    let initiator: Initiator<Model, Effect>
 
-    public init(_ initiator: @escaping Initiator<Types>) {
+    public init(_ initiator: @escaping Initiator<Model, Effect>) {
         self.initiator = initiator
     }
 
-    public func when(_ model: Types.Model) -> Then {
+    public func when(_ model: Model) -> Then {
         return Then(model, initiator: initiator)
     }
 
     public struct Then {
-        let model: Types.Model
-        let initiator: Initiator<Types>
+        let model: Model
+        let initiator: Initiator<Model, Effect>
 
-        public init(_ model: Types.Model, initiator: @escaping Initiator<Types>) {
+        public init(_ model: Model, initiator: @escaping Initiator<Model, Effect>) {
             self.model = model
             self.initiator = initiator
         }
 
-        public func then(_ assertion: AssertFirst<Types.Model, Types.Effect>) {
+        public func then(_ assertion: AssertFirst<Model, Effect>) {
             let first = initiator(model)
             assertion(first)
         }

--- a/MobiusTest/Source/NextMatchers.swift
+++ b/MobiusTest/Source/NextMatchers.swift
@@ -28,11 +28,11 @@ public typealias NextPredicate<Model, Effect> = Predicate<Next<Model, Effect>>
 ///   - predicate: a list of predicates to test
 ///   - failFunction: a function which is called when the predicate fails. Defaults to XCTFail
 /// - Returns: An `UpdateSpec` `Assert` that uses the assert to verify the result passed in to the `Assert`
-public func assertThatNext<Types: LoopTypes>(
-    _ predicates: NextPredicate<Types.Model, Types.Effect>...,
+public func assertThatNext<Model, Event, Effect>(
+    _ predicates: NextPredicate<Model, Effect>...,
     failFunction: @escaping AssertionFailure = XCTFail
-) -> UpdateSpec<Types>.Assert {
-    return { (result: UpdateSpec<Types>.Result) in
+) -> UpdateSpec<Model, Event, Effect>.Assert {
+    return { (result: UpdateSpec<Model, Event, Effect>.Result) in
         predicates.forEach({ predicate in
             let assertionResult = predicate(result.lastNext)
             if case let .failure(message, file, line) = assertionResult {

--- a/MobiusTest/Source/UpdateSpec.swift
+++ b/MobiusTest/Source/UpdateSpec.swift
@@ -19,16 +19,12 @@
 
 import MobiusCore
 
-public struct UpdateSpec<Types: LoopTypes> {
-    public typealias Model = Types.Model
-    public typealias Event = Types.Event
-    public typealias Effect = Types.Effect
-
+public struct UpdateSpec<Model, Event, Effect> {
     public typealias Assert = (Result) -> Void
 
-    private let update: Update<Types>
+    private let update: Update<Model, Event, Effect>
 
-    public init(_ update: @escaping Update<Types>) {
+    public init(_ update: @escaping Update<Model, Event, Effect>) {
         self.update = update
     }
 
@@ -37,10 +33,10 @@ public struct UpdateSpec<Types: LoopTypes> {
     }
 
     public struct When {
-        private let update: Update<Types>
+        private let update: Update<Model, Event, Effect>
         private let model: Model
 
-        init(_ update: @escaping Update<Types>, _ model: Model) {
+        init(_ update: @escaping Update<Model, Event, Effect>, _ model: Model) {
             self.update = update
             self.model = model
         }
@@ -51,11 +47,11 @@ public struct UpdateSpec<Types: LoopTypes> {
     }
 
     public struct Then {
-        private let update: Update<Types>
+        private let update: Update<Model, Event, Effect>
         private let model: Model
         private let events: [Event]
 
-        init(_ update: @escaping Update<Types>, _ model: Model, _ events: [Event]) {
+        init(_ update: @escaping Update<Model, Event, Effect>, _ model: Model, _ events: [Event]) {
             self.update = update
             self.model = model
             self.events = events

--- a/MobiusTest/Test/FirstMatchersTests.swift
+++ b/MobiusTest/Test/FirstMatchersTests.swift
@@ -44,7 +44,7 @@ class FirstMatchersTests: QuickSpec {
             // Testing through proxy: InitSpec
             context("when asserting through predicates that fail") {
                 beforeEach {
-                    InitSpec<AllStrings>(testInitiator)
+                    InitSpec<String, String>(testInitiator)
                         .when("a model")
                         .then(assertThatFirst(
                             hasModel(model + "1"),

--- a/MobiusTest/Test/FirstMatchersTests.swift
+++ b/MobiusTest/Test/FirstMatchersTests.swift
@@ -44,7 +44,7 @@ class FirstMatchersTests: QuickSpec {
             // Testing through proxy: InitSpec
             context("when asserting through predicates that fail") {
                 beforeEach {
-                    InitSpec<String, String>(testInitiator)
+                    InitSpec(testInitiator)
                         .when("a model")
                         .then(assertThatFirst(
                             hasModel(model + "1"),

--- a/MobiusTest/Test/InitSpecTests.swift
+++ b/MobiusTest/Test/InitSpecTests.swift
@@ -40,7 +40,7 @@ class InitSpecTests: QuickSpec {
                         First<String, String>(model: model + model, effects: testEffects)
                     }
 
-                    spec = InitSpec<String, String>(initiator)
+                    spec = InitSpec(initiator)
                 }
 
                 it("should run the test provided") {

--- a/MobiusTest/Test/InitSpecTests.swift
+++ b/MobiusTest/Test/InitSpecTests.swift
@@ -27,8 +27,8 @@ class InitSpecTests: QuickSpec {
     override func spec() {
         describe("InitSpec") {
             context("when setting up a test scenario") {
-                var initiator: Initiator<AllStrings>!
-                var spec: InitSpec<AllStrings>!
+                var initiator: Initiator<String, String>!
+                var spec: InitSpec<String, String>!
                 var testModel: String!
                 var testEffects: [String]!
                 var assertionClosureCalled = false
@@ -40,7 +40,7 @@ class InitSpecTests: QuickSpec {
                         First<String, String>(model: model + model, effects: testEffects)
                     }
 
-                    spec = InitSpec<AllStrings>(initiator)
+                    spec = InitSpec<String, String>(initiator)
                 }
 
                 it("should run the test provided") {

--- a/MobiusTest/Test/NextMatchersTests.swift
+++ b/MobiusTest/Test/NextMatchersTests.swift
@@ -49,7 +49,7 @@ class XCTestNextMatchersTests: QuickSpec {
             // Testing through proxy: UpdateSpec
             context("when asserting through predicates that fail") {
                 beforeEach {
-                    UpdateSpec<AllStrings>(testUpdate)
+                    UpdateSpec<String, String, String>(testUpdate)
                         .given("a model")
                         .when("")
                         .then(assertThatNext(

--- a/MobiusTest/Test/TestUtil.swift
+++ b/MobiusTest/Test/TestUtil.swift
@@ -20,12 +20,6 @@
 import MobiusCore
 import MobiusTest
 
-class AllStrings: LoopTypes {
-    typealias Model = String
-    typealias Event = String
-    typealias Effect = String
-}
-
 extension MobiusTest.PredicateResult {
     var failureMessage: String? {
         if case .failure(let message, _, _) = self {

--- a/MobiusTest/Test/UpdateSpecTests.swift
+++ b/MobiusTest/Test/UpdateSpecTests.swift
@@ -22,12 +22,6 @@ import MobiusTest
 import Nimble
 import Quick
 
-struct MyTypes: LoopTypes {
-    typealias Model = MyModel
-    typealias Event = MyEvent
-    typealias Effect = MyEffect
-}
-
 struct MyModel: Equatable {
     let buttonClicked: Bool
     let count: Int
@@ -49,7 +43,7 @@ enum MyEffect {
 class UpdateSpecTests: QuickSpec {
     // swiftlint:disable function_body_length
     override func spec() {
-        let updateSpec = UpdateSpec<MyTypes>(myUpdate)
+        let updateSpec = UpdateSpec<MyModel, MyEvent, MyEffect>(myUpdate)
 
         describe("UpdateSpec") {
             describe("single events") {


### PR DESCRIPTION
This PR demonstrates what it would look like to remove the `LoopTypes` protocol. 

The protocol currently serves the purpose of unifying the 3 generics `Model`, `Event` and `Effect` into a single generic. That cleans up some call sites, by doing `Update<T>` instead of `Update<Model, Event, Effect>`, but it also has some drawbacks:

* The protocol indirection can hurt type inference because Swift can't know to look inside `T` to figure out what `Model`, `Event` and `Effect` are. This means you have to specify the generic in places that you typically would not have to:
  ```swift
  // With loop types
  let loggingInitiator = LoggingInitiator<Types>(initiator, logger)
  let loggingUpdate = LoggingUpdate<Types>(update, logger)

  // Without loop types
  let loggingInitiator = LoggingInitiator(initiator, logger)
  let loggingUpdate = LoggingUpdate(update, logger)
  ```
  
  The second commit (b465ea5) of this PR shows a few spots where type inference can be leveraged to simplify the code. Most (maybe all) of these type inferences are impossible with the `LoopTypes`.

* There is currently inconsistent usage of `LoopTypes`, so getting rid of `LoopTypes` would help with that inconsistency. For example, `Next` doesn't use it, probably because it is only generic over `Model` and `Effect`, but not `Event`. However, the `Initiator` type _is_ generic over `LoopTypes` even though it does not need `Effect`. That means `Initiator` technically has an additional, unused generic (also known as a phantom type) that could cause type inference problems if the `Event` cannot be inferred.

* The `LoopTypes` conformance requires creating another type for each Mobius loop, and may be seen as boilerplate. It also causes some indirection if you want to immediately see what types a loop is dealing with, you have to jump to the `LoopTypes` instead of just looking at the type of the loop.

⚠️ It is worth mentioning that this change is not backwards compatible, and would require all existing Mobius features to update. That could be some significant churn.