### PR TITLE
Display name of effect without exactly 1 effect handler

### DIFF
--- a/MobiusCore/Source/EffectHandlers/EffectRouter.swift
+++ b/MobiusCore/Source/EffectHandlers/EffectRouter.swift
@@ -89,7 +89,7 @@ private func compose<Effect, Event>(
                     .count
 
                 if handledCount != 1 {
-                    MobiusHooks.onError("Error: \(handledCount) EffectHandlers could be found for effect: \(handledCount). Exactly 1 is required.")
+                    MobiusHooks.onError("Error: \(handledCount) EffectHandlers could be found for effect: \(effect). Exactly 1 is required.")
                 }
             },
             disposeClosure: {


### PR DESCRIPTION
This PR fixes a small typo which caused the name of the effect without exactly 1 `EffectHandler` not to be printed out, making it harder to debug the fatal error.

Before: 
```
Fatal error: Error: 0 EffectHandlers could be found for effect: 0. Exactly 1 is required.
```
After: 
```
Fatal error: Error: 0 EffectHandlers could be found for effect: requestDevices. Exactly 1 is required.
```