### PR TITLE
Enable TSAN

### DIFF
--- a/Mobius.xcodeproj/xcshareddata/xcschemes/MobiusCore.xcscheme
+++ b/Mobius.xcodeproj/xcshareddata/xcschemes/MobiusCore.xcscheme
@@ -54,6 +54,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      enableThreadSanitizer = "YES"
       codeCoverageEnabled = "YES"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>

--- a/Mobius.xcodeproj/xcshareddata/xcschemes/MobiusExtras.xcscheme
+++ b/Mobius.xcodeproj/xcshareddata/xcschemes/MobiusExtras.xcscheme
@@ -26,6 +26,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      enableThreadSanitizer = "YES"
       codeCoverageEnabled = "YES"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>

--- a/Mobius.xcodeproj/xcshareddata/xcschemes/MobiusNimble.xcscheme
+++ b/Mobius.xcodeproj/xcshareddata/xcschemes/MobiusNimble.xcscheme
@@ -26,6 +26,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      enableThreadSanitizer = "YES"
       codeCoverageEnabled = "YES"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>

--- a/Mobius.xcodeproj/xcshareddata/xcschemes/MobiusTest.xcscheme
+++ b/Mobius.xcodeproj/xcshareddata/xcschemes/MobiusTest.xcscheme
@@ -26,6 +26,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      enableThreadSanitizer = "YES"
       codeCoverageEnabled = "YES"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>

