### PR TITLE
Use Xcode 11.0

### DIFF
--- a/.github/workflows/pull.yaml
+++ b/.github/workflows/pull.yaml
@@ -10,5 +10,5 @@ jobs:
     - name: Build and Test
       run: Tools/ci.sh
       env:
-        DEVELOPER_DIR: /Applications/Xcode_11.1.app/Contents/Developer
+        DEVELOPER_DIR: /Applications/Xcode_11.app/Contents/Developer
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -13,5 +13,5 @@ jobs:
     - name: Build and Test
       run: Tools/ci.sh
       env:
-        DEVELOPER_DIR: /Applications/Xcode_11.1.app/Contents/Developer
+        DEVELOPER_DIR: /Applications/Xcode_11.app/Contents/Developer
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Just noticed that in #59 we use Xcode 11.1, but since internally we use Xcode 11.0, we should make sure our OSS repo will also compile internally.