### PR TITLE
Update nimble to resolve test issues

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
         .library(name: "MobiusTest", targets: ["MobiusTest"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/Quick/Nimble", from: "8.0.4"),
+        .package(url: "https://github.com/Quick/Nimble", branch: "master"),
         .package(url: "https://github.com/Quick/Quick", from: "2.1.0"),
     ],
     targets: [

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
         .library(name: "MobiusTest", targets: ["MobiusTest"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/Quick/Nimble", branch: "master"),
+        .package(url: "https://github.com/Quick/Nimble"),
         .package(url: "https://github.com/Quick/Quick", from: "2.1.0"),
     ],
     targets: [

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
         .library(name: "MobiusTest", targets: ["MobiusTest"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/Quick/Nimble", from: "8.0.0"),
+        .package(url: "https://github.com/Quick/Nimble", from: "8.0.4"),
         .package(url: "https://github.com/Quick/Quick", from: "2.1.0"),
     ],
     targets: [


### PR DESCRIPTION
v8.0.0 of Nimble doesn't build with Xcode 11 with the Swift Package Manager -  we need to bump to 8.0.4. 