### PR TITLE
Disable problematic assertion in ConnectableClass

### DIFF
--- a/MobiusExtras/Source/ConnectableClass.swift
+++ b/MobiusExtras/Source/ConnectableClass.swift
@@ -51,7 +51,7 @@ open class ConnectableClass<InputType, OutputType>: Connectable {
     public final func send(_ output: OutputType) {
         lock.synchronized {
             guard let consumer = consumer else {
-                handleError("\(type(of: self)) is unable to send \(type(of: output)) before any consumer has been set. Send should only be used once the Connectable has been properly connected.")
+                // handleError("\(type(of: self)) is unable to send \(type(of: output)) before any consumer has been set. Send should only be used once the Connectable has been properly connected.")
                 return
             }
 

--- a/MobiusExtras/Test/ConnectableClassTests.swift
+++ b/MobiusExtras/Test/ConnectableClassTests.swift
@@ -106,7 +106,7 @@ class ConnectableTests: QuickSpec {
                         sut.handleError = handleError
                     }
 
-                    it("should cause a mobius error") {
+                    xit("should cause a mobius error") {
                         sut.send("Some string")
                         expect(errorThrown).to(beTrue())
                     }


### PR DESCRIPTION
In the current MobiusLoop implementation, client code cannot reasonably fulfil the requirements of this assertion. This is fixed in #85 but we don't want to wait for that to be fully reviewed and tested. As a temporary patch, we’ll just ignore mis-timed events from ConnectableClass.

This branch isn’t actually intended for merging. Instead I’ll tag it and bump it into client-ios to temporarily work around the problem there. I’ll make an equivalent change to master as well, and undo it in #85.

@togi @pettermahlen 