### PR TITLE
Document all functions in `EffectCallback`

### DIFF
--- a/MobiusCore/Source/EffectHandlers/EffectCallback.swift
+++ b/MobiusCore/Source/EffectHandlers/EffectCallback.swift
@@ -32,7 +32,7 @@ public final class EffectCallback<Output> {
 
     /// Determine if this callback has been ended.
     /// This can be called safely from any thread.
-    /// Note: Once this variable is `false`, it will never be `true` again.
+    /// Note: Once this variable is `true`, it will never be `false` again.
     public var ended: Bool {
         return _ended.value
     }

--- a/MobiusCore/Source/EffectHandlers/EffectCallback.swift
+++ b/MobiusCore/Source/EffectHandlers/EffectCallback.swift
@@ -24,18 +24,26 @@ import Foundation
 /// Sending output is done with `.send` and signaling completion is done with `.end`. You can also end in conjunction
 /// with sending output using `.end(with:)`.
 ///
-/// - Note: Once `.end` has been called (from any thread), the closure you provide in `onSend` will no longer be called.
-/// - Note: The closure you provide in `onEnd` will only be called once when `.end` is called on this object.
+/// Note: Once `.end` has been called (from any thread), all operations on this object will be no-ops.
+/// Note: The closure provided in `onEnd` will only be called once when `.end` is called on this object.
 public final class EffectCallback<Output> {
     private let onSend: (Output) -> Void
     private let onEnd: () -> Void
 
+    /// Determine if this callback has been ended.
+    /// This can be called safely from any thread.
+    /// Note: Once this variable is `false`, it will never be `true` again.
     public var ended: Bool {
         return _ended.value
     }
 
     private let _ended = Synchronized<Bool>(value: false)
 
+    /// Create an `EffectCallback` with some behavior associated with its sending and ending mechanisms.
+    /// Note: `onEnd` will only be called once on an instance of this call, regardless of how many times `end` is called.
+    /// Note: `onSend` will not be called if `end` has already been called.
+    /// - Parameter onSend: The closure to called when the underlying `Callback` sends output.
+    /// - Parameter onEnd: The closure to be called when the underlying `Callback` is ended.
     public init(
         onSend: @escaping (Output) -> Void,
         onEnd: @escaping () -> Void
@@ -44,6 +52,8 @@ public final class EffectCallback<Output> {
         self.onEnd = onEnd
     }
 
+    /// Invalidate this callback, and deinit the associated `EffectHandler`.
+    /// Note: any calls to `end`, `end(with:)` or `send(_:)` will be no-ops after this function has been called.
     public func end() {
         var runOnEnd = false
         _ended.mutate {
@@ -55,10 +65,16 @@ public final class EffectCallback<Output> {
         }
     }
 
+    /// Send a number of events to the Mobius loop, then `end()` this callback.
+    /// Note: Calling this function after calling `.end()` is a no-op.
+    /// - Parameter outputs: The events which should be sent to the loop.
     public func end(with outputs: Output...) {
         end(with: outputs)
     }
 
+    /// Send a number of events to the Mobius loop, then `end()` this callback.
+    /// Note: Calling this function after calling `.end()` is a no-op.
+    /// - Parameter outputs: The events which should be sent to the loop.
     public func end(with outputs: [Output]) {
         for output in outputs {
             send(output)
@@ -66,6 +82,9 @@ public final class EffectCallback<Output> {
         end()
     }
 
+    /// Send an event to the Mobius loop.
+    /// Note: Calling this function after calling `.end()` is a no-op.
+    /// - Parameter output: the event that should be sent to the loop.
     public func send(_ output: Output) {
         _ended.mutate {
             if !$0 {

--- a/MobiusCore/Source/EffectHandlers/EffectCallback.swift
+++ b/MobiusCore/Source/EffectHandlers/EffectCallback.swift
@@ -76,15 +76,15 @@ public final class EffectCallback<Output> {
     /// Note: After calling this function, all operations on this object will be no-ops.
     /// - Parameter outputs: The events which should be sent to the loop.
     public func end(with outputs: [Output]) {
-        var runOnEnd = false
+        var shouldRun = false
         _ended.mutate {
-            runOnEnd = !$0
+            shouldRun = !$0
             $0 = true
         }
-        for output in outputs {
-            onSend(output)
-        }
-        if runOnEnd {
+        if shouldRun {
+            for output in outputs {
+                onSend(output)
+            }
             onEnd()
         }
     }

--- a/MobiusCore/Source/EffectHandlers/EffectCallback.swift
+++ b/MobiusCore/Source/EffectHandlers/EffectCallback.swift
@@ -31,6 +31,7 @@ public final class EffectCallback<Output> {
     private let onEnd: () -> Void
 
     /// Determine if this callback has been ended.
+    ///
     /// This can be called safely from any thread.
     /// Note: Once this variable is `true`, it will never be `false` again.
     public var ended: Bool {
@@ -40,6 +41,7 @@ public final class EffectCallback<Output> {
     private let _ended = Synchronized<Bool>(value: false)
 
     /// Create an `EffectCallback` with some behavior associated with its sending and ending mechanisms.
+    ///
     /// Note: `onEnd` will only be called once on an instance of this call, regardless of how many times `end` is called.
     /// Note: `onSend` will not be called if `end` has already been called.
     /// - Parameter onSend: The closure to called when the underlying `Callback` sends output.
@@ -53,6 +55,7 @@ public final class EffectCallback<Output> {
     }
 
     /// Invalidate this callback.
+    ///
     /// Note: any calls to `end`, `end(with:)` or `send(_:)` will be no-ops after this function has been called.
     public func end() {
         var runOnEnd = false
@@ -66,6 +69,7 @@ public final class EffectCallback<Output> {
     }
 
     /// Send a number of events to the Mobius loop, then `end()` this callback.
+    ///
     /// Note: After calling this function, all operations on this object will be no-ops.
     /// - Parameter outputs: The events which should be sent to the loop.
     public func end(with outputs: Output...) {
@@ -73,6 +77,7 @@ public final class EffectCallback<Output> {
     }
 
     /// Send a number of events to the Mobius loop and `end()` this callback.
+    ///
     /// Note: After calling this function, all operations on this object will be no-ops.
     /// - Parameter outputs: The events which should be sent to the loop.
     public func end(with outputs: [Output]) {
@@ -90,6 +95,7 @@ public final class EffectCallback<Output> {
     }
 
     /// Send an event to the Mobius loop.
+    ///
     /// Note: Calling this function after calling `.end()` or `.end(with:)` is a no-op.
     /// - Parameter output: the event that should be sent to the loop.
     public func send(_ output: Output) {

--- a/MobiusCore/Source/EffectHandlers/EffectHandler.swift
+++ b/MobiusCore/Source/EffectHandlers/EffectHandler.swift
@@ -33,7 +33,7 @@ public protocol EffectHandler {
     /// To output events, call `callback.send`.
     /// Call `callback.end()` once the effect has been handled to prevent memory leaks.
     ///
-    /// This returns a `Disposable` which tears down any resources that is being used by this effect handler. This `Disposable` will
+    /// This returns a `Disposable` which tears down any resources used to handle this effect. This `Disposable` will
     /// not be called if `callback.end()` has already been called.
     ///
     /// Note: If it does not make sense to finish handling an effect, you should be using a `Connectable` instead of this protocol.

--- a/MobiusCore/Source/EffectHandlers/EffectHandler.swift
+++ b/MobiusCore/Source/EffectHandlers/EffectHandler.swift
@@ -31,15 +31,16 @@ public protocol EffectHandler {
     /// Handle an `Effect`.
     ///
     /// To output events, call `callback.send`.
+    /// Call `callback.end()` once the effect has been handled to prevent memory leaks.
     ///
-    /// When you are done handling `input`, be sure to call `callback.end()` to prevent memory leaks. If it does not
-    /// make sense to finish handling an effect, you should be using a `Connectable` instead of this protocol.
+    /// This returns a `Disposable` which tears down any resources that is being used by this effect handler. This `Disposable` will
+    /// not be called if `callback.end()` has already been called.
     ///
-    /// - Note: When being disposed by Mobius, the `Disposable` you return will be called before Mobius calls
-    /// `callback.end()`.
-    /// - Note: Mobius will not dispose the returned `Disposable` if `callback.end()` has already been called.
-    ///
-    /// Return a `Disposable` which tears down any resources that is being used by this effect handler.
+    /// Note: If it does not make sense to finish handling an effect, you should be using a `Connectable` instead of this protocol.
+    /// Note: When being disposed by Mobius, the `Disposable` you return will be called before Mobius calls `callback.end()`.
+    /// Note: Mobius will not dispose the returned `Disposable` if `callback.end()` has already been called.
+    /// - Parameter input: The effect being handled
+    /// - Parameter callback: The `EffectCallback` used to communicate with the associated Mobius loop.
     func handle(
         _ input: Effect,
         _ callback: EffectCallback<Event>

--- a/MobiusCore/Source/EffectHandlers/EffectHandler.swift
+++ b/MobiusCore/Source/EffectHandlers/EffectHandler.swift
@@ -33,11 +33,10 @@ public protocol EffectHandler {
     /// To output events, call `callback.send`.
     /// Call `callback.end()` once the effect has been handled to prevent memory leaks.
     ///
-    /// This returns a `Disposable` which tears down any resources used to handle this effect. This `Disposable` will
+    /// This returns a `Disposable` which cancels the handling of this effect. This `Disposable` will
     /// not be called if `callback.end()` has already been called.
     ///
     /// Note: If it does not make sense to finish handling an effect, you should be using a `Connectable` instead of this protocol.
-    /// Note: When being disposed by Mobius, the `Disposable` you return will be called before Mobius calls `callback.end()`.
     /// Note: Mobius will not dispose the returned `Disposable` if `callback.end()` has already been called.
     /// - Parameter input: The effect being handled
     /// - Parameter callback: The `EffectCallback` used to communicate with the associated Mobius loop.

--- a/MobiusCore/Test/EffectHandlers/CallbackTests.swift
+++ b/MobiusCore/Test/EffectHandlers/CallbackTests.swift
@@ -76,7 +76,7 @@ class CallbackTests: QuickSpec {
                     expect(output).to(equal([1]))
                 }
 
-                it("stops calling `onSend` after `.end` has been called") {
+                it("stops calling `onSend` when `send`ing after `.end` has been called") {
                     callback.send(1)
                     callback.send(2)
                     expect(output).to(equal([1, 2]))
@@ -85,6 +85,22 @@ class CallbackTests: QuickSpec {
 
                     callback.send(3)
                     expect(output).to(equal([1, 2]))
+                }
+
+                it("stops calling `onSend` when using `end(with:)` after `.end` has been called") {
+                    callback.end()
+                    callback.end(with: 2)
+                    expect(output).to(equal([]))
+                }
+
+                it("`end(with:)` is idempotent") {
+                    callback.end(with: 1, 2, 3)
+                    expect(callback.ended).to(beTrue())
+                    expect(output).to(equal([1, 2, 3]))
+
+                    callback.end(with: 1, 2, 3)
+                    expect(callback.ended).to(beTrue())
+                    expect(output).to(equal([1, 2, 3]))
                 }
 
                 it("sends events before ending when using `.end(with:)` with varargs") {


### PR DESCRIPTION
This should help clarify the semantics around the order in which `send` and `end` can be called.

@pettermahlen @JensAyton 