### PR TITLE
Pin Xcode version to 11.0

### DIFF
--- a/.github/workflows/pull.yaml
+++ b/.github/workflows/pull.yaml
@@ -10,4 +10,5 @@ jobs:
     - name: Build and Test
       run: Tools/ci.sh
       env:
+        DEVELOPER_DIR: /Applications/Xcode_11.app/Contents/Developer
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -13,4 +13,5 @@ jobs:
     - name: Build and Test
       run: Tools/ci.sh
       env:
+        DEVELOPER_DIR: /Applications/Xcode_11.app/Contents/Developer
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/Tools/helpers.sh
+++ b/Tools/helpers.sh
@@ -27,6 +27,6 @@ xcb() {
 
 do_carthage_bootstrap() {
   carthage bootstrap --platform iOS \
-    --cache-builds --no-use-binaries || \
+    --cache-builds --no-use-binaries --verbose || \
     fail "Carthage bootstrap failed"
 }


### PR DESCRIPTION
We should be using a fixed version of Xcode on CI, instead of relying on whatever version `macOS-latest` contains.