### PR TITLE
Disable problematic assertion in ConnectableClass

### DIFF
--- a/MobiusExtras/Source/ConnectableClass.swift
+++ b/MobiusExtras/Source/ConnectableClass.swift
@@ -54,7 +54,7 @@ open class ConnectableClass<InputType, OutputType>: Connectable {
             lock.unlock()
         }
         guard let consumer = consumer else {
-            handleError("\(type(of: self)) is unable to send \(type(of: output)) before any consumer has been set. Send should only be used once the Connectable has been properly connected.")
+            // handleError("\(type(of: self)) is unable to send \(type(of: output)) before any consumer has been set. Send should only be used once the Connectable has been properly connected.")
             return
         }
 

--- a/MobiusExtras/Test/ConnectableClassTests.swift
+++ b/MobiusExtras/Test/ConnectableClassTests.swift
@@ -106,7 +106,7 @@ class ConnectableTests: QuickSpec {
                         sut.handleError = handleError
                     }
 
-                    it("should cause a mobius error") {
+                    xit("should cause a mobius error") {
                         sut.send("Some string")
                         expect(errorThrown).to(beTrue())
                     }


### PR DESCRIPTION
Like #86, but actually mergeable.

In the current MobiusLoop implementation, client code cannot reasonably fulfil the requirements of this assertion. This is fixed in #85 but we don't want to wait for that to be fully reviewed and tested. As a temporary patch, we’ll just ignore mis-timed events from ConnectableClass.

@togi @pettermahlen 