### PR TITLE
Add a single API for unwrapping Enums and routing to Enum constants

### DIFF
--- a/Mobius.xcodeproj/project.pbxproj
+++ b/Mobius.xcodeproj/project.pbxproj
@@ -19,6 +19,8 @@
 		02D0DDC02366F08300A1CE4C /* EffectHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02D0DDBF2366F08300A1CE4C /* EffectHandler.swift */; };
 		02D0DDC52366F56C00A1CE4C /* EffectHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02D0DDC22366F49200A1CE4C /* EffectHandlerTests.swift */; };
 		02D0DDC723672E6400A1CE4C /* EffectHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02D0DDBF2366F08300A1CE4C /* EffectHandler.swift */; };
+		02D6755323D1E822008200AF /* EnumRoute.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02D6755223D1E822008200AF /* EnumRoute.swift */; };
+		02D6755723D20507008200AF /* EnumRouteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02D6755423D2049E008200AF /* EnumRouteTests.swift */; };
 		2D15DF73238EA4DD00E78B27 /* LoggingAdaptors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D15DF72238EA4DD00E78B27 /* LoggingAdaptors.swift */; };
 		2D3A69662354AC820053C95E /* ConcurrentAccessDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D3A69652354AC820053C95E /* ConcurrentAccessDetector.swift */; };
 		2D3A69672354AC820053C95E /* ConcurrentAccessDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D3A69652354AC820053C95E /* ConcurrentAccessDetector.swift */; };
@@ -264,6 +266,8 @@
 		02CEC48F2379642C00BA1584 /* EffectRouterDSLTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EffectRouterDSLTests.swift; sourceTree = "<group>"; };
 		02D0DDBF2366F08300A1CE4C /* EffectHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EffectHandler.swift; sourceTree = "<group>"; };
 		02D0DDC22366F49200A1CE4C /* EffectHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EffectHandlerTests.swift; sourceTree = "<group>"; };
+		02D6755223D1E822008200AF /* EnumRoute.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnumRoute.swift; sourceTree = "<group>"; };
+		02D6755423D2049E008200AF /* EnumRouteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnumRouteTests.swift; sourceTree = "<group>"; };
 		2D15DF72238EA4DD00E78B27 /* LoggingAdaptors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggingAdaptors.swift; sourceTree = "<group>"; };
 		2D3A69652354AC820053C95E /* ConcurrentAccessDetector.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConcurrentAccessDetector.swift; sourceTree = "<group>"; };
 		2D3A6972235737430053C95E /* WorkBag.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkBag.swift; sourceTree = "<group>"; };
@@ -459,6 +463,7 @@
 				02C4061C2373078400BD7ED8 /* EffectExecutor.swift */,
 				02CAE46F23C75E99009DFF9A /* ThreadSafeConnectable.swift */,
 				02CAE47123C76F34009DFF9A /* EffectCallback.swift */,
+				02D6755223D1E822008200AF /* EnumRoute.swift */,
 			);
 			path = EffectHandlers;
 			sourceTree = "<group>";
@@ -470,6 +475,7 @@
 				02C40622237425E100BD7ED8 /* EffectRouterTests.swift */,
 				02CEC48F2379642C00BA1584 /* EffectRouterDSLTests.swift */,
 				02CAE47323C76FA3009DFF9A /* CallbackTests.swift */,
+				02D6755423D2049E008200AF /* EnumRouteTests.swift */,
 			);
 			path = EffectHandlers;
 			sourceTree = "<group>";
@@ -1169,6 +1175,7 @@
 				5BB288182099957D0043B530 /* Connection.swift in Sources */,
 				5BB2881F209995810043B530 /* BrokenConnection.swift in Sources */,
 				5BB9346420D2A46A00A1FE3A /* EffectRouterBuilder.swift in Sources */,
+				02D6755323D1E822008200AF /* EnumRoute.swift in Sources */,
 				5B1F103C210F5EBC0067193C /* ActionConnectable.swift in Sources */,
 				5BB2881B2099957D0043B530 /* MobiusHooks.swift in Sources */,
 				5BB28824209995810043B530 /* EventProcessor.swift in Sources */,
