### PR TITLE
Fix logical race caused by asynchronous view connection cleanup

### DIFF
--- a/MobiusCore/Source/ConnectableConvenienceClasses/AsyncDispatchQueueConnectable.swift
+++ b/MobiusCore/Source/ConnectableConvenienceClasses/AsyncDispatchQueueConnectable.swift
@@ -57,7 +57,7 @@ final class AsyncDispatchQueueConnectable<InputType, OutputType>: Connectable {
         let connection = underlyingConnectable.connect { [disposalStatus] value in
             // Don’t forward if we’re currently waiting to dispose the connection.
             //
-            // NOTE: the underlying consumer must be called inside the criticial region accessing disposalStatus, or we
+            // NOTE: the underlying consumer must be called inside the critical region accessing disposalStatus, or we
             // could potentially enter the .pendingDispose state before or during the consumer call. This means that the
             // underlying consumer must not call our connection’s acceptClosure or disposeClosure, or it will deadlock.
             //

--- a/MobiusCore/Source/ConnectableConvenienceClasses/AsyncDispatchQueueConnectable.swift
+++ b/MobiusCore/Source/ConnectableConvenienceClasses/AsyncDispatchQueueConnectable.swift
@@ -24,9 +24,19 @@ import Foundation
 /// Creates `Connection`s that forward invocations to `accept` and `dispose` to a connection returned by the underlying
 /// connectable, first switching to the provided `acceptQueue`. In other words, the real `accept` and `dispose` methods
 /// will always be executed asynchronously on the provided queue.
+///
+/// If the connection’s consumer is invoked between the Connectable’s `dispose` and the underlying asynchronous
+/// `dispose`, the call will not be forwarded.
 final class AsyncDispatchQueueConnectable<InputType, OutputType>: Connectable {
     private let underlyingConnectable: AnyConnectable<InputType, OutputType>
     private let acceptQueue: DispatchQueue
+
+    private enum DisposalStatus: Equatable {
+        case notDisposed
+        case pendingDispose
+        case disposed
+    }
+    private var disposalStatus = Synchronized(value: DisposalStatus.notDisposed)
 
     init(
         _ underlyingConnectable: AnyConnectable<InputType, OutputType>,
@@ -44,7 +54,21 @@ final class AsyncDispatchQueueConnectable<InputType, OutputType>: Connectable {
     }
 
     func connect(_ consumer: @escaping (OutputType) -> Void) -> Connection<InputType> {
-        let connection = underlyingConnectable.connect(consumer)
+        let connection = underlyingConnectable.connect { [disposalStatus] value in
+            // Don’t forward if we’re currently waiting to dispose the connection.
+            //
+            // NOTE: the underlying consumer must be called inside the criticial region accessing disposalStatus, or we
+            // could potentially enter the .pendingDispose state before or during the consumer call. This means that the
+            // underlying consumer must not call our connection’s acceptClosure or disposeClosure, or it will deadlock.
+            //
+            // This is OK in our existing use case because the underlying consumer is always flipEventsToLoopQueue from
+            // MobiusController’s initializer, which enters the actual Mobius loop asynchronously. If we exposed this
+            // class, it would be a scary edge case.
+            disposalStatus.read { status in
+                guard status != .pendingDispose else { return }
+                consumer(value)
+            }
+        }
 
         return Connection(
             acceptClosure: { [acceptQueue] input in
@@ -52,9 +76,11 @@ final class AsyncDispatchQueueConnectable<InputType, OutputType>: Connectable {
                     connection.accept(input)
                 }
             },
-            disposeClosure: { [acceptQueue] in
+            disposeClosure: { [acceptQueue, disposalStatus] in
+                disposalStatus.value = .pendingDispose
                 acceptQueue.async {
                     connection.dispose()
+                    disposalStatus.value = .disposed
                 }
             }
         )

--- a/MobiusCore/Source/Lock.swift
+++ b/MobiusCore/Source/Lock.swift
@@ -54,4 +54,10 @@ final class Synchronized<Value> {
             try closure(&storage)
         }
     }
+
+    func read(in closure: (Value) throws -> Void) rethrows {
+        try lock.sync {
+            try closure(storage)
+        }
+    }
 }

--- a/MobiusCore/Source/Lock.swift
+++ b/MobiusCore/Source/Lock.swift
@@ -61,3 +61,16 @@ final class Synchronized<Value> {
         }
     }
 }
+
+extension Synchronized where Value: Equatable {
+    func compareAndSwap(expected: Value, with newValue: Value) -> Bool {
+        var success = false
+        self.mutate { value in
+            if value == expected {
+                value = newValue
+                success = true
+            }
+        }
+        return success
+    }
+}

--- a/MobiusCore/Test/MobiusControllerTests.swift
+++ b/MobiusCore/Test/MobiusControllerTests.swift
@@ -142,7 +142,7 @@ class MobiusControllerTests: QuickSpec {
                             controller.start()
                             expect(controller.running).to(beTrue())
                         }
-                        fit("should ignore events sent while view disposal is pending") {
+                        it("should ignore events sent while view disposal is pending") {
                             self.viewQueue.sync {
                                 controller.stop()
                                 // Sending an event via the view connection here is valid, because the view connection has

--- a/MobiusCore/Test/MobiusControllerTests.swift
+++ b/MobiusCore/Test/MobiusControllerTests.swift
@@ -142,6 +142,17 @@ class MobiusControllerTests: QuickSpec {
                             controller.start()
                             expect(controller.running).to(beTrue())
                         }
+                        fit("should ignore events sent while view disposal is pending") {
+                            self.viewQueue.sync {
+                                controller.stop()
+                                // Sending an event via the view connection here is valid, because the view connection has
+                                // not yet been disposed; that disposal is pending in a block enqueued on the view queue by
+                                // AsyncDispatchQueueConnectable’s asynchronous disposal block
+                                view.dispatchSameQueue("late event")
+                            }
+
+                            expect(errorThrown).to(beFalse())
+                        }
                     }
                 }
 

--- a/MobiusCore/Test/TestingUtil.swift
+++ b/MobiusCore/Test/TestingUtil.swift
@@ -82,6 +82,11 @@ class RecordingTestConnectable: Connectable {
         }
     }
 
+    func dispatchSameQueue(_ string: String) {
+        verifyQueue()
+        consumer?(string)
+    }
+
     func accept(_ value: String) {
         verifyQueue()
 


### PR DESCRIPTION
View connections are disposed asynchronously on the view queue (typically the main queue). If an event is dispatched on the view queue after stopping the Mobius controller, we would hit an assertion. Unlike previous logic races, this could reasonably be worked around in client code, but it would introduce annoying coupling and synchronization work which we can handle generically using our existing dropping-events-on-the-floor technique.

@jeppes 