### PR TITLE
Deprecate direct construction of MobiusController

### DIFF
--- a/MobiusCore/Source/BackwardsCompatibility.swift
+++ b/MobiusCore/Source/BackwardsCompatibility.swift
@@ -45,6 +45,14 @@ public extension MobiusLoop {
         return latestModel
     }
 }
+
+public extension MobiusController {
+    @available(*, deprecated, message: "use `Mobius.Builder.makeController` instead")
+    convenience init(builder: Mobius.Builder<Model, Event, Effect>, defaultModel: Model) {
+        self.init(builder: builder, initialModel: defaultModel)
+    }
+}
+
 @available(*, deprecated, message: "use `EffectHandler` instead")
 public protocol EffectPredicate {
     associatedtype Effect

--- a/MobiusCore/Source/Mobius.swift
+++ b/MobiusCore/Source/Mobius.swift
@@ -154,13 +154,13 @@ public extension Mobius {
         /// Create a `MobiusController` from the builder
         ///
         /// - Parameters:
-        ///   - defaultModel: The initial default model of the `MobiusController`
+        ///   - initialModel: The initial default model of the `MobiusController`
         public func makeController(
-            from defaultModel: Model
+            from initialModel: Model
         ) -> MobiusController<Model, Event, Effect> {
             return MobiusController(
                 builder: self,
-                defaultModel: defaultModel
+                initialModel: initialModel
             )
         }
     }

--- a/MobiusCore/Source/MobiusController.swift
+++ b/MobiusCore/Source/MobiusController.swift
@@ -39,9 +39,9 @@ public class MobiusController<Model, Event, Effect> {
         }
     }
 
-    public init(builder: Mobius.Builder<Model, Event, Effect>, defaultModel: Model) {
+    init(builder: Mobius.Builder<Model, Event, Effect>, initialModel: Model) {
         loopFactory = builder.start
-        modelToStartFrom = defaultModel
+        modelToStartFrom = initialModel
     }
 
     /// Connect a view to this controller.

--- a/MobiusCore/Test/MobiusControllerTests.swift
+++ b/MobiusCore/Test/MobiusControllerTests.swift
@@ -41,13 +41,10 @@ class MobiusControllerTests: QuickSpec {
                     .next("\(model)-\(event)")
                 }
 
-                var builder = Mobius.loop(
-                    update: updateFunction,
-                    effectHandler: SimpleTestConnectable()
-                )
-                builder = builder.withEventQueue(self.serialEventQueue)
-                builder = builder.withEffectQueue(self.serialEffectQueue)
-                controller = MobiusController(builder: builder, initialModel: "S")
+                controller = Mobius.loop(update: updateFunction, effectHandler: SimpleTestConnectable())
+                    .withEventQueue(self.serialEventQueue)
+                    .withEffectQueue(self.serialEffectQueue)
+                    .makeController(from: "S")
 
                 errorThrown = false
                 MobiusHooks.setErrorHandler({ _, _, _ in
@@ -124,8 +121,8 @@ class MobiusControllerTests: QuickSpec {
                     beforeEach {
                         modelObserver = MockConnectable()
                         effectObserver = MockConnectable()
-                        let builder: Mobius.Builder<String, String, String> = Mobius.loop(update: { _, _ in .noChange }, effectHandler: effectObserver)
-                        controller = MobiusController(builder: builder, initialModel: "")
+                        controller = Mobius.loop(update: { _, _ in .noChange }, effectHandler: effectObserver)
+                            .makeController(from: "")
                         controller.connectView(modelObserver)
                         controller.start()
                     }

--- a/MobiusCore/Test/MobiusControllerTests.swift
+++ b/MobiusCore/Test/MobiusControllerTests.swift
@@ -17,8 +17,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
+@testable import MobiusCore
+
 import Foundation
-import MobiusCore
 import Nimble
 import Quick
 
@@ -46,7 +47,7 @@ class MobiusControllerTests: QuickSpec {
                 )
                 builder = builder.withEventQueue(self.serialEventQueue)
                 builder = builder.withEffectQueue(self.serialEffectQueue)
-                controller = MobiusController(builder: builder, defaultModel: "S")
+                controller = MobiusController(builder: builder, initialModel: "S")
 
                 errorThrown = false
                 MobiusHooks.setErrorHandler({ _, _, _ in
@@ -124,7 +125,7 @@ class MobiusControllerTests: QuickSpec {
                         modelObserver = MockConnectable()
                         effectObserver = MockConnectable()
                         let builder: Mobius.Builder<String, String, String> = Mobius.loop(update: { _, _ in .noChange }, effectHandler: effectObserver)
-                        controller = MobiusController(builder: builder, defaultModel: "")
+                        controller = MobiusController(builder: builder, initialModel: "")
                         controller.connectView(modelObserver)
                         controller.start()
                     }


### PR DESCRIPTION
Obvious next step is obvious. @jeppes 