@@ -1200,6 +1207,7 @@
 				2DDF54C3229BEEC400D05861 /* CompositeEventSourceBuilderTests.swift in Sources */,
 				02D0DDC52366F56C00A1CE4C /* EffectHandlerTests.swift in Sources */,
 				5B85AD0220AAA8CA00C4FCD5 /* MobiusHooksTests.swift in Sources */,
+				02D6755723D20507008200AF /* EnumRouteTests.swift in Sources */,
 				5BB2886D20999AD60043B530 /* MobiusControllerTests.swift in Sources */,
 				5BB2887B20999AD60043B530 /* ConnectablePublisherTests.swift in Sources */,
 				5BB2887620999AD60043B530 /* NextTests.swift in Sources */,

--- a/MobiusCore/Source/EffectHandlers/EnumRoute.swift
+++ b/MobiusCore/Source/EffectHandlers/EnumRoute.swift
@@ -32,8 +32,14 @@ public extension EffectRouter {
 public extension EffectRouter where Input: Equatable {
     func routeCase(
         _ enumCase: Input
-    ) -> PartialEffectRouter<Input, Input, Output> {
-        return routeEffects(equalTo: enumCase)
+    ) -> PartialEffectRouter<Input, Void, Output> {
+        return routeEffects(withPayload: { effect in
+            if enumCase == effect {
+                return ()
+            } else {
+                return nil
+            }
+        })
     }
 }
 

--- a/MobiusCore/Source/EffectHandlers/EnumRoute.swift
+++ b/MobiusCore/Source/EffectHandlers/EnumRoute.swift
@@ -1,0 +1,75 @@
+// Copyright (c) 2019 Spotify AB.
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import Darwin
+
+public extension EffectRouter {
+    func routeEnumCase<Payload>(
+        _ enumCase: @escaping (Payload) -> Input
+    ) -> PartialEffectRouter<Input, Payload, Output> {
+        return routeEffects(withPayload: { effect in
+            UnwrapEnum<Input, Payload>.extract(case: enumCase, from: effect)
+        })
+    }
+}
+
+public extension EffectRouter where Input: Equatable {
+    func routeCase(
+        _ enumCase: Input
+    ) -> PartialEffectRouter<Input, Input, Output> {
+        return routeEffects(equalTo: enumCase)
+    }
+}
+
+private enum UnwrapEnum<Payload, Enum> {
+    static func extract<Enum, Payload>(case: (Payload) -> Enum, from root: Enum) -> Payload? {
+        func extractHelp(from root: Enum) -> ([String], Payload)? {
+            if let value = root as? Payload {
+                var otherRoot = `case`(value)
+                var root = root
+                if memcmp(&root, &otherRoot, MemoryLayout<Enum>.size) == 0 {
+                    return ([], value)
+                }
+            }
+            var path: [String] = []
+            var any: Any = root
+            while case let (label?, anyChild)? = Mirror(reflecting: any).children.first {
+                path.append(label)
+                path.append(String(describing: type(of: anyChild)))
+                if let child = anyChild as? Payload {
+                    return (path, child)
+                }
+                any = anyChild
+            }
+            if MemoryLayout<Payload>.size == 0 {
+                return (["\(root)"], unsafeBitCast((), to: Payload.self))
+            }
+            if Payload.self == Void.self {
+                return (path, ()) as? ([String], Payload)
+            }
+            return nil
+        }
+        guard
+            let (rootPath, child) = extractHelp(from: root),
+            let (otherPath, _) = extractHelp(from: `case`(child)),
+            rootPath == otherPath
+            else { return nil }
+        return child
+    }
+}

--- a/MobiusCore/Source/EffectHandlers/EnumRoute.swift
+++ b/MobiusCore/Source/EffectHandlers/EnumRoute.swift
@@ -20,7 +20,7 @@
 import Darwin
 
 public extension EffectRouter {
-    func routeEnumCase<Payload>(
+    func routeCase<Payload>(
         _ enumCase: @escaping (Payload) -> Input
     ) -> PartialEffectRouter<Input, Payload, Output> {
         return routeEffects(withPayload: { effect in

--- a/MobiusCore/Test/EffectHandlers/EnumRouteTests.swift
+++ b/MobiusCore/Test/EffectHandlers/EnumRouteTests.swift
@@ -1,0 +1,102 @@
+// Copyright (c) 2019 Spotify AB.
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import MobiusCore
+import Nimble
+import Quick
+
+private typealias Event = ()
+
+private enum Effect: Equatable {
+    case justEffect
+    case effectWithString(String)
+    case effectWithTuple(left: String, right: Int)
+}
+
+private indirect enum List: Equatable {
+    case singleton(String)
+}
+
+class PayloadExtractionRouteTests: QuickSpec {
+    override func spec() {
+        context("Different types of enums being unwrapped") {
+            it("supports routing to an effect with nothing to unwrap") {
+                var receivedEffect: Effect? = nil
+                let handler = EffectRouter<Effect, Effect>()
+                    .routeCase(.justEffect)
+                        .to { effect in
+                            receivedEffect = effect
+                        }
+                    .asConnectable
+                    .connect { _ in }
+
+                handler.accept(.justEffect)
+                expect(receivedEffect).to(equal(.justEffect))
+                handler.dispose()
+            }
+
+            it("supports unwrapping an effect with a string") {
+                var unwrapped: String? = nil
+                let handler = EffectRouter<Effect, Event>()
+                    .routeEnumCase(Effect.effectWithString)
+                        .to { payload in unwrapped = payload }
+                    .asConnectable
+                    .connect { _ in }
+
+                handler.accept(.effectWithString("Test"))
+                expect(unwrapped).to(equal("Test"))
+                handler.dispose()
+            }
+
+            it("supports unwrapping an effect with a tuple") {
+                var leftUnwrapped: String? = nil
+                var rightUnwrapped: Int? = nil
+                let handler = EffectRouter<Effect, Event>()
+                    .routeEnumCase(Effect.effectWithTuple)
+                    .to { payload in
+                        let (left, right) = payload
+                        leftUnwrapped = left
+                        rightUnwrapped = right
+                    }
+                    .asConnectable
+                    .connect { _ in }
+
+                handler.accept(.effectWithTuple(left: "Test", right: 1))
+                expect(leftUnwrapped).to(equal("Test"))
+                expect(rightUnwrapped).to(equal(1))
+                handler.dispose()
+            }
+
+            it("supports unwrapping an indirect type") {
+                var result: String? = nil
+                let handler = EffectRouter<List, Event>()
+                    .routeEnumCase(List.singleton)
+                    .to { payload in
+                        result = payload
+                    }
+                    .asConnectable
+                    .connect { _ in }
+
+                handler.accept(.singleton("Test"))
+                expect(result).to(equal("Test"))
+                handler.dispose()
+            }
+        }
+    }
+}

--- a/MobiusCore/Test/EffectHandlers/EnumRouteTests.swift
+++ b/MobiusCore/Test/EffectHandlers/EnumRouteTests.swift
@@ -40,7 +40,7 @@ class PayloadExtractionRouteTests: QuickSpec {
     override func spec() {
         context("Different types of enums being unwrapped") {
             it("supports routing to an effect with nothing to unwrap") {
-                var receivedEffect: Effect? = nil
+                var receivedEffect: Effect?
                 let handler = EffectRouter<Effect, Effect>()
                     .routeCase(.justEffect)
                         .to { effect in
@@ -55,7 +55,7 @@ class PayloadExtractionRouteTests: QuickSpec {
             }
 
             it("supports unwrapping an effect with a string") {
-                var unwrapped: String? = nil
+                var unwrapped: String?
                 let handler = EffectRouter<Effect, Event>()
                     .routeEnumCase(Effect.effectWithString)
                         .to { payload in unwrapped = payload }
@@ -68,8 +68,8 @@ class PayloadExtractionRouteTests: QuickSpec {
             }
 
             it("supports unwrapping an effect with a tuple") {
-                var leftUnwrapped: String? = nil
-                var rightUnwrapped: Int? = nil
+                var leftUnwrapped: String?
+                var rightUnwrapped: Int?
                 let handler = EffectRouter<Effect, Event>()
                     .routeEnumCase(Effect.effectWithTuple)
                     .to { payload in
@@ -87,7 +87,7 @@ class PayloadExtractionRouteTests: QuickSpec {
             }
 
             it("supports unwrapping an indirect type") {
-                var result: String? = nil
+                var result: String?
                 let handler = EffectRouter<List, Event>()
                     .routeEnumCase(List.singleton)
                     .to { payload in

--- a/MobiusCore/Test/EffectHandlers/EnumRouteTests.swift
+++ b/MobiusCore/Test/EffectHandlers/EnumRouteTests.swift
@@ -21,6 +21,8 @@ import MobiusCore
 import Nimble
 import Quick
 
+// swiftlint:disable type_body_length file_length
+
 private typealias Event = ()
 
 private enum Effect: Equatable {
@@ -34,6 +36,7 @@ private indirect enum List: Equatable {
 }
 
 class PayloadExtractionRouteTests: QuickSpec {
+    // swiftlint:disable function_body_length
     override func spec() {
         context("Different types of enums being unwrapped") {
             it("supports routing to an effect with nothing to unwrap") {

--- a/MobiusCore/Test/EffectHandlers/EnumRouteTests.swift
+++ b/MobiusCore/Test/EffectHandlers/EnumRouteTests.swift
@@ -57,7 +57,7 @@ class PayloadExtractionRouteTests: QuickSpec {
             it("supports unwrapping an effect with a string") {
                 var unwrapped: String?
                 let handler = EffectRouter<Effect, Event>()
-                    .routeEnumCase(Effect.effectWithString)
+                    .routeCase(Effect.effectWithString)
                         .to { payload in unwrapped = payload }
                     .asConnectable
                     .connect { _ in }
@@ -71,7 +71,7 @@ class PayloadExtractionRouteTests: QuickSpec {
                 var leftUnwrapped: String?
                 var rightUnwrapped: Int?
                 let handler = EffectRouter<Effect, Event>()
-                    .routeEnumCase(Effect.effectWithTuple)
+                    .routeCase(Effect.effectWithTuple)
                     .to { payload in
                         let (left, right) = payload
                         leftUnwrapped = left
@@ -89,7 +89,7 @@ class PayloadExtractionRouteTests: QuickSpec {
             it("supports unwrapping an indirect type") {
                 var result: String?
                 let handler = EffectRouter<List, Event>()
-                    .routeEnumCase(List.singleton)
+                    .routeCase(List.singleton)
                     .to { payload in
                         result = payload
                     }

--- a/MobiusCore/Test/EffectHandlers/EnumRouteTests.swift
+++ b/MobiusCore/Test/EffectHandlers/EnumRouteTests.swift
@@ -60,9 +60,9 @@ class PayloadExtractionRouteTests: QuickSpec {
                 let route = EffectRouter<Effect, Never>()
                     .routeCase(Effect.justEffect)
 
-                let result = unwrap(effect: .justEffect, usingRoute: route)
+                let result: Void? = unwrap(effect: .justEffect, usingRoute: route)
 
-                expect(result).to(equal(.justEffect))
+                expect(result).to(beVoid())
             }
 
             it("supports unwrapping an effect with a string") {


### PR DESCRIPTION
This PR introduces a single way of routing to any `enum`-based effect.
This is what it would look like:
```swift
enum Effect: Equatable {
   case a
   case b(string: String)
   case c(left: String, right: String)
}
​
let router = EffectRouter<Effect, Event>()
    .routeCase(Effect.a).to { a in ... }
    .routeCase(Effect.b).to { string in ... }
    .routeCase(Effect.c).to { (left, right) in ... }
```
Reflection is used to unwrap effects with associated data, so no more unwrapping boilerplate or code generation is required. Thank you @mbrandonw and @stephencelis for your work on this code!

One issue is that `enum`s which do not have associated data must be equatable to work with this. The error for this luckily is very intuitive.

@pettermahlen @JensAyton 