### PR TITLE
Add ability to end with events in `EventCallback`

### DIFF
--- a/MobiusCore/Source/EffectHandlers/EffectCallback.swift
+++ b/MobiusCore/Source/EffectHandlers/EffectCallback.swift
@@ -21,6 +21,7 @@ import Foundation
 
 /// An `EffectCallback` can send output and signal completion.
 /// Sending output is done with `.send` and signaling completion is done with `.end`.
+/// You can also end in conjunction with sending output using `.end(with:)`
 ///
 /// Note: Once `.end` has been called (from any thread), the closure you provide in `onSend` will no longer be called.
 /// Note: The closure you provide in `onEnd` will only be called once when `.end` is called on this object.

--- a/MobiusCore/Source/EffectHandlers/EffectCallback.swift
+++ b/MobiusCore/Source/EffectHandlers/EffectCallback.swift
@@ -53,6 +53,17 @@ public final class EffectCallback<Output> {
         }
     }
 
+    public func end(with outputs: Output...) {
+        end(with: outputs)
+    }
+
+    public func end(with outputs: [Output]) {
+        for output in outputs {
+            send(output)
+        }
+        end()
+    }
+
     public func send(_ output: Output) {
         _ended.mutate {
             if !$0 {

--- a/MobiusCore/Test/EffectHandlers/CallbackTests.swift
+++ b/MobiusCore/Test/EffectHandlers/CallbackTests.swift
@@ -86,6 +86,18 @@ class CallbackTests: QuickSpec {
                     callback.send(3)
                     expect(output).to(equal([1, 2]))
                 }
+
+                it("sends events before ending when using `.end(with:)` with varargs") {
+                    callback.end(with: 1, 2, 3)
+                    expect(output).to(equal([1, 2, 3]))
+                    expect(callback.ended).to(beTrue())
+                }
+
+                it("sends events before ending when using `.end(with:)` with an array") {
+                    callback.end(with: [1, 2, 3])
+                    expect(output).to(equal([1, 2, 3]))
+                    expect(callback.ended).to(beTrue())
+                }
             }
         }
     }


### PR DESCRIPTION
Add the ability to end an `EventCallback` with a number of events to output.
Instead of:
```swift
callback.send(1)
callback.send(2)
callback.end()
```
You would write:
```swift
callback.end(with: 1, 2)
```

Thanks to @kmcbride and @rastersize for this suggestion.

@pettermahlen @JensAyton 