### PR TITLE
Deprecate raw loop initiator

### DIFF
--- a/Mobius.xcodeproj/project.pbxproj
+++ b/Mobius.xcodeproj/project.pbxproj
@@ -127,7 +127,7 @@
 		5BB2886D20999AD60043B530 /* MobiusControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BB2884B20999ACE0043B530 /* MobiusControllerTests.swift */; };
 		5BB2886E20999AD60043B530 /* MobiusIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BB2884C20999ACE0043B530 /* MobiusIntegrationTests.swift */; };
 		5BB2886F20999AD60043B530 /* TestingUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BB2884D20999ACE0043B530 /* TestingUtil.swift */; };
-		5BB2887120999AD60043B530 /* LoggingInitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BB2884F20999ACE0043B530 /* LoggingInitTests.swift */; };
+		5BB2887120999AD60043B530 /* LoggingInitiateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BB2884F20999ACE0043B530 /* LoggingInitiateTests.swift */; };
 		5BB2887220999AD60043B530 /* EventProcessorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BB2885020999ACE0043B530 /* EventProcessorTests.swift */; };
 		5BB2887320999AD60043B530 /* BrokenConnectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BB2885120999ACE0043B530 /* BrokenConnectionTests.swift */; };
 		5BB2887520999AD60043B530 /* AnyEventSourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BB2885320999ACE0043B530 /* AnyEventSourceTests.swift */; };
@@ -338,7 +338,7 @@
 		5BB2884B20999ACE0043B530 /* MobiusControllerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MobiusControllerTests.swift; sourceTree = "<group>"; };
 		5BB2884C20999ACE0043B530 /* MobiusIntegrationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MobiusIntegrationTests.swift; sourceTree = "<group>"; };
 		5BB2884D20999ACE0043B530 /* TestingUtil.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestingUtil.swift; sourceTree = "<group>"; };
-		5BB2884F20999ACE0043B530 /* LoggingInitTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoggingInitTests.swift; sourceTree = "<group>"; };
+		5BB2884F20999ACE0043B530 /* LoggingInitiateTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoggingInitiateTests.swift; sourceTree = "<group>"; };
 		5BB2885020999ACE0043B530 /* EventProcessorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EventProcessorTests.swift; sourceTree = "<group>"; };
 		5BB2885120999ACE0043B530 /* BrokenConnectionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BrokenConnectionTests.swift; sourceTree = "<group>"; };
 		5BB2885320999ACE0043B530 /* AnyEventSourceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnyEventSourceTests.swift; sourceTree = "<group>"; };
@@ -692,7 +692,7 @@
 				5BB2885020999ACE0043B530 /* EventProcessorTests.swift */,
 				2D58735F238EC60F001F21ED /* EventRouterDisposalLogicalRaceRegressionTest.swift */,
 				5BB2885520999ACE0043B530 /* FirstTests.swift */,
-				5BB2884F20999ACE0043B530 /* LoggingInitTests.swift */,
+				5BB2884F20999ACE0043B530 /* LoggingInitiateTests.swift */,
 				5BB2885A20999ACE0043B530 /* LoggingUpdateTests.swift */,
 				5BB2884B20999ACE0043B530 /* MobiusControllerTests.swift */,
 				5B85AD0020AAA87D00C4FCD5 /* MobiusHooksTests.swift */,
@@ -1184,7 +1184,7 @@
 				5BB2887C20999AD60043B530 /* LoggingUpdateTests.swift in Sources */,
 				5BB2887820999AD60043B530 /* AnyConnectionTests.swift in Sources */,
 				5B1F104B211037500067193C /* ConsumerConnectableTests.swift in Sources */,
-				5BB2887120999AD60043B530 /* LoggingInitTests.swift in Sources */,
+				5BB2887120999AD60043B530 /* LoggingInitiateTests.swift in Sources */,
 				2D3A69772359EAAA0053C95E /* WorkBagTests.swift in Sources */,
 				2DDF54C3229BEEC400D05861 /* CompositeEventSourceBuilderTests.swift in Sources */,
 				02D0DDC52366F56C00A1CE4C /* EffectHandlerTests.swift in Sources */,

--- a/MobiusCore/Source/BackwardsCompatibility.swift
+++ b/MobiusCore/Source/BackwardsCompatibility.swift
@@ -53,7 +53,8 @@ public extension Mobius.Builder {
         return self
     }
 
