### PR TITLE
Disable ConnectableClass assertion

### DIFF
--- a/MobiusExtras/Source/ConnectableClass.swift
+++ b/MobiusExtras/Source/ConnectableClass.swift
@@ -54,7 +54,7 @@ open class ConnectableClass<InputType, OutputType>: Connectable {
             lock.unlock()
         }
         guard let consumer = consumer else {
-            handleError("\(type(of: self)) is unable to send \(type(of: output)) before any consumer has been set. Send should only be used once the Connectable has been properly connected.")
+            // handleError("\(type(of: self)) is unable to send \(type(of: output)) before any consumer has been set. Send should only be used once the Connectable has been properly connected.")
             return
         }
 

--- a/MobiusExtras/Test/ConnectableClassTests.swift
+++ b/MobiusExtras/Test/ConnectableClassTests.swift
@@ -106,7 +106,7 @@ class ConnectableTests: QuickSpec {
                         sut.handleError = handleError
                     }
 
-                    it("should cause a mobius error") {
+                    xit("should cause a mobius error") {
                         sut.send("Some string")
                         expect(errorThrown).to(beTrue())
                     }


### PR DESCRIPTION
We've disabled this in production because it's not critical and was being hit occasionally. We have a regression test which _was_ hitting it 100% of the time, but is now hitting it about 0.05% of the time. Since use of ConnectableClass for effect handlers is deprecated, we don't want to spend the time to track down the cause.

@jeppes 