### PR TITLE
Remove ConnectableClass deprecation

### DIFF
--- a/MobiusExtras/Source/ConnectableClass.swift
+++ b/MobiusExtras/Source/ConnectableClass.swift
@@ -33,7 +33,6 @@ import MobiusCore
 ///
 /// - Attention: Should not be used directly. Instead a subclass should be used which overrides the
 /// `handle` and `disposed` functions
-@available(*, deprecated, message: "use `EffectHandler` instead")
 open class ConnectableClass<InputType, OutputType>: Connectable {
     private var consumer: Consumer<OutputType>?
 


### PR DESCRIPTION
ConnectableClass still has use cases outside of handling effects. We should remove the deprecation until we have a true replacement