--- a/MobiusCore/Test/EffectRouterBuilderTests.swift
+++ b/MobiusCore/Test/EffectRouterBuilderTests.swift
@@ -26,13 +26,15 @@ import Quick
 
 class EffectRouterBuilderTests: QuickSpec {
     // swiftlint:disable function_body_length
+
     override func spec() {
         describe("Legacy EffectRouterBuilder") {
             var sut: EffectRouterBuilder<String, String>!
 
-            var output: String?
+            var output = Synchronized<String?>(value: nil)
+
             let outputHandler: Consumer<String> = { (string: String) in
-                output = string
+                output.value = string
             }
 
             beforeEach {
@@ -64,7 +66,7 @@ class EffectRouterBuilderTests: QuickSpec {
                     }
 
                     it("that output handler should be passed to the effect handler") {
-                        expect(output).to(equal(expectedOutput))
+                        expect(output.value).to(equal(expectedOutput))
                     }
                 }
 
@@ -329,12 +331,12 @@ class EffectRouterBuilderTests: QuickSpec {
 
                 it("should call the function when the effect matches its predicate") {
                     handler.accept(TestFunction.acceptableEffect)
-                    expect(output).to(equal(TestFunction.acceptableEffect + TestFunction.responseEvent))
+                    expect(output.value).to(equal(TestFunction.acceptableEffect + TestFunction.responseEvent))
                 }
 
                 it("should not call the function when the effect does not match its predicate") {
                     handler.accept(TestFunction.acceptableEffect + "not")
-                    expect(output).to(equal(fallback))
+                    expect(output.value).to(equal(fallback))
                 }
             }
 
@@ -356,7 +358,7 @@ class EffectRouterBuilderTests: QuickSpec {
                         .build()
                         .connect(outputHandler)
                         .accept("test")
-                    expect(output).toEventually(equal(testQueue.label))
+                    expect(output.value).toEventually(equal(testQueue.label))
                 }
             }
 

--- a/MobiusCore/Test/EffectRouterBuilderTests.swift
+++ b/MobiusCore/Test/EffectRouterBuilderTests.swift
@@ -31,6 +31,7 @@ class EffectRouterBuilderTests: QuickSpec {
         describe("Legacy EffectRouterBuilder") {
             var sut: EffectRouterBuilder<String, String>!
 
+            // swiftlint:disable:next quick_discouraged_call
             var output = Synchronized<String?>(value: nil)
 
             let outputHandler: Consumer<String> = { (string: String) in

--- a/MobiusCore/Test/MobiusControllerTests.swift
+++ b/MobiusCore/Test/MobiusControllerTests.swift
@@ -77,7 +77,7 @@ class MobiusControllerTests: QuickSpec {
                         beforeEach {
                             controller.connectView(view)
                             controller.start()
-                            view.recorder.items.removeAll()
+                            view.recorder.clear()
                         }
                         it("should allow stopping and starting again") {
                             controller.stop()
@@ -95,7 +95,7 @@ class MobiusControllerTests: QuickSpec {
                         it("should retain updated state") {
                             view.dispatch("hi")
                             controller.stop()
-                            view.recorder.items.removeAll()
+                            view.recorder.clear()
 
                             controller.start()
 
@@ -282,7 +282,7 @@ class MobiusControllerTests: QuickSpec {
 
                         controller.stop()
 
-                        view.recorder.items.removeAll()
+                        view.recorder.clear()
 
                         controller.start()
 

--- a/MobiusCore/Test/MobiusIntegrationTests.swift
+++ b/MobiusCore/Test/MobiusIntegrationTests.swift
@@ -111,7 +111,7 @@ class MobiusIntegrationTests: QuickSpec {
                     // clear out startup noise
                     queue.waitForOutstandingTasks() // Wait for the serial queue before clearing effects
                     receivedModels.removeAll()
-                    receivedEffects.items.removeAll()
+                    receivedEffects.clear()
                 }
 
                 it("should be possible for the UI to push events and receive models") {

--- a/MobiusCore/Test/MobiusIntegrationTests.swift
+++ b/MobiusCore/Test/MobiusIntegrationTests.swift
@@ -53,6 +53,7 @@ class MobiusIntegrationTests: QuickSpec {
                 }
             }
 
+            // swiftlint:disable:next quick_discouraged_call
             var receivedModels = Synchronized<[String]?>(value: nil)
             var builder: Mobius.Builder<String, String, String>!
             var loop: MobiusLoop<String, String, String>!

--- a/MobiusCore/Test/MobiusLoopTests.swift
+++ b/MobiusCore/Test/MobiusLoopTests.swift
@@ -202,7 +202,7 @@ class MobiusLoopTests: QuickSpec {
                 }
 
                 it("should log updates") {
-                    logger.logMessages.removeAll()
+                    logger.clear()
 
                     loop.dispatchEvent("hey")
 
@@ -272,17 +272,17 @@ class MobiusLoopTests: QuickSpec {
 
         context("when configuring with an EffectHandler") {
             var loop: MobiusLoop<Int, Int, Int>!
-            var isDisposed: Bool!
-            var didReceiveEffect: Bool!
+            let isDisposed = Synchronized<Bool>(value: false)
+            let didReceiveEffect = Synchronized<Bool>(value: false)
             beforeEach {
-                isDisposed = false
-                didReceiveEffect = false
+                isDisposed.value = false
+                didReceiveEffect.value = false
                 let effectHandler = EffectHandler<Int, Int>(
                     handle: { _, _ in
-                        didReceiveEffect = true
+                        didReceiveEffect.value = true
                     },
                     disposable: AnonymousDisposable {
-                        isDisposed = true
+                        isDisposed.value = true
                     }
                 )
                 let payload: (Int) -> Int? = { $0 }
@@ -300,12 +300,12 @@ class MobiusLoopTests: QuickSpec {
 
             it("should dispatch effects to the EffectHandler") {
                 loop.dispatchEvent(1)
-                expect(didReceiveEffect).toEventually(beTrue())
+                expect(didReceiveEffect.value).toEventually(beTrue())
             }
 
             it("should dispose the EffectHandler when the loop is disposed") {
                 loop.dispose()
-                expect(isDisposed).toEventually(beTrue())
+                expect(isDisposed.value).toEventually(beTrue())
             }
         }
     }

--- a/MobiusCore/Test/MobiusLoopTests.swift
+++ b/MobiusCore/Test/MobiusLoopTests.swift
@@ -272,7 +272,9 @@ class MobiusLoopTests: QuickSpec {
 
         context("when configuring with an EffectHandler") {
             var loop: MobiusLoop<Int, Int, Int>!
+            // swiftlint:disable:next quick_discouraged_call
             let isDisposed = Synchronized<Bool>(value: false)
+            // swiftlint:disable:next quick_discouraged_call
             let didReceiveEffect = Synchronized<Bool>(value: false)
             beforeEach {
                 isDisposed.value = false

--- a/MobiusCore/Test/TestingUtil.swift
+++ b/MobiusCore/Test/TestingUtil.swift
@@ -178,7 +178,6 @@ class TestEventSource<Event>: EventSource {
     }
 }
 
-
 /*
  Helper to simulate atomic access to a property.
 

--- a/MobiusCore/Test/TestingUtil.swift
+++ b/MobiusCore/Test/TestingUtil.swift
@@ -57,7 +57,7 @@ class RecordingTestConnectable: Connectable {
     }
 
     func accept(_ value: String) {
-        recorder.items.append(value)
+        recorder.append(value)
     }
 
     func dispose() {
@@ -65,8 +65,27 @@ class RecordingTestConnectable: Connectable {
     }
 }
 
-class Recorder<T> {
-    var items = [T]()
+final class Recorder<T> {
+    private var storage = [T]()
+    private let queue = DispatchQueue(label: "Recorder")
+
+    var items: [T] {
+        return queue.sync {
+            storage
+        }
+    }
+
+    func append(_ item: T) {
+        queue.sync {
+            storage.append(item)
+        }
+    }
+
+    func clear() {
+        queue.sync {
+            storage = []
+        }
+    }
 }
 
 class TestDisposable: Disposable {

--- a/Tools/ZZZ_MOBIUS_ALL.xcscheme
+++ b/Tools/ZZZ_MOBIUS_ALL.xcscheme
@@ -184,6 +184,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      enableThreadSanitizer = "YES"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/Tools/ci.sh
+++ b/Tools/ci.sh
@@ -23,7 +23,7 @@ has_command xcpretty || fail "xcpretty must be installed"
 
 # until then using SPM to unblock CI:
 
-swift test --enable-code-coverage || fail "SPM Test Failed"
+swift test --enable-code-coverage --sanitize=thread || fail "SPM Test Failed"
 
 # h4x to trick codecov
 for bundle in .build/x86_64-apple-macosx/debug/*.xctest ; do


### PR DESCRIPTION
It turns out that our effect handler tests had a bunch of data races. Let’s not have that.

@pettermahlen @dflems 