### PR TITLE
[RFC] Use inout signature for update function

### DIFF
--- a/MobiusCore/Source/EventProcessor.swift
+++ b/MobiusCore/Source/EventProcessor.swift
@@ -67,14 +67,9 @@ class EventProcessor<Model, Event, Effect>: Disposable, CustomDebugStringConvert
 
     func accept(_ event: Event) {
         access.guard {
-            if let current = self.currentModel {
-                let next = self.update.update(model: current, event: event)
-
-                if let newModel = next.model {
-                    self.currentModel = newModel
-                }
-
-                self.publisher.post(next)
+            if self.currentModel != nil {
+                let effects = self.update.update(into: &self.currentModel!, event: event)
+                self.publisher.post(.next(self.currentModel!, effects: effects))
             } else {
                 self.queuedEvents.append(event)
             }

--- a/MobiusCore/Source/EventProcessor.swift
+++ b/MobiusCore/Source/EventProcessor.swift
@@ -42,7 +42,7 @@ class EventProcessor<Model, Event, Effect>: Disposable, CustomDebugStringConvert
     }
 
     init(
-        update: @escaping Update<Model, Event, Effect>,
+        update: Update<Model, Event, Effect>,
         publisher: ConnectablePublisher<Next<Model, Effect>>,
         accessGuard: ConcurrentAccessDetector = ConcurrentAccessDetector()
     ) {
@@ -68,7 +68,7 @@ class EventProcessor<Model, Event, Effect>: Disposable, CustomDebugStringConvert
     func accept(_ event: Event) {
         access.guard {
             if let current = self.currentModel {
-                let next = self.update(current, event)
+                let next = self.update.update(model: current, event: event)
 
                 if let newModel = next.model {
                     self.currentModel = newModel

--- a/MobiusCore/Source/LoggingAdaptors.swift
+++ b/MobiusCore/Source/LoggingAdaptors.swift
@@ -59,9 +59,9 @@ extension Update {
     func logging<L: MobiusLogger>(_ logger: L) -> Update where L.Model == Model, L.Event == Event, L.Effect == Effect {
         return Update { model, event in
             logger.willUpdate(model: model, event: event)
-            let next = self.update(model: model, event: event)
-            logger.didUpdate(model: model, event: event, next: next)
-            return next
+            let effects = self.update(into: &model, event: event)
+            logger.didUpdate(model: model, event: event, next: Next(model: model, effects: effects))
+            return effects
         }
     }
 }

--- a/MobiusCore/Source/Mobius.swift
+++ b/MobiusCore/Source/Mobius.swift
@@ -65,6 +65,22 @@ public extension Mobius {
         )
     }
 
+    /// A convenience version of `loop` that takes an unwrapped update function.
+    ///
+    /// - Parameters:
+    ///   - update: the update function of the loop
+    ///   - effectHandler: an instance conforming to the `ConnectableProtocol`. Will be used to handle effects by the loop
+    /// - Returns: a `Builder` instance that you can further configure before starting the loop
+    static func loop<Model, Event, Effect, C: Connectable>(
+        update: @escaping (Model, Event) -> Next<Model, Effect>,
+        effectHandler: C
+    ) -> Builder<Model, Event, Effect> where C.InputType == Effect, C.OutputType == Event {
+        return self.loop(
+            update: Update(update),
+            effectHandler: effectHandler
+        )
+    }
+
     struct Builder<Model, Event, Effect> {
         private let update: Update<Model, Event, Effect>
         private let effectHandler: AnyConnectable<Effect, Event>

--- a/MobiusCore/Source/Mobius.swift
+++ b/MobiusCore/Source/Mobius.swift
@@ -19,10 +19,11 @@
 
 import Foundation
 
+/// A wrapper around an update function.
 public struct Update<Model, Event, Effect> {
     private let update: (Model, Event) -> Next<Model, Effect>
 
-    public init(update: @escaping (Model, Event) -> Next<Model, Effect>) {
+    public init(_ update: @escaping (Model, Event) -> Next<Model, Effect>) {
         self.update = update
     }
 

--- a/MobiusCore/Source/MobiusLoop.swift
+++ b/MobiusCore/Source/MobiusLoop.swift
@@ -104,7 +104,7 @@ public final class MobiusLoop<Model, Event, Effect>: Disposable, CustomDebugStri
 
     // swiftlint:disable:next function_parameter_count
     static func createLoop<C: Connectable>(
-        update: @escaping Update<Model, Event, Effect>,
+        update: Update<Model, Event, Effect>,
         effectHandler: C,
         initialModel: Model,
         initiator: @escaping Initiator<Model, Effect>,
@@ -114,7 +114,7 @@ public final class MobiusLoop<Model, Event, Effect>: Disposable, CustomDebugStri
     ) -> MobiusLoop where C.InputType == Effect, C.OutputType == Event {
         let accessGuard = ConcurrentAccessDetector()
         let loggingInitiator = LoggingInitiator(initiator, logger)
-        let loggingUpdate = LoggingUpdate(update, logger)
+        let loggingUpdate = update.logging(logger)
         let workBag = WorkBag(accessGuard: accessGuard)
 
         // create somewhere for the event processor to push nexts to; later, we'll observe these nexts and
@@ -123,7 +123,7 @@ public final class MobiusLoop<Model, Event, Effect>: Disposable, CustomDebugStri
 
         // event processor: process events, publish Next:s, retain current model
         let eventProcessor = EventProcessor(
-            update: loggingUpdate.update,
+            update: loggingUpdate,
             publisher: nextPublisher,
             accessGuard: accessGuard
         )

--- a/MobiusCore/Test/EventProcessorTests.swift
+++ b/MobiusCore/Test/EventProcessorTests.swift
@@ -118,6 +118,7 @@ class EventProcessorTests: QuickSpec {
     }
 
     let testUpdate = Update<Int, Int, Int> { model, event in
-        Next.next(model + event)
+        model += event
+        return []
     }
 }

--- a/MobiusCore/Test/EventProcessorTests.swift
+++ b/MobiusCore/Test/EventProcessorTests.swift
@@ -117,7 +117,7 @@ class EventProcessorTests: QuickSpec {
         }
     }
 
-    func testUpdate(model: Int, event: Int) -> Next<Int, Int> {
+    let testUpdate = Update<Int, Int, Int> { model, event in
         return Next.next(model + event)
     }
 }

--- a/MobiusCore/Test/EventProcessorTests.swift
+++ b/MobiusCore/Test/EventProcessorTests.swift
@@ -118,6 +118,6 @@ class EventProcessorTests: QuickSpec {
     }
 
     let testUpdate = Update<Int, Int, Int> { model, event in
-        return Next.next(model + event)
+        Next.next(model + event)
     }
 }

--- a/MobiusCore/Test/EventRouterDisposalLogicalRaceRegressionTest.swift
+++ b/MobiusCore/Test/EventRouterDisposalLogicalRaceRegressionTest.swift
@@ -69,9 +69,7 @@ class EventRouterDisposalLogicalRaceRegressionTest: QuickSpec {
                     errorThrown = true
                 })
 
-                let update = Update<Model, Event, Effect> { _, _ in
-                    .dispatchEffects([.effect1])
-                }
+                let update = Update<Model, Event, Effect> { _, _ in [.effect1] }
 
                 controller = Mobius.loop(update: update, effectHandler: effectHandler)
                     .withEventSource(eventSource)

--- a/MobiusCore/Test/EventRouterDisposalLogicalRaceRegressionTest.swift
+++ b/MobiusCore/Test/EventRouterDisposalLogicalRaceRegressionTest.swift
@@ -69,7 +69,7 @@ class EventRouterDisposalLogicalRaceRegressionTest: QuickSpec {
                     errorThrown = true
                 })
 
-                func update(model: Model, event: Event) -> Next<Model, Effect> {
+                let update = Update<Model, Event, Effect> { _, _ in
                     return .dispatchEffects([.effect1])
                 }
 

--- a/MobiusCore/Test/EventRouterDisposalLogicalRaceRegressionTest.swift
+++ b/MobiusCore/Test/EventRouterDisposalLogicalRaceRegressionTest.swift
@@ -70,7 +70,7 @@ class EventRouterDisposalLogicalRaceRegressionTest: QuickSpec {
                 })
 
                 let update = Update<Model, Event, Effect> { _, _ in
-                    return .dispatchEffects([.effect1])
+                    .dispatchEffects([.effect1])
                 }
 
                 controller = Mobius.loop(update: update, effectHandler: effectHandler)

--- a/MobiusCore/Test/LoggingUpdateTests.swift
+++ b/MobiusCore/Test/LoggingUpdateTests.swift
@@ -29,20 +29,22 @@ class LoggingUpdateTests: QuickSpec {
 
             beforeEach {
                 logger = TestMobiusLogger()
-                loggingUpdate = Update { model, event in Next(model: model, effects: [event]) }.logging(logger)
+                loggingUpdate = Update { _, event in [event] }.logging(logger)
             }
 
             it("should log willUpdate and didUpdate for each update attempt") {
-                _ = loggingUpdate.update(model: "from this", event: "ee")
+                var model = "from this"
+                _ = loggingUpdate.update(into: &model, event: "ee")
 
                 expect(logger.logMessages).to(equal(["willUpdate(from this, ee)", "didUpdate(from this, ee, (\"from this\", [\"ee\"]))"]))
             }
 
             it("should return update from delegate") {
-                let next = loggingUpdate.update(model: "hey", event: "event/effect")
+                var model = "hey"
+                let effects = loggingUpdate.update(into: &model, event: "event/effect")
 
-                expect(next.model).to(equal("hey"))
-                expect(next.effects).to(equal(["event/effect"]))
+                expect(model).to(equal("hey"))
+                expect(effects).to(equal(["event/effect"]))
             }
         }
     }

--- a/MobiusCore/Test/LoggingUpdateTests.swift
+++ b/MobiusCore/Test/LoggingUpdateTests.swift
@@ -25,21 +25,21 @@ class LoggingUpdateTests: QuickSpec {
     override func spec() {
         describe("LoggingUpdate") {
             var logger: TestMobiusLogger!
-            var loggingUpdate: LoggingUpdate<String, String, String>!
+            var loggingUpdate: Update<String, String, String>!
 
             beforeEach {
                 logger = TestMobiusLogger()
-                loggingUpdate = LoggingUpdate({ model, event in Next(model: model, effects: [event]) }, logger)
+                loggingUpdate = Update { model, event in Next(model: model, effects: [event]) }.logging(logger)
             }
 
             it("should log willUpdate and didUpdate for each update attempt") {
-                _ = loggingUpdate.update("from this", "ee")
+                _ = loggingUpdate.update(model: "from this", event: "ee")
 
                 expect(logger.logMessages).to(equal(["willUpdate(from this, ee)", "didUpdate(from this, ee, (\"from this\", [\"ee\"]))"]))
             }
 
             it("should return update from delegate") {
-                let next = loggingUpdate.update("hey", "event/effect")
+                let next = loggingUpdate.update(model: "hey", event: "event/effect")
 
                 expect(next.model).to(equal("hey"))
                 expect(next.effects).to(equal(["event/effect"]))

--- a/MobiusCore/Test/MobiusControllerTests.swift
+++ b/MobiusCore/Test/MobiusControllerTests.swift
@@ -46,7 +46,7 @@ class MobiusControllerTests: QuickSpec {
                 view = RecordingTestConnectable(expectedQueue: self.viewQueue)
                 let loopQueue = self.loopQueue
 
-                let updateFunction = Update<String, String, String> { model, event in
+                let updateFunction = Update<String, String, String>.create { model, event in
                     dispatchPrecondition(condition: .onQueue(loopQueue))
                     return .next("\(model)-\(event)")
                 }
@@ -136,7 +136,7 @@ class MobiusControllerTests: QuickSpec {
                     beforeEach {
                         modelObserver = MockConnectable()
                         effectObserver = MockConnectable()
-                        controller = Mobius.loop(update: Update { _, _ in .noChange }, effectHandler: effectObserver)
+                        controller = Mobius.loop(update: Update { _, _ in [] }, effectHandler: effectObserver)
                             .makeController(from: "")
                         controller.connectView(modelObserver)
                         controller.start()

--- a/MobiusCore/Test/MobiusControllerTests.swift
+++ b/MobiusCore/Test/MobiusControllerTests.swift
@@ -46,7 +46,7 @@ class MobiusControllerTests: QuickSpec {
                 view = RecordingTestConnectable(expectedQueue: self.viewQueue)
                 let loopQueue = self.loopQueue
 
-                let updateFunction: Update<String, String, String> = { model, event in
+                let updateFunction = Update<String, String, String> { model, event in
                     dispatchPrecondition(condition: .onQueue(loopQueue))
                     return .next("\(model)-\(event)")
                 }
@@ -136,7 +136,7 @@ class MobiusControllerTests: QuickSpec {
                     beforeEach {
                         modelObserver = MockConnectable()
                         effectObserver = MockConnectable()
-                        controller = Mobius.loop(update: { _, _ in .noChange }, effectHandler: effectObserver)
+                        controller = Mobius.loop(update: Update { _, _ in .noChange }, effectHandler: effectObserver)
                             .makeController(from: "")
                         controller.connectView(modelObserver)
                         controller.start()

--- a/MobiusCore/Test/MobiusIntegrationTests.swift
+++ b/MobiusCore/Test/MobiusIntegrationTests.swift
@@ -37,18 +37,23 @@ class MobiusIntegrationTests: QuickSpec {
                     }
                 }
 
-                let update = Update<String, String, String> { _, event in
+                let update = Update<String, String, String> { model, event in
                     switch event {
                     case "button pushed":
-                        return Next.next("pushed")
+                        model = "pushed"
+                        return []
                     case "trigger effect":
-                        return Next.next("triggered", effects: ["leads to event"])
+                        model = "triggered"
+                        return ["leads to event"]
                     case "effect feedback":
-                        return Next.next("done")
+                        model = "done"
+                        return []
                     case "from source":
-                        return Next.next("event sourced")
+                        model = "event sourced"
+                        return []
                     default:
-                        fatalError("unexpected event \(event)")
+                        model = "unexpected event \(event)"
+                        return []
                     }
                 }
             }

--- a/MobiusCore/Test/MobiusIntegrationTests.swift
+++ b/MobiusCore/Test/MobiusIntegrationTests.swift
@@ -37,7 +37,7 @@ class MobiusIntegrationTests: QuickSpec {
                     }
                 }
 
-                func update(model: String, event: String) -> Next<String, String> {
+                let update = Update<String, String, String> { model, event in
                     switch event {
                     case "button pushed":
                         return Next.next("pushed")

--- a/MobiusCore/Test/MobiusIntegrationTests.swift
+++ b/MobiusCore/Test/MobiusIntegrationTests.swift
@@ -37,7 +37,7 @@ class MobiusIntegrationTests: QuickSpec {
                     }
                 }
 
-                let update = Update<String, String, String> { model, event in
+                let update = Update<String, String, String> { _, event in
                     switch event {
                     case "button pushed":
                         return Next.next("pushed")

--- a/MobiusCore/Test/MobiusLoopTests.swift
+++ b/MobiusCore/Test/MobiusLoopTests.swift
@@ -56,7 +56,7 @@ class MobiusLoopTests: QuickSpec {
 
                 modelObserver = { receivedModels.append($0) }
 
-                let update: Update<String, String, String> = { _, event in Next.next(event) }
+                let update = Update<String, String, String> { _, event in Next.next(event) }
 
                 effectHandler = SimpleTestConnectable()
 
@@ -114,7 +114,7 @@ class MobiusLoopTests: QuickSpec {
                 }
 
                 it("should queue up events dispatched before start to support racy initialisations") {
-                    loop = Mobius.loop(update: { model, event in .next(model + "-" + event) }, effectHandler: EagerEffectHandler())
+                    loop = Mobius.loop(update: Update { model, event in .next(model + "-" + event) }, effectHandler: EagerEffectHandler())
                         .start(from: "the beginning")
 
                     loop.addObserver(modelObserver)
@@ -177,7 +177,7 @@ class MobiusLoopTests: QuickSpec {
 
                 beforeEach {
                     eventProcessor = TestEventProcessor(
-                        update: { _, _ in .noChange },
+                        update: Update { _, _ in .noChange },
                         publisher: ConnectablePublisher()
                     )
                     modelPublisher = ConnectablePublisher<String>()
@@ -238,7 +238,7 @@ class MobiusLoopTests: QuickSpec {
             describe("when creating a builder") {
                 context("when a class corresponding to the ConnectableProtocol is used as effecthandler") {
                     beforeEach {
-                        let update = { (_: String, _: String) -> Next<String, String> in
+                        let update = Update { (_: String, _: String) -> Next<String, String> in
                             Next<String, String>.noChange
                         }
 
@@ -256,7 +256,7 @@ class MobiusLoopTests: QuickSpec {
                 beforeEach {
                     let publisher = ConnectablePublisher<String>()
                     let eventProcessor = TestEventProcessor<String, String, String>(
-                        update: { _, _ in .noChange },
+                        update: Update { _, _ in .noChange },
                         publisher: ConnectablePublisher<Next<String, String>>()
                     )
                     eventProcessor.desiredDebugDescription = eventProcessorDebugDescription
@@ -302,7 +302,7 @@ class MobiusLoopTests: QuickSpec {
                 let effectConnectable = EffectRouter<Int, Int>()
                     .routeEffects(withPayload: payload).to(effectHandler)
                     .asConnectable
-                let update = { (_: Int, _: Int) -> Next<Int, Int> in Next.dispatchEffects([1]) }
+                let update = Update { (_: Int, _: Int) -> Next<Int, Int> in Next.dispatchEffects([1]) }
                 loop = Mobius
                     .loop(update: update, effectHandler: effectConnectable)
                     .start(from: 0)

--- a/MobiusExtras/Test/EventHandlerDisposalLogicalRaceRegressionTest.swift
+++ b/MobiusExtras/Test/EventHandlerDisposalLogicalRaceRegressionTest.swift
@@ -62,9 +62,7 @@ class EventHandlerDisposalLogicalRaceRegressionTest: QuickSpec {
                     errorThrown = true
                 })
 
-                let update = Update<Model, Event, Effect> { _, _ in
-                    .dispatchEffects([.effect1])
-                }
+                let update = Update<Model, Event, Effect> { _, _ in [.effect1] }
 
                 controller = Mobius.loop(update: update, effectHandler: effectHandler)
                     .withEventSource(eventSource)

--- a/MobiusExtras/Test/EventHandlerDisposalLogicalRaceRegressionTest.swift
+++ b/MobiusExtras/Test/EventHandlerDisposalLogicalRaceRegressionTest.swift
@@ -63,7 +63,7 @@ class EventHandlerDisposalLogicalRaceRegressionTest: QuickSpec {
                 })
 
                 let update = Update<Model, Event, Effect> { _, _ in
-                    return .dispatchEffects([.effect1])
+                    .dispatchEffects([.effect1])
                 }
 
                 controller = Mobius.loop(update: update, effectHandler: effectHandler)

--- a/MobiusExtras/Test/EventHandlerDisposalLogicalRaceRegressionTest.swift
+++ b/MobiusExtras/Test/EventHandlerDisposalLogicalRaceRegressionTest.swift
@@ -62,7 +62,7 @@ class EventHandlerDisposalLogicalRaceRegressionTest: QuickSpec {
                     errorThrown = true
                 })
 
-                func update(model: Model, event: Event) -> Next<Model, Effect> {
+                let update = Update<Model, Event, Effect> { _, _ in
                     return .dispatchEffects([.effect1])
                 }
 

--- a/MobiusNimble/Test/NimbleNextMatchersTests.swift
+++ b/MobiusNimble/Test/NimbleNextMatchersTests.swift
@@ -48,8 +48,9 @@ class NimbleNextMatchersTests: QuickSpec {
                 NimbleAssertionHandler = defaultHandler!
             }
 
-            let testUpdate = Update<String, String, String> { _, _ in
-                .next("some model", effects: ["some effect"])
+            let testUpdate = Update<String, String, String> { model, _ in
+                model = "some model"
+                return ["some effect"]
             }
 
             // Testing through proxy: UpdateSpec

--- a/MobiusNimble/Test/NimbleNextMatchersTests.swift
+++ b/MobiusNimble/Test/NimbleNextMatchersTests.swift
@@ -48,8 +48,8 @@ class NimbleNextMatchersTests: QuickSpec {
                 NimbleAssertionHandler = defaultHandler!
             }
 
-            let testUpdate = Update<String, String, String> { model, event in
-                return .next("some model", effects: ["some effect"])
+            let testUpdate = Update<String, String, String> { _, _ in
+                .next("some model", effects: ["some effect"])
             }
 
             // Testing through proxy: UpdateSpec

--- a/MobiusNimble/Test/NimbleNextMatchersTests.swift
+++ b/MobiusNimble/Test/NimbleNextMatchersTests.swift
@@ -48,7 +48,7 @@ class NimbleNextMatchersTests: QuickSpec {
                 NimbleAssertionHandler = defaultHandler!
             }
 
-            func testUpdate(model: String, event: String) -> Next<String, String> {
+            let testUpdate = Update<String, String, String> { model, event in
                 return .next("some model", effects: ["some effect"])
             }
 

--- a/MobiusTest/Source/UpdateSpec.swift
+++ b/MobiusTest/Source/UpdateSpec.swift
@@ -58,16 +58,15 @@ public struct UpdateSpec<Model, Event, Effect> {
         }
 
         public func then(_ expression: Assert) {
-            var lastNext: Next<Model, Effect>?
+            var lastEffects: [Effect]?
             var lastModel = model
 
             for event in events {
-                lastNext = update.update(model: lastModel, event: event)
-                lastModel = lastNext?.model ?? lastModel
+                lastEffects = update.update(into: &lastModel, event: event)
             }
 
             // there will always be at least one event, so lastNext is guaranteed to have a value
-            expression(Result(model: lastModel, lastNext: lastNext!))
+            expression(Result(model: lastModel, lastNext: .next(lastModel, effects: lastEffects!)))
         }
     }
 

--- a/MobiusTest/Source/UpdateSpec.swift
+++ b/MobiusTest/Source/UpdateSpec.swift
@@ -24,7 +24,7 @@ public struct UpdateSpec<Model, Event, Effect> {
 
     private let update: Update<Model, Event, Effect>
 
-    public init(_ update: @escaping Update<Model, Event, Effect>) {
+    public init(_ update: Update<Model, Event, Effect>) {
         self.update = update
     }
 
@@ -36,7 +36,7 @@ public struct UpdateSpec<Model, Event, Effect> {
         private let update: Update<Model, Event, Effect>
         private let model: Model
 
-        init(_ update: @escaping Update<Model, Event, Effect>, _ model: Model) {
+        init(_ update: Update<Model, Event, Effect>, _ model: Model) {
             self.update = update
             self.model = model
         }
@@ -51,7 +51,7 @@ public struct UpdateSpec<Model, Event, Effect> {
         private let model: Model
         private let events: [Event]
 
-        init(_ update: @escaping Update<Model, Event, Effect>, _ model: Model, _ events: [Event]) {
+        init(_ update: Update<Model, Event, Effect>, _ model: Model, _ events: [Event]) {
             self.update = update
             self.model = model
             self.events = events
@@ -62,7 +62,7 @@ public struct UpdateSpec<Model, Event, Effect> {
             var lastModel = model
 
             for event in events {
-                lastNext = update(lastModel, event)
+                lastNext = update.update(model: lastModel, event: event)
                 lastModel = lastNext?.model ?? lastModel
             }
 

--- a/MobiusTest/Test/NextMatchersTests.swift
+++ b/MobiusTest/Test/NextMatchersTests.swift
@@ -42,7 +42,7 @@ class XCTestNextMatchersTests: QuickSpec {
                 failMessages = []
             }
 
-            let testUpdate = Update<String, String, String> { _, _ in
+            let testUpdate = Update<String, String, String>.create { _, _ in
                 .next("some model", effects: ["some effect"])
             }
 

--- a/MobiusTest/Test/NextMatchersTests.swift
+++ b/MobiusTest/Test/NextMatchersTests.swift
@@ -42,8 +42,8 @@ class XCTestNextMatchersTests: QuickSpec {
                 failMessages = []
             }
 
-            let testUpdate = Update<String, String, String> { model, event in
-                return .next("some model", effects: ["some effect"])
+            let testUpdate = Update<String, String, String> { _, _ in
+                .next("some model", effects: ["some effect"])
             }
 
             // Testing through proxy: UpdateSpec

--- a/MobiusTest/Test/NextMatchersTests.swift
+++ b/MobiusTest/Test/NextMatchersTests.swift
@@ -42,7 +42,7 @@ class XCTestNextMatchersTests: QuickSpec {
                 failMessages = []
             }
 
-            func testUpdate(model: String, event: String) -> Next<String, String> {
+            let testUpdate = Update<String, String, String> { model, event in
                 return .next("some model", effects: ["some effect"])
             }
 

--- a/MobiusTest/Test/UpdateSpecTests.swift
+++ b/MobiusTest/Test/UpdateSpecTests.swift
@@ -111,7 +111,7 @@ class UpdateSpecTests: QuickSpec {
         }
     }
 
-    let myUpdate = Update<MyModel, MyEvent, MyEffect> { model, event in
+    let myUpdate = Update<MyModel, MyEvent, MyEffect>.create { model, event in
         switch event {
         case .didTapButton:
             return Next.next(MyModel(buttonClicked: !model.buttonClicked, count: model.count + 1))

--- a/MobiusTest/Test/UpdateSpecTests.swift
+++ b/MobiusTest/Test/UpdateSpecTests.swift
@@ -111,7 +111,7 @@ class UpdateSpecTests: QuickSpec {
         }
     }
 
-    func myUpdate(_ model: MyModel, _ event: MyEvent) -> Next<MyModel, MyEffect> {
+    let myUpdate = Update<MyModel, MyEvent, MyEffect> { model, event in
         switch event {
         case .didTapButton:
             return Next.next(MyModel(buttonClicked: !model.buttonClicked, count: model.count + 1))


### PR DESCRIPTION
(**NB**: This PR is technically based off of #92, but until #92 is merged we won't be able to see the minimal diff here. To see the true diff click [here](https://github.com/stephencelis/Mobius.swift/compare/update-struct...stephencelis:inout))

## What

This changes the signature of `Update` to be of the form `(inout Model, Event) -> [Effect]` instead of `(Model, Event) -> (Model, [Effect])`.

Although it may seem that allowing mutation in the reducer is not something we want, it is in fact no different to returning a new model, thanks to Swift's value types. The mutation is locally scoped to just the invocation of this function, as opposed to reference type mutations, which can travel far and are not controlled.

There are two main benefits to doing this:

### Simpler reducers

Implementations of reducers can be simpler. Currently you must construct a new model to return from a reducer, which can be done in 3 different ways:

* Construct it from scratch each time:
     ```swift
     func update(model: MyModel, event: Event) -> Next<Model, Effect> {
       return Next(MyModel(id: model.id, name: model.name, isAdmin: true))
     }
     ```
    This can get really tedious for large models.
* Adopt a "builder" pattern for models:
     ```swift
     func update(model: MyModel, event: Event) -> Next<Model, Effect> {
       return Next(model.builder().isAdmin(true).build())
     }
     ```
     This requires some kind of code generation to give us access to these builder methods.
* Make a mutable copy, and then return it at the end:
     ```swift
     func update(model: MyModel, event: Event) -> Next<Model, Effect> {
       var model = model
       model.isAdmin = true
       return Next(model)
     }
     ```
    This is boilerplate that will be done in every reducer, and either requires shadowing the model or potentially having two different versions of the model in the scope of this function.

Alternatively, with `inout` we can just apply the mutations directly without any set up, and then return the effects:

```swift
func update(model: MyModel, event: Event) -> [Effect] {
  model.isAdmin = true
  return []
}
```

### More efficient reducers

Reducers no longer need to make entirely new copies of the model every time an event is dispatched. This may not always be a concern, but for very large models it could become a problem.
