### PR TITLE
Avoid spurious access guard violation when dispatching events from views

### DIFF
--- a/MobiusCore/Source/EventProcessor.swift
+++ b/MobiusCore/Source/EventProcessor.swift
@@ -28,6 +28,7 @@ class EventProcessor<Model, Event, Effect>: Disposable, CustomDebugStringConvert
 
     private var currentModel: Model?
     private var queuedEvents = [Event]()
+    private var disposed = false
 
     public var debugDescription: String {
         return access.guard {
@@ -67,6 +68,8 @@ class EventProcessor<Model, Event, Effect>: Disposable, CustomDebugStringConvert
 
     func accept(_ event: Event) {
         access.guard {
+            guard !disposed else { return }
+
             if let current = self.currentModel {
                 let next = self.update(current, event)
 
@@ -83,6 +86,7 @@ class EventProcessor<Model, Event, Effect>: Disposable, CustomDebugStringConvert
 
     func dispose() {
         access.guard {
+            disposed = true
             publisher.dispose()
         }
     }

--- a/MobiusCore/Source/MobiusController.swift
+++ b/MobiusCore/Source/MobiusController.swift
@@ -110,6 +110,12 @@ public final class MobiusController<Model, Event, Effect> {
         loopFactory = builder.withEventConsumerTransformer(flipEventsToLoopQueue).start
     }
 
+    deinit {
+        if running {
+           stop()
+        }
+    }
+
     /// Connect a view to this controller.
     ///
     /// Must be called before `start`. May not be called directly from the update function or an effect handler running

--- a/MobiusCore/Source/MobiusLoop.swift
+++ b/MobiusCore/Source/MobiusLoop.swift
@@ -104,11 +104,7 @@ public final class MobiusLoop<Model, Event, Effect>: Disposable, CustomDebugStri
     /// This should not be used directly, but is useful in constructing asynchronous wrappers around loops (like
     /// `MobiusController`, where the eventConsumerTransformer is used to implement equivalent async-safe assertions).
     public func unguardedDispatchEvent(_ event: Event) {
-        return access.guard {
-            if !disposed {
-                consumeEvent(event)
-            }
-        }
+        consumeEvent(event)
     }
 
     // swiftlint:disable:next function_parameter_count


### PR DESCRIPTION
We were occasionally hitting this `access.guard` in unit tests (well, one in ~250 times for me, apparently more often for Stephen). The whole point of `unguardedDispatchEvent` is to allow us to call the thread-flipping transformed version of `dispatchEvent`, so checking that we do it from the “right” thread makes no sense.

We shouldn’t check `disposed` in `MobiusLoop` without an access guard, so the check is now duplicated in the `EventProcessor`.

@jeppes 