### PR TITLE
[WIP] test assertion cleanup

### DIFF
--- a/MobiusCore/Source/MobiusController.swift
+++ b/MobiusCore/Source/MobiusController.swift
@@ -136,7 +136,7 @@ public final class MobiusController<Model, Event, Effect> {
     /// time the loop is started.
     ///
     /// May not be called directly from an effect handler running on the controller’s loop queue.
-    /// To stop the queue as an effect, dispatch to a different queue.
+    /// To stop the loop as an effect, dispatch to a different queue.
     ///
     /// - Attention: fails via `MobiusHooks.onError` if the loop isn't running
     public func stop() {

--- a/MobiusCore/Test/BrokenConnectionTests.swift
+++ b/MobiusCore/Test/BrokenConnectionTests.swift
@@ -24,32 +24,21 @@ import Quick
 class BrokenConnectionTests: QuickSpec {
     override func spec() {
         var connection: Connection<Int>!
-        var errorThrown: Bool!
 
-        describe("BrokenAnyConnection") {
+        describe("BrokenConnection") {
             beforeEach {
                 connection = BrokenConnection<Int>.connection()
-                errorThrown = false
-                MobiusHooks.setErrorHandler({ _, _, _ in
-                    errorThrown = true
-                })
-            }
-
-            afterEach {
-                MobiusHooks.setDefaultErrorHandler()
             }
 
             context("when calling accept value") {
                 it("should trigger the error handler") {
-                    connection.accept(3)
-                    expect(errorThrown).to(beTrue())
+                    expect(connection.accept(3)).to(throwAssertion())
                 }
             }
 
             context("when attempting to dispose") {
                 it("should trigger the error handler") {
-                    connection.dispose()
-                    expect(errorThrown).to(beTrue())
+                    expect(connection.dispose()).to(throwAssertion())
                 }
             }
         }

--- a/MobiusCore/Test/ConnectablePublisherTests.swift
+++ b/MobiusCore/Test/ConnectablePublisherTests.swift
@@ -29,7 +29,6 @@ class ConnectablePublisherTests: QuickSpec {
             var publisher: ConnectablePublisher<String>!
             var received: [String]!
             var consumer: Consumer<String>!
-            var errorThrown: Bool!
 
             beforeEach {
                 publisher = ConnectablePublisher()
@@ -38,15 +37,6 @@ class ConnectablePublisherTests: QuickSpec {
                 consumer = {
                     received.append($0)
                 }
-
-                errorThrown = false
-                MobiusHooks.setErrorHandler({ _, _, _ in
-                    errorThrown = true
-                })
-            }
-
-            afterEach {
-                MobiusHooks.setDefaultErrorHandler()
             }
 
             describe("connections") {
@@ -138,11 +128,10 @@ class ConnectablePublisherTests: QuickSpec {
 
                     context("when trying to connect") {
                         it("should refuse connections") {
-                            publisher.connect(to: consumer)
-
-                            expect(errorThrown).to(beTrue())
+                            expect { publisher.connect(to: consumer) }.to(throwAssertion())
                         }
 
+                        // NOTE: This can be removed when removing MobiusHooks
                         context("when error handling does not cause a crash") {
                             var errorMessage: String?
                             beforeEach {
@@ -169,9 +158,7 @@ class ConnectablePublisherTests: QuickSpec {
 
                     context("when trying to post") {
                         it("should refuse values") {
-                            publisher.post("crashme")
-
-                            expect(errorThrown).to(beTrue())
+                            expect(publisher.post("crashme")).to(throwAssertion())
                         }
                     }
 

--- a/MobiusCore/Test/EffectHandlers/EffectHandlerDSLTests.swift
+++ b/MobiusCore/Test/EffectHandlers/EffectHandlerDSLTests.swift
@@ -55,7 +55,6 @@ class EffectRouterDSLTests: QuickSpec {
                     .connect { events.append($0) }
 
                 dslHandler.accept(.effect1)
-                dslHandler.accept(.effect2)
                 expect(events).to(equal([.eventForEffect1]))
 
                 dslHandler.dispose()
@@ -76,7 +75,6 @@ class EffectRouterDSLTests: QuickSpec {
                     }
 
                 dslHandler.accept(.effect1)
-                dslHandler.accept(.effect2)
                 expect(effectPerformedCount).to(equal(1))
                 expect(didDispatchEvents).to(beFalse())
             }
@@ -121,7 +119,6 @@ class EffectRouterDSLTests: QuickSpec {
                     .connect { events.append($0) }
 
                 dslHandler.accept(.effect1)
-                dslHandler.accept(.effect2)
                 expect(events).to(equal([.eventForEffect1]))
 
                 dslHandler.dispose()
@@ -141,7 +138,6 @@ class EffectRouterDSLTests: QuickSpec {
                     }
 
                 dslHandler.accept(.effect1)
-                dslHandler.accept(.effect2)
                 expect(performedEffects).to(equal([.effect1]))
                 expect(didDispatchEvents).to(beFalse())
             }
@@ -187,7 +183,6 @@ class EffectRouterDSLTests: QuickSpec {
                     .connect { events.append($0) }
 
                 dslHandler.accept(.effect1)
-                dslHandler.accept(.effect2)
                 expect(events).to(equal([.eventForEffect1]))
 
                 dslHandler.dispose()
@@ -208,7 +203,6 @@ class EffectRouterDSLTests: QuickSpec {
                     }
 
                 dslHandler.accept(.effect1)
-                dslHandler.accept(.effect2)
                 expect(performedEffects).to(equal([.effect1]))
                 expect(didDispatchEvents).to(beFalse())
             }

--- a/MobiusCore/Test/EffectHandlers/EffectRouterTests.swift
+++ b/MobiusCore/Test/EffectHandlers/EffectRouterTests.swift
@@ -99,15 +99,10 @@ class EffectRouterTests: QuickSpec {
         }
 
         context("Router error cases") {
-            var didCrash: Bool!
             var route: Consumer<Effect>!
             var dispose: (() -> Void)!
 
             beforeEach {
-                didCrash = false
-                MobiusHooks.setErrorHandler { _, _, _ in
-                    didCrash = true
-                }
                 let handler = EffectHandler<Effect, Event>(
                     handle: { _, _ in },
                     disposable: AnonymousDisposable {}
@@ -126,15 +121,11 @@ class EffectRouterTests: QuickSpec {
             }
 
             it("should crash if more than 1 effect handler could be found") {
-                route(.multipleHandlersForThisEffect)
-
-                expect(didCrash).to(beTrue())
+                expect(route(.multipleHandlersForThisEffect)).to(throwAssertion())
             }
 
             it("should crash if no effect handlers could be found") {
-                route(.noHandlersForThisEffect)
-
-                expect(didCrash).to(beTrue())
+                expect(route(.noHandlersForThisEffect)).to(throwAssertion())
             }
         }
     }

--- a/MobiusCore/Test/EffectRouterBuilderTests.swift
+++ b/MobiusCore/Test/EffectRouterBuilderTests.swift
@@ -103,36 +103,18 @@ class EffectRouterBuilderTests: QuickSpec {
                 }
 
                 context("when that effect is dispatched") {
-                    var mobiusError: String?
-                    beforeEach {
-                        MobiusHooks.setErrorHandler({ (error: String, _, _) in
-                            mobiusError = error
-                        })
-
-                        sut.build().connect(outputHandler).accept(effect)
-                    }
-
                     it("should generate an error in the error handler") {
-                        expect(mobiusError).toNot(beNil())
+                        expect { sut.build().connect(outputHandler).accept(effect) }.to(throwAssertion())
                     }
                 }
             }
 
             context("when adding no effect handler for an effect") {
                 context("when that effect is dispatched") {
-                    var mobiusError: String?
-
                     let effect = "Effect"
-                    beforeEach {
-                        MobiusHooks.setErrorHandler({ (error: String, _, _) in
-                            mobiusError = error
-                        })
-
-                        sut.build().connect(outputHandler).accept(effect)
-                    }
 
                     it("should generate an error in the error handler") {
-                        expect(mobiusError).toNot(beNil())
+                        expect { sut.build().connect(outputHandler).accept(effect) }.to(throwAssertion())
                     }
                 }
             }

--- a/MobiusCore/Test/EventRouterDisposalLogicalRaceRegressionTest.swift
+++ b/MobiusCore/Test/EventRouterDisposalLogicalRaceRegressionTest.swift
@@ -51,7 +51,6 @@ class EventRouterDisposalLogicalRaceRegressionTest: QuickSpec {
         describe("Effect Handler connection") {
             var controller: MobiusController<Model, Event, Effect>!
             var collaborator: EffectCollaborator!
-            var errorThrown: Bool!
             var eventSource: TestEventSource<Event>!
 
             beforeEach {
@@ -64,11 +63,6 @@ class EventRouterDisposalLogicalRaceRegressionTest: QuickSpec {
 
                 eventSource = TestEventSource()
 
-                errorThrown = false
-                MobiusHooks.setErrorHandler({ _, _, _ in
-                    errorThrown = true
-                })
-
                 func update(model: Model, event: Event) -> Next<Model, Effect> {
                     return .dispatchEffects([.effect1])
                 }
@@ -80,15 +74,10 @@ class EventRouterDisposalLogicalRaceRegressionTest: QuickSpec {
                 controller.connectView(ActionConnectable {})
             }
 
-            afterEach {
-                MobiusHooks.setDefaultErrorHandler()
-            }
-
             it("allows stopping a loop immediately after dispatching an event") {
                 controller.start()
                 eventSource.dispatch(.event1)
-                controller.stop()
-                expect(errorThrown).to(beFalse())
+                expect(controller.stop()).toNot(throwAssertion())
             }
         }
     }

--- a/MobiusCore/Test/MobiusControllerTests.swift
+++ b/MobiusCore/Test/MobiusControllerTests.swift
@@ -234,7 +234,7 @@ class MobiusControllerTests: QuickSpec {
                         controller.start()
                         controller.stop()
                     }
-                    xit("should allow dispatching an event from the event source immediately") {
+                    it("should allow dispatching an event from the event source immediately") {
                         controller.connectView(view)
                         eventSource.dispatchOnSubscribe("startup")
                         controller.start()

--- a/MobiusCore/Test/MobiusControllerTests.swift
+++ b/MobiusCore/Test/MobiusControllerTests.swift
@@ -212,6 +212,10 @@ class MobiusControllerTests: QuickSpec {
 
                 #if arch(x86_64) || arch(arm64)
                 describe("error handling") {
+                    beforeEach {
+                        controller.connectView(view)
+                    }
+
                     it("should not allow disconnecting while running") {
                         controller.start()
                         controller.disconnectView()

--- a/MobiusCore/Test/MobiusControllerTests.swift
+++ b/MobiusCore/Test/MobiusControllerTests.swift
@@ -191,7 +191,7 @@ class MobiusControllerTests: QuickSpec {
                         expect(view.recorder.items).toEventually(equal(["S"]))
                     }
                     it("should not send events to a disconnected view") {
-                        let disconnectedView = RecordingTestConnectable()
+                        let disconnectedView = RecordingTestConnectable(expectedQueue: self.viewQueue)
                         controller.connectView(disconnectedView)
                         controller.disconnectView()
 

--- a/MobiusCore/Test/MobiusHooksTests.swift
+++ b/MobiusCore/Test/MobiusHooksTests.swift
@@ -43,6 +43,11 @@ class MobiusHooksTests: QuickSpec {
                     errorCalledOnLine = #line + 1
                     MobiusHooks.onError(someString)
                 }
+
+                afterEach {
+                    MobiusHooks.setDefaultErrorHandler()
+                }
+
                 it("should use that error handler when an error occurs") {
                     expect(errorMessage).to(match(someString))
                 }

--- a/MobiusCore/Test/MobiusIntegrationTests.swift
+++ b/MobiusCore/Test/MobiusIntegrationTests.swift
@@ -18,7 +18,7 @@
 // under the License.
 
 import Foundation
-import MobiusCore
+@testable import MobiusCore
 import Nimble
 import Quick
 

--- a/MobiusCore/Test/MobiusLoopTests.swift
+++ b/MobiusCore/Test/MobiusLoopTests.swift
@@ -136,24 +136,13 @@ class MobiusLoopTests: QuickSpec {
             }
 
             describe("dispose integration tests") {
-                var errorThrown: Bool!
                 beforeEach {
                     loop = builder.start(from: "disposable")
-                    errorThrown = false
-                    MobiusHooks.setErrorHandler({ _, _, _ in
-                        errorThrown = true
-                    })
-                }
-
-                afterEach {
-                    MobiusHooks.setDefaultErrorHandler()
                 }
 
                 it("should allow disposing immediately after an effect") {
                     loop.dispatchEvent("event")
-                    loop.dispose()
-
-                    expect(errorThrown).to(beFalse())
+                    expect(loop.dispose()).toNot(throwAssertion())
                 }
 
                 it("should dispose effect handler connection on dispose") {
@@ -164,9 +153,7 @@ class MobiusLoopTests: QuickSpec {
 
                 it("should disallow events post dispose") {
                     loop.dispose()
-                    loop.dispatchEvent("nnooooo!!!")
-
-                    expect(errorThrown).to(beTrue())
+                    expect(loop.dispatchEvent("nnooooo!!!")).to(throwAssertion())
                 }
             }
 

--- a/MobiusCore/Test/TestingUtil.swift
+++ b/MobiusCore/Test/TestingUtil.swift
@@ -18,7 +18,7 @@
 // under the License.
 
 import Foundation
-import MobiusCore
+@testable import MobiusCore
 import Nimble
 
 class SimpleTestConnectable: Connectable {
@@ -195,30 +195,5 @@ class TestEventSource<Event>: EventSource {
         activeSubscriptions.forEach {
             $0(event)
         }
-    }
-}
-
-/*
- Helper to simulate atomic access to a property.
-
- This could be a property wrapper when we raise our target to Swift 5.1.
- */
-final class Synchronized<Value> {
-    private var _value: Value
-    private var lock = DispatchQueue(label: "TestUtil Synchronized lock")
-
-    var value: Value {
-        get { return lock.sync { _value } }
-        set(newValue) { lock.sync { _value = newValue } }
-    }
-
-    func mutate(with closure: (inout Value) -> Void) {
-        lock.sync {
-            closure(&_value)
-        }
-    }
-
-    init(value: Value) {
-        _value = value
     }
 }

--- a/MobiusCore/Test/TestingUtil.swift
+++ b/MobiusCore/Test/TestingUtil.swift
@@ -56,7 +56,11 @@ class RecordingTestConnectable: Connectable {
     }
 
     func dispatch(_ string: String) {
-        consumer?(string)
+        if let queue = self.expectedQueue {
+            queue.sync { consumer?(string) }
+        } else {
+            consumer?(string)
+        }
     }
 
     func accept(_ value: String) {

--- a/MobiusCore/Test/TestingUtil.swift
+++ b/MobiusCore/Test/TestingUtil.swift
@@ -201,3 +201,16 @@ class TestEventSource<Event>: EventSource {
         }
     }
 }
+
+/// Wrapper around `DispatchQueue.sync` which forwards `BadInstructionException`s to the calling queue.
+///
+/// Use with `MobiusHooks.dispatchSync` to catch precondition failures on `MobiusController`’s queue.
+func exceptionForwardingDispatchSync(queue: DispatchQueue, closure: @escaping () -> Void) {
+    var exception: BadInstructionException?
+
+    queue.sync {
+        exception = catchBadInstruction(in: closure)
+    }
+
+    exception?.raise()
+}


### PR DESCRIPTION
The use of `MobiusHooks` to filter assertions so we can test them is quite unpleasant. As it turns out, it was also causing tests to pass which shouldn’t have, in some cases because of hooks being set and not cleared in other tests (which made the results different depending on whether you ran all the tests or just one test suite).

Fortunately (?), Nimble now incorporates a [horrible, horrible hack](http://www.cocoawithlove.com/blog/2016/02/02/partial-functions-part-two-catching-precondition-failures.html) which allows for ergonomic testing of assertions. Yay!

The first three commits are #89 and can be ignored here.