-    @available(*, deprecated, message: "use withInitiate instead")
+    @available(*, deprecated, message:
+    "initiators are deprecated for raw loops. For MobiusController, pass the initiator to makeController instead")
     func withInitiator(_ initiate: @escaping Initiate<Model, Effect>) -> Mobius.Builder<Model, Event, Effect> {
         return withInitiate(initiate)
     }

--- a/MobiusCore/Source/BackwardsCompatibility.swift
+++ b/MobiusCore/Source/BackwardsCompatibility.swift
@@ -19,6 +19,9 @@
 
 import Foundation
 
+@available(*, deprecated, message: "use Initiate instead")
+public typealias Initiator<Model, Effect> = Initiate<Model, Effect>
+
 public extension First where Effect: Hashable {
     @available(*, deprecated, message: "use array of effects instead")
     init(model: Model, effects: Set<Effect>) {
@@ -48,6 +51,11 @@ public extension Mobius.Builder {
     @available(*, unavailable, message: "handle dispatching manually, or use MobiusController")
     func withEffectQueue(_ effectQueue: DispatchQueue) -> Mobius.Builder<Model, Event, Effect> {
         return self
+    }
+
+    @available(*, deprecated, message: "use withInitiate instead")
+    func withInitiator(_ initiate: @escaping Initiate<Model, Effect>) -> Mobius.Builder<Model, Event, Effect> {
+        return withInitiate(initiate)
     }
 }
 

--- a/MobiusCore/Source/LoggingAdaptors.swift
+++ b/MobiusCore/Source/LoggingAdaptors.swift
@@ -20,15 +20,15 @@
 /// Helper to wrap initator functions with log calls.
 ///
 /// Also adds call stack annotation where we call into the client-provided initiator.
-class LoggingInitiator<Model, Effect> {
-    typealias Initiator = MobiusCore.Initiator<Model, Effect>
+class LoggingInitiate<Model, Effect> {
+    typealias Initiate = MobiusCore.Initiate<Model, Effect>
     typealias First = MobiusCore.First<Model, Effect>
 
-    private let realInit: Initiator
+    private let realInit: Initiate
     private let willInit: (Model) -> Void
     private let didInit: (Model, First) -> Void
 
-    init<Logger: MobiusLogger>(_ realInit: @escaping Initiator, logger: Logger)
+    init<Logger: MobiusLogger>(_ realInit: @escaping Initiate, logger: Logger)
     where Logger.Model == Model, Logger.Effect == Effect {
         self.realInit = realInit
         willInit = logger.willInitiate

--- a/MobiusCore/Source/Mobius.swift
+++ b/MobiusCore/Source/Mobius.swift
@@ -21,7 +21,7 @@ import Foundation
 
 public typealias Update<Model, Event, Effect> = (Model, Event) -> Next<Model, Effect>
 
-public typealias Initiator<Model, Effect> = (Model) -> First<Model, Effect>
+public typealias Initiate<Model, Effect> = (Model) -> First<Model, Effect>
 
 public enum Mobius {}
 
@@ -47,7 +47,7 @@ public extension Mobius {
         return Builder(
             update: update,
             effectHandler: effectHandler,
-            initiator: { First(model: $0) },
+            initiate: { First(model: $0) },
             eventSource: AnyEventSource({ _ in AnonymousDisposable(disposer: {}) }),
             eventConsumerTransformer: { $0 },
             logger: AnyMobiusLogger(NoopLogger())
@@ -57,7 +57,7 @@ public extension Mobius {
     struct Builder<Model, Event, Effect> {
         private let update: Update<Model, Event, Effect>
         private let effectHandler: AnyConnectable<Effect, Event>
-        private let initiator: Initiator<Model, Effect>
+        private let initiate: Initiate<Model, Effect>
         private let eventSource: AnyEventSource<Event>
         private let logger: AnyMobiusLogger<Model, Event, Effect>
         private let eventConsumerTransformer: ConsumerTransformer<Event>
@@ -65,14 +65,14 @@ public extension Mobius {
         fileprivate init<C: Connectable>(
             update: @escaping Update<Model, Event, Effect>,
             effectHandler: C,
-            initiator: @escaping Initiator<Model, Effect>,
+            initiate: @escaping Initiate<Model, Effect>,
             eventSource: AnyEventSource<Event>,
             eventConsumerTransformer: @escaping ConsumerTransformer<Event>,
             logger: AnyMobiusLogger<Model, Event, Effect>
         ) where C.InputType == Effect, C.OutputType == Event {
             self.update = update
             self.effectHandler = AnyConnectable(effectHandler)
-            self.initiator = initiator
+            self.initiate = initiate
             self.eventSource = eventSource
             self.logger = logger
             self.eventConsumerTransformer = eventConsumerTransformer
@@ -82,18 +82,18 @@ public extension Mobius {
             return Builder(
                 update: update,
                 effectHandler: effectHandler,
-                initiator: initiator,
+                initiate: initiate,
                 eventSource: AnyEventSource(eventSource),
                 eventConsumerTransformer: eventConsumerTransformer,
                 logger: logger
             )
         }
 
-        public func withInitiator(_ initiator: @escaping Initiator<Model, Effect>) -> Builder {
+        public func withInitiate(_ initiate: @escaping Initiate<Model, Effect>) -> Builder {
             return Builder(
                 update: update,
                 effectHandler: effectHandler,
-                initiator: initiator,
+                initiate: initiate,
                 eventSource: eventSource,
                 eventConsumerTransformer: eventConsumerTransformer,
                 logger: logger
@@ -104,7 +104,7 @@ public extension Mobius {
             return Builder(
                 update: update,
                 effectHandler: effectHandler,
-                initiator: initiator,
+                initiate: initiate,
                 eventSource: eventSource,
                 eventConsumerTransformer: eventConsumerTransformer,
                 logger: AnyMobiusLogger(logger)
@@ -130,7 +130,7 @@ public extension Mobius {
             return Builder(
                 update: update,
                 effectHandler: effectHandler,
-                initiator: initiator,
+                initiate: initiate,
                 eventSource: eventSource,
                 eventConsumerTransformer: { consumer in transformer(oldTransfomer(consumer)) },
                 logger: logger
@@ -142,7 +142,7 @@ public extension Mobius {
                 update: update,
                 effectHandler: effectHandler,
                 initialModel: initialModel,
-                initiator: initiator,
+                initiate: initiate,
                 eventSource: eventSource,
                 eventConsumerTransformer: eventConsumerTransformer,
                 logger: logger

--- a/MobiusCore/Source/Mobius.swift
+++ b/MobiusCore/Source/Mobius.swift
@@ -89,7 +89,7 @@ public extension Mobius {
             )
         }
 
-        public func withInitiate(_ initiate: @escaping Initiate<Model, Effect>) -> Builder {
+        func withInitiate(_ initiate: @escaping Initiate<Model, Effect>) -> Builder {
             return Builder(
                 update: update,
                 effectHandler: effectHandler,
@@ -156,27 +156,31 @@ public extension Mobius {
         ///   - qos: The Quality of Service class for the controller’s work queue. Default: `.userInitiated`
         public func makeController(
             from initialModel: Model,
+            initiate: Initiate<Model, Effect>? = nil,
             qos: DispatchQoS.QoSClass = .userInitiated
         ) -> MobiusController<Model, Event, Effect> {
-            return makeController(from: initialModel, loopQueue: .global(qos: qos))
+            return makeController(from: initialModel, initiate: initiate, loopQueue: .global(qos: qos))
         }
 
         /// Create a `MobiusController` from the builder
         ///
         /// - Parameters:
         ///   - initialModel: The initial default model of the `MobiusController`
+        ///   - initiate: An optional initiator function to invoke each time the controller’s loop is started.
         ///   - loopQueue: The target queue for the `MobiusController`’s work queue. The controller will dispatch events
         ///     and effects on a serial queue that targets this queue.
         ///   - viewQueue: The queue to use to post to the `MobiusController`’s view connection.
         ///     Default: the main queue.
         public func makeController(
             from initialModel: Model,
+            initiate: Initiate<Model, Effect>? = nil,
             loopQueue: DispatchQueue,
             viewQueue: DispatchQueue = .main
         ) -> MobiusController<Model, Event, Effect> {
             return MobiusController(
                 builder: self,
                 initialModel: initialModel,
+                initiate: initiate,
                 loopQueue: loopQueue,
                 viewQueue: viewQueue
             )

--- a/MobiusCore/Source/MobiusController.swift
+++ b/MobiusCore/Source/MobiusController.swift
@@ -42,6 +42,7 @@ public final class MobiusController<Model, Event, Effect> {
     init(
         builder: Mobius.Builder<Model, Event, Effect>,
         initialModel: Model,
+        initiate: Initiate<Model, Effect>? = nil,
         loopQueue loopTargetQueue: DispatchQueue,
         viewQueue: DispatchQueue
     ) {
@@ -107,7 +108,12 @@ public final class MobiusController<Model, Event, Effect> {
             }
         }
 
-        loopFactory = builder.withEventConsumerTransformer(flipEventsToLoopQueue).start
+        var decoratedBuilder = builder.withEventConsumerTransformer(flipEventsToLoopQueue)
+        if let initiate = initiate {
+            decoratedBuilder = decoratedBuilder.withInitiate(initiate)
+        }
+
+        loopFactory = decoratedBuilder.start
     }
 
     /// Connect a view to this controller.

--- a/MobiusCore/Source/MobiusController.swift
+++ b/MobiusCore/Source/MobiusController.swift
@@ -113,7 +113,7 @@ public final class MobiusController<Model, Event, Effect> {
             decoratedBuilder = decoratedBuilder.withInitiate(initiate)
         }
 
-        loopFactory = decoratedBuilder.start
+        loopFactory = { decoratedBuilder.start(from: $0) }
     }
 
     /// Connect a view to this controller.

--- a/MobiusCore/Source/MobiusLogger.swift
+++ b/MobiusCore/Source/MobiusLogger.swift
@@ -25,21 +25,21 @@ public protocol MobiusLogger {
     associatedtype Event
     associatedtype Effect
 
-    ///  Called right before the `Initiator` function is called.
+    ///  Called right before the `Initiate` function is called.
     ///
     ///  This method mustn't block, as it'll hinder the loop from running. It will be called on the
-    ///  same thread as the `Initiator` function.
+    ///  same thread as the `Initiate` function.
     ///
-    /// - Parameter model: the model that will be passed to the initiator function
+    /// - Parameter model: the model that will be passed to the initiate function
     func willInitiate(model: Model)
 
-    /// Called right after the `Initiator` function is called.
+    /// Called right after the `Initiate` function is called.
     ///
     /// This method mustn't block, as it'll hinder the loop from running. It will be called on the
-    /// same thread as the initiator function.
+    /// same thread as the initiate function.
     ///
     /// - Parameters:
-    ///     - model: the model that was passed to the initiator
+    ///     - model: the model that was passed to the initiate function
     ///     - first: the resulting `First` instance
     func didInitiate(model: Model, first: First<Model, Effect>)
 

--- a/MobiusCore/Source/MobiusLoop.swift
+++ b/MobiusCore/Source/MobiusLoop.swift
@@ -116,13 +116,13 @@ public final class MobiusLoop<Model, Event, Effect>: Disposable, CustomDebugStri
         update: @escaping Update<Model, Event, Effect>,
         effectHandler: C,
         initialModel: Model,
-        initiator: @escaping Initiator<Model, Effect>,
+        initiate: @escaping Initiate<Model, Effect>,
         eventSource: AnyEventSource<Event>,
         eventConsumerTransformer: ConsumerTransformer<Event>,
         logger: AnyMobiusLogger<Model, Event, Effect>
     ) -> MobiusLoop where C.InputType == Effect, C.OutputType == Event {
         let accessGuard = ConcurrentAccessDetector()
-        let loggingInitiator = LoggingInitiator(initiator, logger: logger)
+        let loggingInitiate = LoggingInitiate(initiate, logger: logger)
         let loggingUpdate = LoggingUpdate(update, logger: logger)
         let workBag = WorkBag(accessGuard: accessGuard)
 
@@ -168,7 +168,7 @@ public final class MobiusLoop<Model, Event, Effect>: Disposable, CustomDebugStri
         let nextConnection = nextPublisher.connect(to: nextConsumer)
 
         // everything is hooked up, start processing!
-        eventProcessor.start(from: loggingInitiator.initiate(initialModel))
+        eventProcessor.start(from: loggingInitiate.initiate(initialModel))
 
         return MobiusLoop(
             eventProcessor: eventProcessor,

--- a/MobiusCore/Test/LoggingInitiateTests.swift
+++ b/MobiusCore/Test/LoggingInitiateTests.swift
@@ -21,25 +21,25 @@
 import Nimble
 import Quick
 
-class LoggingInitiatorTests: QuickSpec {
+class LoggingInitiateTests: QuickSpec {
     override func spec() {
-        describe("LoggingInitiator") {
+        describe("LoggingInitiate") {
             var logger: TestMobiusLogger!
-            var loggingInitiator: LoggingInitiator<String, String>!
+            var loggingInitiate: LoggingInitiate<String, String>!
 
             beforeEach {
                 logger = TestMobiusLogger()
-                loggingInitiator = LoggingInitiator({ model in First(model: model) }, logger: logger)
+                loggingInitiate = LoggingInitiate({ model in First(model: model) }, logger: logger)
             }
 
             it("should log willInitiate and didInitiate for each initiate attempt") {
-                _ = loggingInitiator.initiate("from this")
+                _ = loggingInitiate.initiate("from this")
 
                 expect(logger.logMessages).to(equal(["willInitiate(from this)", "didInitiate(from this, First<String, String>(model: \"from this\", effects: []))"]))
             }
 
             it("should return init from delegate") {
-                let first = loggingInitiator.initiate("hey")
+                let first = loggingInitiate.initiate("hey")
 
                 expect(first.model).to(equal("hey"))
                 expect(first.effects).to(beEmpty())

--- a/MobiusCore/Test/MobiusIntegrationTests.swift
+++ b/MobiusCore/Test/MobiusIntegrationTests.swift
@@ -81,7 +81,7 @@ class MobiusIntegrationTests: QuickSpec {
                 }
 
                 builder = Mobius.loop(update: logic.update, effectHandler: effectHandler)
-                    .withInitiate(logic.initiate)
+                    .withInitiator(logic.initiate)
                     .withEventSource(AnyEventSource<String>(subscribe))
             }
 

--- a/MobiusCore/Test/MobiusIntegrationTests.swift
+++ b/MobiusCore/Test/MobiusIntegrationTests.swift
@@ -81,7 +81,7 @@ class MobiusIntegrationTests: QuickSpec {
                 }
 
                 builder = Mobius.loop(update: logic.update, effectHandler: effectHandler)
-                    .withInitiator(logic.initiate)
+                    .withInitiate(logic.initiate)
                     .withEventSource(AnyEventSource<String>(subscribe))
             }
 

--- a/MobiusCore/Test/MobiusLoopTests.swift
+++ b/MobiusCore/Test/MobiusLoopTests.swift
@@ -29,7 +29,7 @@ class MobiusLoopTests: QuickSpec {
             var builder: Mobius.Builder<String, String, String>!
             var loop: MobiusLoop<String, String, String>!
             var receivedModels: [String]!
-            var effectHandler: SimpleTestConnectable!
+            var effectHandler: RecordingTestConnectable!
             var modelObserver: Consumer<String>!
 
             beforeEach {
@@ -39,7 +39,7 @@ class MobiusLoopTests: QuickSpec {
 
                 let update: Update<String, String, String> = { _, event in Next.next(event) }
 
-                effectHandler = SimpleTestConnectable()
+                effectHandler = RecordingTestConnectable()
 
                 builder = Mobius.loop(update: update, effectHandler: effectHandler)
             }
@@ -258,6 +258,16 @@ class MobiusLoopTests: QuickSpec {
                         let description = String(describing: loop)
                         expect(description).to(equal("Optional(disposed MobiusLoop<String, String, String>!)"))
                     }
+                }
+            }
+
+            context("when starting with effects") {
+                beforeEach {
+                    loop = builder.start(from: "S", effects: ["F1", "F2"])
+                }
+
+                it("should immediately execute the specified events") {
+                    expect(effectHandler.recorder.items).to(contain("F1", "F2"))
                 }
             }
         }

--- a/MobiusNimble/Test/NimbleFirstMatchersTests.swift
+++ b/MobiusNimble/Test/NimbleFirstMatchersTests.swift
@@ -44,14 +44,14 @@ class NimbleFirstMatchersTests: QuickSpec {
             }
 
             let model = "3"
-            func testInitiator(model: String) -> First<String, String> {
+            func testInitiate(model: String) -> First<String, String> {
                 return First<String, String>(model: model, effects: ["2", "4"])
             }
 
             // Testing through proxy: UpdateSpec
             context("when asserting through predicates that fail") {
                 beforeEach {
-                    InitSpec(testInitiator)
+                    InitSpec(testInitiate)
                         .when("a model")
                         .then(assertThatFirst(haveModel(model + "1"), haveNoEffects()))
                 }

--- a/MobiusTest/Source/InitSpec.swift
+++ b/MobiusTest/Source/InitSpec.swift
@@ -22,27 +22,33 @@ import MobiusCore
 public typealias AssertFirst<Model, Effect> = (First<Model, Effect>) -> Void
 
 public final class InitSpec<Model, Effect> {
-    let initiator: Initiator<Model, Effect>
+    let initiate: Initiate<Model, Effect>
 
-    public init(_ initiator: @escaping Initiator<Model, Effect>) {
-        self.initiator = initiator
+    public init(_ initiate: @escaping Initiate<Model, Effect>) {
+        self.initiate = initiate
     }
 
     public func when(_ model: Model) -> Then {
-        return Then(model, initiator: initiator)
+        return Then(model, initiate: initiate)
     }
 
     public struct Then {
         let model: Model
-        let initiator: Initiator<Model, Effect>
+        let initiate: Initiate<Model, Effect>
 
-        public init(_ model: Model, initiator: @escaping Initiator<Model, Effect>) {
+        init(_ model: Model, initiate: @escaping Initiate<Model, Effect>) {
             self.model = model
-            self.initiator = initiator
+            self.initiate = initiate
+        }
+
+        // It’s unclear why this was public; the replacement isn’t.
+        @available(*, deprecated, message: "use InitSpec.then instead")
+        public init(_ model: Model, initiator: @escaping Initiate<Model, Effect>) {
+            self.init(model, initiate: initiator)
         }
 
         public func then(_ assertion: AssertFirst<Model, Effect>) {
-            let first = initiator(model)
+            let first = initiate(model)
             assertion(first)
         }
     }

--- a/MobiusTest/Test/FirstMatchersTests.swift
+++ b/MobiusTest/Test/FirstMatchersTests.swift
@@ -29,7 +29,7 @@ class FirstMatchersTests: QuickSpec {
             var failureMessages: [String] = []
             let model = "3"
 
-            func testInitiator(model: String) -> First<String, String> {
+            func testInitiate(model: String) -> First<String, String> {
                 return First<String, String>(model: model, effects: ["2", "4"])
             }
 
@@ -44,7 +44,7 @@ class FirstMatchersTests: QuickSpec {
             // Testing through proxy: InitSpec
             context("when asserting through predicates that fail") {
                 beforeEach {
-                    InitSpec(testInitiator)
+                    InitSpec(testInitiate)
                         .when("a model")
                         .then(assertThatFirst(
                             hasModel(model + "1"),

--- a/MobiusTest/Test/InitSpecTests.swift
+++ b/MobiusTest/Test/InitSpecTests.swift
@@ -27,7 +27,7 @@ class InitSpecTests: QuickSpec {
     override func spec() {
         describe("InitSpec") {
             context("when setting up a test scenario") {
-                var initiator: Initiator<String, String>!
+                var initiate: Initiate<String, String>!
                 var spec: InitSpec<String, String>!
                 var testModel: String!
                 var testEffects: [String]!
@@ -36,11 +36,11 @@ class InitSpecTests: QuickSpec {
                 beforeEach {
                     testModel = UUID().uuidString
                     testEffects = ["1", "2", "3"]
-                    initiator = { (model: String) in
+                    initiate = { (model: String) in
                         First<String, String>(model: model + model, effects: testEffects)
                     }
 
-                    spec = InitSpec(initiator)
+                    spec = InitSpec(initiate)
                 }
 
                 it("should run the test provided") {


### PR DESCRIPTION
For consistency with Android. We can remove the backwards compatibility and simplify the implementation after 0.3.

@togi 