### PR TITLE
Add Mobius.Builder.makeController

### DIFF
--- a/MobiusCore/Source/Mobius.swift
+++ b/MobiusCore/Source/Mobius.swift
@@ -150,6 +150,19 @@ public extension Mobius {
                 logger: logger
             )
         }
+
+        /// Create a `MobiusController` from the builder
+        ///
+        /// - Parameters:
+        ///   - defaultModel: The initial default model of the `MobiusController`
+        public func makeController(
+            from defaultModel: Model
+        ) -> MobiusController<Model, Event, Effect> {
+            return MobiusController(
+                builder: self,
+                defaultModel: defaultModel
+            )
+        }
     }
 }
 


### PR DESCRIPTION
It seems odd that the most common use case for a `Builder` is to put it in a variable and pass it to a constructor. With this, a `Builder` can be used to create either a raw loop or a controller.

Maybe there was a reason not to do it this way, though?

@jeppes @pettermahlen @togi 