### PR TITLE
EventSource as Connectable<Model, Event>

### DIFF
--- a/Mobius.xcodeproj/project.pbxproj
+++ b/Mobius.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0280FB55237C1476007489A2 /* EventSourceConnectableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0280FB53237C1450007489A2 /* EventSourceConnectableTests.swift */; };
 		02BED1BB21DD20D20093FB47 /* ConnectableContramap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B9CE80421197FE000DB79A7 /* ConnectableContramap.swift */; };
 		02C4061D2373078400BD7ED8 /* PredicatedSafeConnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02C4061C2373078400BD7ED8 /* PredicatedSafeConnection.swift */; };
 		02C40621237422EF00BD7ED8 /* EffectRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02C40620237422EF00BD7ED8 /* EffectRouter.swift */; };
@@ -243,6 +244,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		0280FB53237C1450007489A2 /* EventSourceConnectableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventSourceConnectableTests.swift; sourceTree = "<group>"; };
 		02C4061C2373078400BD7ED8 /* PredicatedSafeConnection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PredicatedSafeConnection.swift; sourceTree = "<group>"; };
 		02C40620237422EF00BD7ED8 /* EffectRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EffectRouter.swift; sourceTree = "<group>"; };
 		02C40622237425E100BD7ED8 /* EffectRouterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EffectRouterTests.swift; sourceTree = "<group>"; };
@@ -529,6 +531,7 @@
 			children = (
 				5BB2885320999ACE0043B530 /* AnyEventSourceTests.swift */,
 				2DDF54C2229BEEC400D05861 /* CompositeEventSourceBuilderTests.swift */,
+				0280FB53237C1450007489A2 /* EventSourceConnectableTests.swift */,
 			);
 			path = EventSources;
 			sourceTree = "<group>";
@@ -1154,6 +1157,7 @@
 				02C406242374260700BD7ED8 /* EffectRouterTests.swift in Sources */,
 				5BB2887520999AD60043B530 /* AnyEventSourceTests.swift in Sources */,
 				5B1F1047211037270067193C /* BlockingFunctionConnectableTests.swift in Sources */,
+				0280FB55237C1476007489A2 /* EventSourceConnectableTests.swift in Sources */,
 				5BB2887C20999AD60043B530 /* LoggingUpdateTests.swift in Sources */,
 				5BB2887820999AD60043B530 /* AnyConnectionTests.swift in Sources */,
 				5B1F104B211037500067193C /* ConsumerConnectableTests.swift in Sources */,

--- a/MobiusCore/Test/EventSources/EventSourceConnectableTests.swift
+++ b/MobiusCore/Test/EventSources/EventSourceConnectableTests.swift
@@ -1,0 +1,109 @@
+// Copyright (c) 2019 Spotify AB.
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import Foundation
+import MobiusCore
+import Nimble
+import Quick
+
+class EventSourceConnectableTests: QuickSpec {
+    override func spec() {
+        let queue = DispatchQueue.testQueue("Event Queue")
+
+        context("") {
+            var receivedEvents: [String]!
+            var testEventSource: TestEventSource!
+            var loop: Disposable!
+            func update(model: String, event: String) -> Next<String, String> {
+                receivedEvents.append(event)
+                return .next(event)
+            }
+            beforeEach {
+                receivedEvents = []
+                testEventSource = TestEventSource()
+                loop = Mobius.loop(update: update, effectHandler: noOpEffectHandler)
+                    .withEventSourceConnectable(testEventSource.asConnectable)
+                    .withEventQueue(queue)
+                    .start(from: "1")
+            }
+
+            afterEach {
+                loop.dispose()
+            }
+
+            it("Should call the event source with the model that the loop was started from") {
+                queue.waitForOutstandingTasks()
+
+                expect(testEventSource.receivedModels).to(equal(["1"]))
+            }
+
+            it("Should send all updates of the model to the event source") {
+                testEventSource.sendEvent?("2")
+                testEventSource.sendEvent?("3")
+
+                queue.waitForOutstandingTasks()
+
+                expect(testEventSource.receivedModels).to(equal(["1", "2", "3"]))
+            }
+
+            it("Should send all evernts from the event source to the update function") {
+                testEventSource.sendEvent?("2")
+                testEventSource.sendEvent?("3")
+
+                queue.waitForOutstandingTasks()
+
+                expect(receivedEvents).to(equal(["2", "3"]))
+            }
+
+            it("Should dispose the event source when the loop is disposed") {
+                expect(testEventSource.isDisposed).to(beFalse())
+                loop.dispose()
+                expect(testEventSource.isDisposed).to(beTrue())
+            }
+        }
+    }
+}
+
+private let noOpEffectHandler = EffectRouter<String, String>()
+    .routeEffects(matching: { _ in true }).to { _ in }
+    .asConnectable
+
+private class TestEventSource {
+    var receivedModels: [String] = []
+    var sendEvent: Consumer<String>?
+    var isDisposed: Bool {
+        return sendEvent == nil
+    }
+
+    lazy var asConnectable: AnyConnectable<String, String> =
+        EffectRouter<String, String>()
+            .routeEffects(matching: { _ in true })
+            .to(effectHandler)
+            .asConnectable
+
+    private lazy var effectHandler = EffectHandler<String, String>(
+        handle: { model, dispatch in
+            self.receivedModels.append(model)
+            self.sendEvent = dispatch
+        },
+        disposable: AnonymousDisposable {
+            self.sendEvent = nil
+        }
+    )
+}


### PR DESCRIPTION
It should be possible to create an `EventSource` as a `Connectable<Model, Event>`.
This will make it easier to compose loops (since event sources can be triggered on a per sub-domain basis), and it will align the Swift version with the Java version.

There are some things we need to discuss:
1. Should `EventSource<Event>` be removed entirely in favor of `EventSource<Model, Event>`?
2. Should we create an approachable way of creating thread-safe `EventSource`s? This PR uses the EffectRouter to do so. This is doable, but definitely not obvious.

@JensAyton @togi @pettermahlen