### PR TITLE
Misc documentation and cleanup

### DIFF
--- a/MobiusCore/Source/BackwardsCompatibility.swift
+++ b/MobiusCore/Source/BackwardsCompatibility.swift
@@ -133,7 +133,7 @@ public extension EffectRouterBuilder {
     /// - Parameters:
     ///   - connectable: The `Connectable` which handles an effect
     /// - Returns: This builder.
-    func addConnectable<C: Connectable & EffectPredicate>(_ connectable: C) -> EffectRouterBuilder<Input, Output> where C.InputType == Input, C.OutputType == Output, C.Effect == Input {
+    func addConnectable<C: Connectable & EffectPredicate>(_ connectable: C) -> EffectRouterBuilder<Input, Output> where C.Input == Input, C.Output == Output, C.Effect == Input {
         return addConnectable(connectable, predicate: connectable.canAccept)
     }
 
@@ -160,9 +160,17 @@ public extension EffectRouterBuilder {
     }
 }
 
+public extension Connectable {
+    @available(*, deprecated, message: "use Input instead")
+    typealias InputType = Input
+
+    @available(*, deprecated, message: "use Output instead")
+    typealias OutputType = Output
+}
+
 public extension BrokenConnection {
     @available(*, deprecated)
-    static func accept(_ value: ValueType) {
+    static func accept(_ value: Value) {
         _accept(value)
     }
 

--- a/MobiusCore/Source/BackwardsCompatibility.swift
+++ b/MobiusCore/Source/BackwardsCompatibility.swift
@@ -159,3 +159,6 @@ public extension BrokenConnection {
         _dispose()
     }
 }
+
+@available(*, deprecated)
+public typealias ConnectClosure<InputType, OutputType> = (@escaping Consumer<OutputType>) -> Connection<InputType>

--- a/MobiusCore/Source/BackwardsCompatibility.swift
+++ b/MobiusCore/Source/BackwardsCompatibility.swift
@@ -22,12 +22,24 @@ import Foundation
 @available(*, deprecated, message: "use Initiate instead")
 public typealias Initiator<Model, Effect> = Initiate<Model, Effect>
 
+public extension First {
+    /// A Boolean indicating whether the `First` object has any effects or not.
+    @available(*, deprecated, message: "use !effects.isEmpty instead")
+    var hasEffects: Bool { return !effects.isEmpty }
+}
+
 public extension First where Effect: Hashable {
     @available(*, deprecated, message: "use array of effects instead")
     init(model: Model, effects: Set<Effect>) {
         self.model = model
         self.effects = Array(effects)
     }
+}
+
+public extension Next {
+    /// A Boolean indicating whether the `Next` object has any effects or not.
+    @available(*, deprecated, message: "use !effects.isEmpty instead")
+    var hasEffects: Bool { return !effects.isEmpty }
 }
 
 public extension Next where Effect: Hashable {

--- a/MobiusCore/Source/BackwardsCompatibility.swift
+++ b/MobiusCore/Source/BackwardsCompatibility.swift
@@ -147,3 +147,15 @@ public extension EffectRouterBuilder {
         return addConnectable(connectable, predicate: action.canAccept)
     }
 }
+
+public extension BrokenConnection {
+    @available(*, deprecated)
+    static func accept(_ value: ValueType) {
+        _accept(value)
+    }
+
+    @available(*, deprecated)
+    static func dispose() {
+        _dispose()
+    }
+}

--- a/MobiusCore/Source/BackwardsCompatibility.swift
+++ b/MobiusCore/Source/BackwardsCompatibility.swift
@@ -162,3 +162,8 @@ public extension BrokenConnection {
 
 @available(*, deprecated)
 public typealias ConnectClosure<InputType, OutputType> = (@escaping Consumer<OutputType>) -> Connection<InputType>
+
+public extension Connection {
+    @available(*, deprecated, message: "use Value instead")
+    typealias ValueType = Value
+}

--- a/MobiusCore/Source/BrokenConnection.swift
+++ b/MobiusCore/Source/BrokenConnection.swift
@@ -19,16 +19,24 @@
 
 import Foundation
 
+/// A helper to construct `Connection`s that will fail when used.
+///
+/// `BrokenConnection.connection()` is used when functions return `Connection` fail an assertion. The resulting
+/// connection will trigger an assertion whenever its `accept` or `dispose` methods are called.
 public enum BrokenConnection<ValueType> {
-    public static func accept(_ value: ValueType) {
+    static func _accept(_ value: ValueType) {
         MobiusHooks.onError("'accept' called on invalid connection")
     }
 
-    public static func dispose() {
+    static func _dispose() {
         MobiusHooks.onError("'dispose' called on invalid connection")
     }
 
+    /// Construct a broken connection.
+    ///
+    /// The resulting connection will trigger an assertion whenever its `accept` or `dispose` methods are
+    /// called.
     public static func connection() -> Connection<ValueType> {
-        return Connection(acceptClosure: accept, disposeClosure: dispose)
+        return Connection(acceptClosure: _accept, disposeClosure: _dispose)
     }
 }

--- a/MobiusCore/Source/BrokenConnection.swift
+++ b/MobiusCore/Source/BrokenConnection.swift
@@ -23,8 +23,8 @@ import Foundation
 ///
 /// `BrokenConnection.connection()` is used when functions return `Connection` fail an assertion. The resulting
 /// connection will trigger an assertion whenever its `accept` or `dispose` methods are called.
-public enum BrokenConnection<ValueType> {
-    static func _accept(_ value: ValueType) {
+public enum BrokenConnection<Value> {
+    static func _accept(_ value: Value) {
         MobiusHooks.onError("'accept' called on invalid connection")
     }
 
@@ -36,7 +36,7 @@ public enum BrokenConnection<ValueType> {
     ///
     /// The resulting connection will trigger an assertion whenever its `accept` or `dispose` methods are
     /// called.
-    public static func connection() -> Connection<ValueType> {
+    public static func connection() -> Connection<Value> {
         return Connection(acceptClosure: _accept, disposeClosure: _dispose)
     }
 }

--- a/MobiusCore/Source/Connectable.swift
+++ b/MobiusCore/Source/Connectable.swift
@@ -27,8 +27,8 @@ import Foundation
 /// Alternatively used in `MobiusController.connectView(_:)` to connect a view to the controller. In that case, the
 /// incoming values will be models, and the outgoing values will be events.
 public protocol Connectable {
-    associatedtype InputType
-    associatedtype OutputType
+    associatedtype Input
+    associatedtype Output
 
     /// Create a new connection that accepts input values and sends outgoing values to a supplied consumer.
     ///
@@ -41,24 +41,24 @@ public protocol Connectable {
     ///
     /// - Parameter consumer: the consumer that the new connection should use to emit values
     /// - Returns: a new connection
-    func connect(_ consumer: @escaping Consumer<OutputType>) -> Connection<InputType>
+    func connect(_ consumer: @escaping Consumer<Output>) -> Connection<Input>
 }
 
 /// Type-erased wrapper for `Connectable`s
-public final class AnyConnectable<InputType, OutputType>: Connectable {
-    private let connectClosure: (@escaping Consumer<OutputType>) -> Connection<InputType>
+public final class AnyConnectable<Input, Output>: Connectable {
+    private let connectClosure: (@escaping Consumer<Output>) -> Connection<Input>
 
     /// Creates a type-erased `Connectable` that wraps the given instance.
-    public init<C: Connectable>(_ connectable: C) where C.InputType == InputType, C.OutputType == OutputType {
+    public init<C: Connectable>(_ connectable: C) where C.Input == Input, C.Output == Output {
         connectClosure = connectable.connect
     }
 
     /// Creates an anonymous `Connectable` that implements `connect` with the provided closure.
-    public init(_ connectable: @escaping (@escaping Consumer<OutputType>) -> Connection<InputType>) {
+    public init(_ connectable: @escaping (@escaping Consumer<Output>) -> Connection<Input>) {
         connectClosure = connectable
     }
 
-    public func connect(_ consumer: @escaping Consumer<OutputType>) -> Connection<InputType> {
+    public func connect(_ consumer: @escaping Consumer<Output>) -> Connection<Input> {
         return connectClosure(consumer)
     }
 }

--- a/MobiusCore/Source/Connectable.swift
+++ b/MobiusCore/Source/Connectable.swift
@@ -21,51 +21,44 @@ import Foundation
 
 /// API for something that can be connected to be part of a MobiusLoop.
 ///
-/// Primarily used in `Mobius.loop(update:effectHandler:)` to define the effect handler of a
-/// Mobius loop. In that case, the incoming values will be effects, and the outgoing values will be
-/// events that should be sent back to the loop.
+/// Primarily used in `Mobius.loop(update:effectHandler:)` to define the effect handler of a Mobius loop. In that case,
+/// the incoming values will be effects, and the outgoing values will be events that should be sent back to the loop.
 ///
-/// Alternatively used in `MobiusController.connect(view:)` to connect a view to the
-/// controller. In that case, the incoming values will be models, and the outgoing values will be
-/// events.
-///
-/// Create a new connection that accepts input values and sends outgoing values to a supplied
-/// consumer.
-///
-/// Must return a new `Connection` that accepts incoming values. After `dispose()` is called on
-/// the returned `Connection`, the connection must be broken, and no more values may be sent
-/// to the output consumer.
-///
-/// Every call to this method should create a new independent connection that can be disposed of
-/// individually without affecting the other connections. If your Connectable doesn't support this,
-/// it should throw an exception if someone tries to connect a second
-/// time before disposing of the first connection.
-/// - Parameter output: the consumer that the new connection should use to emit values
-/// - Returns: a new connection
+/// Alternatively used in `MobiusController.connectView(_:)` to connect a view to the controller. In that case, the
+/// incoming values will be models, and the outgoing values will be events.
 public protocol Connectable {
     associatedtype InputType
     associatedtype OutputType
 
+    /// Create a new connection that accepts input values and sends outgoing values to a supplied consumer.
+    ///
+    /// Must return a new `Connection` that accepts incoming values. After `dispose()` is called on the returned
+    /// `Connection`, the connection must be broken, and no more values may be sent to the output consumer.
+    ///
+    /// Every call to this method should create a new independent connection that can be disposed of individually
+    /// without affecting the other connections. If your `Connectable` doesn't support this, it should assert if someone
+    /// tries to connect a second time before disposing of the first connection.
+    ///
+    /// - Parameter consumer: the consumer that the new connection should use to emit values
+    /// - Returns: a new connection
     func connect(_ consumer: @escaping Consumer<OutputType>) -> Connection<InputType>
 }
 
-public typealias ConnectClosure<InputType, OutputType> = (@escaping Consumer<OutputType>) -> Connection<InputType>
+/// Type-erased wrapper for `Connectable`s
+public final class AnyConnectable<InputType, OutputType>: Connectable {
+    private let connectClosure: (@escaping Consumer<OutputType>) -> Connection<InputType>
 
-public final class AnyConnectable<Input, Output>: Connectable {
-    public typealias InputType = Input
-    public typealias OutputType = Output
-
-    private let connectClosure: ConnectClosure<Input, Output>
-
-    public init<C: Connectable>(_ connectable: C) where C.InputType == Input, C.OutputType == Output {
+    /// Creates a type-erased `Connectable` that wraps the given instance.
+    public init<C: Connectable>(_ connectable: C) where C.InputType == InputType, C.OutputType == OutputType {
         connectClosure = connectable.connect
     }
 
-    public init(_ connectable: @escaping ConnectClosure<Input, Output>) {
+    /// Creates an anonymous `Connectable` that implements `connect` with the provided closure.
+    public init(_ connectable: @escaping (@escaping Consumer<OutputType>) -> Connection<InputType>) {
         connectClosure = connectable
     }
 
-    public func connect(_ consumer: @escaping Consumer<Output>) -> Connection<Input> {
+    public func connect(_ consumer: @escaping Consumer<OutputType>) -> Connection<InputType> {
         return connectClosure(consumer)
     }
 }

--- a/MobiusCore/Source/ConnectableConvenienceClasses/ActionConnectable.swift
+++ b/MobiusCore/Source/ConnectableConvenienceClasses/ActionConnectable.swift
@@ -22,9 +22,6 @@ import Foundation
 /// Baseclass for creating an action based `connectable`. Invoking the `connection` functions
 /// will block the current thread until done.
 open class ActionConnectable<Input, Output>: Connectable {
-    public typealias InputType = Input
-    public typealias OutputType = Output
-
     private var innerConnectable: ClosureConnectable<Input, Output>
 
     /// Initialise with an action (no input, no output)

--- a/MobiusCore/Source/ConnectableConvenienceClasses/AsyncDispatchQueueConnectable.swift
+++ b/MobiusCore/Source/ConnectableConvenienceClasses/AsyncDispatchQueueConnectable.swift
@@ -27,8 +27,8 @@ import Foundation
 ///
 /// If the connection’s consumer is invoked between the Connectable’s `dispose` and the underlying asynchronous
 /// `dispose`, the call will not be forwarded.
-final class AsyncDispatchQueueConnectable<InputType, OutputType>: Connectable {
-    private let underlyingConnectable: AnyConnectable<InputType, OutputType>
+final class AsyncDispatchQueueConnectable<Input, Output>: Connectable {
+    private let underlyingConnectable: AnyConnectable<Input, Output>
     private let acceptQueue: DispatchQueue
 
     private enum DisposalStatus: Equatable {
@@ -38,7 +38,7 @@ final class AsyncDispatchQueueConnectable<InputType, OutputType>: Connectable {
     }
 
     init(
-        _ underlyingConnectable: AnyConnectable<InputType, OutputType>,
+        _ underlyingConnectable: AnyConnectable<Input, Output>,
         acceptQueue: DispatchQueue
     ) {
         self.underlyingConnectable = underlyingConnectable
@@ -48,11 +48,11 @@ final class AsyncDispatchQueueConnectable<InputType, OutputType>: Connectable {
     convenience init<C: Connectable>(
         _ underlyingConnectable: C,
         acceptQueue: DispatchQueue
-    ) where C.InputType == InputType, C.OutputType == OutputType {
+    ) where C.Input == Input, C.Output == Output {
         self.init(AnyConnectable(underlyingConnectable), acceptQueue: acceptQueue)
     }
 
-    func connect(_ consumer: @escaping (OutputType) -> Void) -> Connection<InputType> {
+    func connect(_ consumer: @escaping (Output) -> Void) -> Connection<Input> {
         let disposalStatus = Synchronized(value: DisposalStatus.notDisposed)
 
         let connection = underlyingConnectable.connect { value in

--- a/MobiusCore/Source/ConnectableConvenienceClasses/BlockingFunctionConnectable.swift
+++ b/MobiusCore/Source/ConnectableConvenienceClasses/BlockingFunctionConnectable.swift
@@ -22,9 +22,6 @@ import Foundation
 /// Baseclass for creating a function based `connectable`. Invoking the `connection` functions
 /// will block the current thread until done.
 open class BlockingFunctionConnectable<Input, Output>: Connectable {
-    public typealias InputType = Input
-    public typealias OutputType = Output
-
     private var innerConnectable: ClosureConnectable<Input, Output>
 
     /// Initialise with a function (input, output).

--- a/MobiusCore/Source/ConnectableConvenienceClasses/ClosureConnectable.swift
+++ b/MobiusCore/Source/ConnectableConvenienceClasses/ClosureConnectable.swift
@@ -20,11 +20,8 @@
 import Foundation
 
 class ClosureConnectable<Input, Output>: Connectable {
-    public typealias InputType = Input
-    public typealias OutputType = Output
-
     private var queue: DispatchQueue?
-    private var output: Consumer<OutputType>?
+    private var output: Consumer<Output>?
     private let closure: (Input) -> Output?
     private let lock = Lock()
 
@@ -64,7 +61,7 @@ class ClosureConnectable<Input, Output>: Connectable {
     }
 
     func connect(_ consumer: @escaping Consumer<Output>) -> Connection<Input> {
-        return lock.synchronized { () -> Connection<InputType> in
+        return lock.synchronized { () -> Connection<Input> in
             self.output = consumer
             return Connection(
                 acceptClosure: { input in

--- a/MobiusCore/Source/ConnectableConvenienceClasses/ConsumerConnectable.swift
+++ b/MobiusCore/Source/ConnectableConvenienceClasses/ConsumerConnectable.swift
@@ -22,9 +22,6 @@ import Foundation
 /// Baseclass for creating a consumer based `connectable`. Invoking the `connection` functions
 /// will block the current thread until done.
 open class ConsumerConnectable<Input, Output>: Connectable {
-    public typealias InputType = Input
-    public typealias OutputType = Output
-
     private var innerConnectable: ClosureConnectable<Input, Output>
 
     /// Initialise with a consumer (input, no output)

--- a/MobiusCore/Source/ConnectablePublisher.swift
+++ b/MobiusCore/Source/ConnectablePublisher.swift
@@ -19,13 +19,13 @@
 
 import Foundation
 
-/// Internal class that provides a 'publisher' for connectables; that is, something that you can post values to, and that
-/// will broadcast posted values to all connections. It also retains a current value, and will post that value to new
-/// connections.
-class ConnectablePublisher<ValueType>: Disposable {
+/// Internal class that provides a 'publisher' for connectables; that is, something that you can post values to, and
+/// that will broadcast posted values to all connections. It also retains a current value, and will post that value to
+/// new connections.
+class ConnectablePublisher<Value>: Disposable {
     private let access: ConcurrentAccessDetector
-    private var connections = [UUID: Connection<ValueType>]()
-    private var currentValue: ValueType?
+    private var connections = [UUID: Connection<Value>]()
+    private var currentValue: Value?
     private var _disposed = false
 
     init(accessGuard: ConcurrentAccessDetector = ConcurrentAccessDetector()) {
@@ -36,8 +36,8 @@ class ConnectablePublisher<ValueType>: Disposable {
         return access.guard { _disposed }
     }
 
-    func post(_ value: ValueType) {
-        let connections: [Connection<ValueType>] = access.guard {
+    func post(_ value: Value) {
+        let connections: [Connection<Value>] = access.guard {
             guard !disposed else {
                 // Callers are responsible for ensuring post is never entered after dispose.
                 MobiusHooks.onError("cannot accept values when disposed")
@@ -55,12 +55,12 @@ class ConnectablePublisher<ValueType>: Disposable {
     }
 
     @discardableResult
-    func connect(to outputConsumer: @escaping Consumer<ValueType>) -> Connection<ValueType> {
-        return access.guard { () -> Connection<ValueType> in
+    func connect(to outputConsumer: @escaping Consumer<Value>) -> Connection<Value> {
+        return access.guard { () -> Connection<Value> in
             guard !_disposed else {
                 // Callers are responsible for ensuring connect is never entered after dispose.
                 MobiusHooks.onError("cannot add connections when disposed")
-                return BrokenConnection<ValueType>.connection()
+                return BrokenConnection<Value>.connection()
             }
 
             let uuid = UUID()
@@ -77,7 +77,7 @@ class ConnectablePublisher<ValueType>: Disposable {
     }
 
     func dispose() {
-        let connections: [Connection<ValueType>] = access.guard {
+        let connections: [Connection<Value>] = access.guard {
             guard !_disposed else { return [] }
 
             _disposed = true

--- a/MobiusCore/Source/Connection.swift
+++ b/MobiusCore/Source/Connection.swift
@@ -21,19 +21,18 @@ import Foundation
 
 /// Handle for a connection created by a `Connectable`.
 ///
-/// Used for sending values to the connection and to dispose of it and all resources associated
-/// with it.
+/// Used for sending values to the connection and to dispose of it and all resources associated with it.
 public final class Connection<Value>: Disposable {
-    public typealias ValueType = Value
-
     private let acceptClosure: (Value) -> Void
     private let disposeClosure: () -> Void
 
+    /// Create a new connection that calls `acceptClosure` for incoming values, and `disposeClosure` when disposed.
     public init(acceptClosure: @escaping (Value) -> Void, disposeClosure: @escaping () -> Void) {
         self.acceptClosure = acceptClosure
         self.disposeClosure = disposeClosure
     }
 
+    /// Send a value to the connection.
     public func accept(_ value: Value) {
         acceptClosure(value)
     }

--- a/MobiusCore/Source/Consumer.swift
+++ b/MobiusCore/Source/Consumer.swift
@@ -20,7 +20,7 @@
 import Foundation
 
 /// A function that can receive values of some type.
-public typealias Consumer<ValueType> = (ValueType) -> Void
+public typealias Consumer<Value> = (Value) -> Void
 
 /// A function that can transform a Consumer.
-public typealias ConsumerTransformer<ValueType> = (@escaping Consumer<ValueType>) -> Consumer<ValueType>
+public typealias ConsumerTransformer<Value> = (@escaping Consumer<Value>) -> Consumer<Value>

--- a/MobiusCore/Source/EffectHandlers/EffectRouter.swift
+++ b/MobiusCore/Source/EffectHandlers/EffectRouter.swift
@@ -85,7 +85,7 @@ public struct PartialEffectRouter<Input, Payload, Output> {
     /// - Parameter connectable: a connectable which will be used to handle effects
     public func to<C: Connectable>(
         _ connectable: C
-    ) -> EffectRouter<Input, Output> where C.InputType == Payload, C.OutputType == Output {
+    ) -> EffectRouter<Input, Output> where C.Input == Payload, C.Output == Output {
         let connectable = ThreadSafeConnectable(connectable: connectable)
         let route = Route(extractPayload: path, connectable: connectable)
         return EffectRouter(routes: routes + [route])
@@ -98,7 +98,7 @@ private struct Route<Input, Output> {
     init<Payload, Conn: Connectable>(
         extractPayload: @escaping (Input) -> Payload?,
         connectable: Conn
-    ) where Conn.InputType == Payload, Conn.OutputType == Output {
+    ) where Conn.Input == Payload, Conn.Output == Output {
         connect = { output in
             let connection = connectable.connect(output)
             return ConnectedRoute(

--- a/MobiusCore/Source/EffectHandlers/ThreadSafeConnectable.swift
+++ b/MobiusCore/Source/EffectHandlers/ThreadSafeConnectable.swift
@@ -26,7 +26,7 @@ final class ThreadSafeConnectable<Event, Effect>: Connectable {
 
     init<Conn: Connectable>(
         connectable: Conn
-    ) where Conn.InputType == Effect, Conn.OutputType == Event {
+    ) where Conn.Input == Effect, Conn.Output == Event {
         self.connectable = AnyConnectable(connectable)
     }
 

--- a/MobiusCore/Source/EffectRouterBuilder.swift
+++ b/MobiusCore/Source/EffectRouterBuilder.swift
@@ -46,7 +46,7 @@ public struct EffectRouterBuilder<Input, Output> {
         self.connectables = connectables
     }
 
-    func addConnectable<C: Connectable>(_ connectable: C, predicate: @escaping (Input) -> Bool) -> EffectRouterBuilder<Input, Output> where C.InputType == Input, C.OutputType == Output {
+    func addConnectable<C: Connectable>(_ connectable: C, predicate: @escaping (Input) -> Bool) -> EffectRouterBuilder<Input, Output> where C.Input == Input, C.Output == Output {
         let handler = (connect: connectable.connect, predicate: predicate)
         return EffectRouterBuilder<Input, Output>(connectables: connectables + [handler])
     }

--- a/MobiusCore/Source/EffectRouterBuilder.swift
+++ b/MobiusCore/Source/EffectRouterBuilder.swift
@@ -19,7 +19,7 @@
 
 import Foundation
 
-private typealias PredicatedConnectable<Input, Output> = (connect: ConnectClosure<Input, Output>, predicate: (Input) -> Bool)
+private typealias PredicatedConnectable<Input, Output> = (connect: (@escaping Consumer<Output>) -> Connection<Input>, predicate: (Input) -> Bool)
 private typealias PredicatedConnection<Input> = (connection: Connection<Input>, predicate: (Input) -> Bool)
 
 /// Builder for an effect handler that routes to different sub-handlers based on effect type.

--- a/MobiusCore/Source/First.swift
+++ b/MobiusCore/Source/First.swift
@@ -39,8 +39,3 @@ public struct First<Model, Effect> {
         self.effects = effects
     }
 }
-
-public extension First {
-    /// A Boolean indicating whether the `First` object has any effects or not.
-    var hasEffects: Bool { return !effects.isEmpty }
-}

--- a/MobiusCore/Source/First.swift
+++ b/MobiusCore/Source/First.swift
@@ -23,12 +23,13 @@ import Foundation
 public struct First<Model, Effect> {
     /// The initial model object that should be used.
     public let model: Model
+
     /// An optional set of effects to initially dispatch.
     ///
     /// If empty, no effects will be dispatched.
     public let effects: [Effect]
 
-    /// Initialize a `First` object with the given model and
+    /// Create a `First` with the given model and effects.
     ///
     /// - Parameters:
     ///   - model: The initial model.

--- a/MobiusCore/Source/Mobius.swift
+++ b/MobiusCore/Source/Mobius.swift
@@ -54,7 +54,7 @@ public extension Mobius {
     static func loop<Model, Event, Effect, C: Connectable>(
         update: Update<Model, Event, Effect>,
         effectHandler: C
-    ) -> Builder<Model, Event, Effect> where C.InputType == Effect, C.OutputType == Event {
+    ) -> Builder<Model, Event, Effect> where C.Input == Effect, C.Output == Event {
         return Builder(
             update: update,
             effectHandler: effectHandler,
@@ -74,7 +74,7 @@ public extension Mobius {
     static func loop<Model, Event, Effect, C: Connectable>(
         update: @escaping (Model, Event) -> Next<Model, Effect>,
         effectHandler: C
-    ) -> Builder<Model, Event, Effect> where C.InputType == Effect, C.OutputType == Event {
+    ) -> Builder<Model, Event, Effect> where C.Input == Effect, C.Output == Event {
         return self.loop(
             update: Update(update),
             effectHandler: effectHandler
@@ -96,7 +96,7 @@ public extension Mobius {
             eventSource: AnyEventSource<Event>,
             eventConsumerTransformer: @escaping ConsumerTransformer<Event>,
             logger: AnyMobiusLogger<Model, Event, Effect>
-        ) where C.InputType == Effect, C.OutputType == Event {
+        ) where C.Input == Effect, C.Output == Event {
             self.update = update
             self.effectHandler = AnyConnectable(effectHandler)
             self.initiate = initiate

--- a/MobiusCore/Source/MobiusController.swift
+++ b/MobiusCore/Source/MobiusController.swift
@@ -132,7 +132,7 @@ public final class MobiusController<Model, Event, Effect> {
     /// make the view stop emitting events.
     ///
     /// - Attention: fails via `MobiusHooks.onError` if the loop is running or if the controller already is connected
-    public func connectView<C: Connectable>(_ connectable: C) where C.InputType == Model, C.OutputType == Event {
+    public func connectView<C: Connectable>(_ connectable: C) where C.Input == Model, C.Output == Event {
         state.mutateIfStopped(elseError: "cannot connect to a running controller") { state in
             guard state.viewConnectable == nil else {
                 MobiusHooks.onError("controller only supports connecting one view")

--- a/MobiusCore/Source/MobiusLoop.swift
+++ b/MobiusCore/Source/MobiusLoop.swift
@@ -116,7 +116,7 @@ public final class MobiusLoop<Model, Event, Effect>: Disposable, CustomDebugStri
         eventSource: AnyEventSource<Event>,
         eventConsumerTransformer: ConsumerTransformer<Event>,
         logger: AnyMobiusLogger<Model, Event, Effect>
-    ) -> MobiusLoop where C.InputType == Effect, C.OutputType == Event {
+    ) -> MobiusLoop where C.Input == Effect, C.Output == Event {
         let accessGuard = ConcurrentAccessDetector()
         let loggingInitiate = LoggingInitiate(initiate, logger: logger)
         let loggingUpdate = update.logging(logger)

--- a/MobiusCore/Source/Next.swift
+++ b/MobiusCore/Source/Next.swift
@@ -67,11 +67,6 @@ public extension Next {
     }
 }
 
-public extension Next {
-    /// A Boolean indicating whether the `Next` object has any effects or not.
-    var hasEffects: Bool { return !effects.isEmpty }
-}
-
 extension Next: Equatable where Model: Equatable, Effect: Equatable {
     public static func == (lhs: Next<Model, Effect>, rhs: Next<Model, Effect>) -> Bool {
         return lhs.model == rhs.model && lhs.effects == rhs.effects

--- a/MobiusCore/Test/EffectRouterBuilderTests.swift
+++ b/MobiusCore/Test/EffectRouterBuilderTests.swift
@@ -393,9 +393,6 @@ private func handleEffect(effect: Int, dispatch: @escaping Consumer<Int>) {
 }
 
 private class TestFilteredConnectable: Connectable, EffectPredicate {
-    typealias InputType = String
-    typealias OutputType = String
-
     var outputHandler: Consumer<String>?
     var queueLabel: String?
     var receivedString: String?

--- a/MobiusCore/Test/FirstTests.swift
+++ b/MobiusCore/Test/FirstTests.swift
@@ -45,38 +45,6 @@ class FirstTests: QuickSpec {
                     expect(sut.effects).toNot(contain(Effect.refresh))
                 }
             }
-
-            describe("hasEffects") {
-                context("when the object has multiple effects") {
-                    beforeEach {
-                        sut = First<String, Effect>(model: "1", effects: [.send, .refresh])
-                    }
-
-                    it("should return true") {
-                        expect(sut.hasEffects).to(beTrue())
-                    }
-                }
-
-                context("when the object has one effect") {
-                    beforeEach {
-                        sut = First<String, Effect>(model: "1", effects: [.refresh])
-                    }
-
-                    it("should return true") {
-                        expect(sut.hasEffects).to(beTrue())
-                    }
-                }
-
-                context("when the object does not have any effects") {
-                    beforeEach {
-                        sut = First<String, Effect>(model: "1", effects: [])
-                    }
-
-                    it("should return true") {
-                        expect(sut.hasEffects).to(beFalse())
-                    }
-                }
-            }
         }
     }
 }

--- a/MobiusCore/Test/MobiusControllerTests.swift
+++ b/MobiusCore/Test/MobiusControllerTests.swift
@@ -404,9 +404,6 @@ class MobiusControllerTests: QuickSpec {
 }
 
 class MockConnectable: Connectable {
-    typealias InputType = String
-    typealias OutputType = String
-
     var disposed = false
 
     func connect(_ consumer: @escaping (String) -> Void) -> Connection<String> {

--- a/MobiusCore/Test/MobiusLoopTests.swift
+++ b/MobiusCore/Test/MobiusLoopTests.swift
@@ -315,9 +315,6 @@ class MobiusLoopTests: QuickSpec {
 }
 
 private class EagerEffectHandler: Connectable {
-    typealias InputType = String
-    typealias OutputType = String
-
     func connect(_ consumer: @escaping Consumer<String>) -> Connection<String> {
         consumer("one")
         consumer("two")
@@ -340,9 +337,6 @@ private class TestEventProcessor<Model, Event, Effect>: EventProcessor<Model, Ev
 }
 
 private class TestConnectableProtocolImpl: Connectable {
-    typealias InputType = String
-    typealias OutputType = String
-
     func connect(_: @escaping (String) -> Void) -> Connection<String> {
         return Connection(acceptClosure: { _ in }, disposeClosure: {})
     }

--- a/MobiusCore/Test/NextTests.swift
+++ b/MobiusCore/Test/NextTests.swift
@@ -125,42 +125,6 @@ class NextTests: QuickSpec {
                 }
             }
 
-            describe("hasEffects") {
-                context("when the Next has multiple effects") {
-                    beforeEach {
-                        sut = Next.dispatchEffects([.send, .refresh])
-                    }
-
-                    it("should return true") {
-                        expect(sut.hasEffects).to(beTrue())
-                    }
-                }
-
-                context("when the Next has one effect") {
-                    beforeEach {
-                        sut = Next.dispatchEffects([.refresh])
-                    }
-
-                    it("should return true") {
-                        expect(sut.hasEffects).to(beTrue())
-                    }
-                }
-
-                context("when the Next does not have any effects") {
-                    it("should return false") {
-                        expect(Next<String, Effect>.next("foo", effects: []).hasEffects).to(beFalse())
-                    }
-
-                    it("should return false for a change with nil effects") {
-                        expect(Next<String, Effect>.dispatchEffects([]).hasEffects).to(beFalse())
-                    }
-
-                    it("should return false for a noChange") {
-                        expect(Next<String, Effect>.noChange.hasEffects).to(beFalse())
-                    }
-                }
-            }
-
             describe("Equatable") {
                 context("when the model type is equatable") {
                     let model1 = "some text"

--- a/MobiusCore/Test/TestingUtil.swift
+++ b/MobiusCore/Test/TestingUtil.swift
@@ -41,9 +41,6 @@ extension MobiusLoop {
 }
 
 class SimpleTestConnectable: Connectable {
-    typealias InputType = String
-    typealias OutputType = String
-
     var disposed = false
 
     func connect(_ consumer: @escaping (String) -> Void) -> Connection<String> {
@@ -52,9 +49,6 @@ class SimpleTestConnectable: Connectable {
 }
 
 class RecordingTestConnectable: Connectable {
-    typealias InputType = String
-    typealias OutputType = String
-
     private(set) var consumer: Consumer<String>?
 
     private(set) var recorder: Recorder<String>

--- a/MobiusExtras/Source/ConnectableClass.swift
+++ b/MobiusExtras/Source/ConnectableClass.swift
@@ -33,8 +33,8 @@ import MobiusCore
 ///
 /// - Attention: Should not be used directly. Instead a subclass should be used which overrides the
 /// `handle` and `disposed` functions
-open class ConnectableClass<InputType, OutputType>: Connectable {
-    private var consumer: Consumer<OutputType>?
+open class ConnectableClass<Input, Output>: Connectable {
+    private var consumer: Consumer<Output>?
 
     private let lock = NSRecursiveLock()
     var handleError = { (message: String) -> Void in
@@ -48,7 +48,7 @@ open class ConnectableClass<InputType, OutputType>: Connectable {
     ///
     /// - Attention: This class will throw an error to the MobiusHooks error handler if a connection has not been
     /// established before a call to this function is made. Setting up a connection is usually handled by the MobiusLoop
-    public final func send(_ output: OutputType) {
+    public final func send(_ output: Output) {
         lock.lock()
         defer {
             lock.unlock()
@@ -66,7 +66,7 @@ open class ConnectableClass<InputType, OutputType>: Connectable {
     ///
     /// - Attention: This function has to be overridden by a subclass or an error will be thrown to the MobiusHooks
     /// error handler.
-    open func handle(_ input: InputType) {
+    open func handle(_ input: Input) {
         handleError("The function `\(#function)` must be overridden in subclass \(type(of: self))")
     }
 
@@ -78,7 +78,7 @@ open class ConnectableClass<InputType, OutputType>: Connectable {
         handleError("The function `\(#function)` must be overridden in subclass \(type(of: self))")
     }
 
-    public final func connect(_ consumer: @escaping (OutputType) -> Void) -> Connection<InputType> {
+    public final func connect(_ consumer: @escaping (Output) -> Void) -> Connection<Input> {
         lock.lock()
         defer {
             lock.unlock()
@@ -93,7 +93,7 @@ open class ConnectableClass<InputType, OutputType>: Connectable {
         return Connection(acceptClosure: self.accept, disposeClosure: self.dispose)
     }
 
-    private func accept(_ input: InputType) {
+    private func accept(_ input: Input) {
         // The construct of consumerSet is there to release the lock asap.
         // We dont know what goes on in the overriden `handle` function...
         var consumerSet: Bool = false

--- a/MobiusExtras/Source/ConnectableClass.swift
+++ b/MobiusExtras/Source/ConnectableClass.swift
@@ -86,11 +86,11 @@ open class ConnectableClass<InputType, OutputType>: Connectable {
 
         guard self.consumer == nil else {
             handleError("ConnectionLimitExceeded: The Connectable \(type(of: self)) is already connected. Unable to connect more than once")
-            return BrokenConnection<InputType>.connection()
+            return BrokenConnection.connection()
         }
 
         self.consumer = consumer
-        return Connection<InputType>(acceptClosure: self.accept, disposeClosure: self.dispose)
+        return Connection(acceptClosure: self.accept, disposeClosure: self.dispose)
     }
 
     private func accept(_ input: InputType) {

--- a/MobiusExtras/Source/ConnectableContramap.swift
+++ b/MobiusExtras/Source/ConnectableContramap.swift
@@ -20,21 +20,21 @@
 import MobiusCore
 
 public extension Connectable {
-    func contramap<NewInputType>(_ map: @escaping (NewInputType) -> InputType) -> AnyConnectable<NewInputType, OutputType> {
-        let newConnectClosure = { (consumer: @escaping Consumer<OutputType>) -> Connection<NewInputType> in
+    func contramap<NewInput>(_ map: @escaping (NewInput) -> Input) -> AnyConnectable<NewInput, Output> {
+        let newConnectClosure = { (consumer: @escaping Consumer<Output>) -> Connection<NewInput> in
             let connection = self.connect(consumer)
-            let mappedAcceptFunction = { (newTypeInput: NewInputType) in
+            let mappedAcceptFunction = { (newTypeInput: NewInput) in
                 let oldTypeInput = map(newTypeInput)
                 connection.accept(oldTypeInput)
             }
 
-            return Connection<NewInputType>(
+            return Connection<NewInput>(
                 acceptClosure: mappedAcceptFunction,
                 disposeClosure: connection.dispose
             )
         }
 
-        let contramapped = AnyConnectable<NewInputType, OutputType>(newConnectClosure)
+        let contramapped = AnyConnectable<NewInput, Output>(newConnectClosure)
 
         return contramapped
     }

--- a/MobiusExtras/Test/EventHandlerDisposalLogicalRaceRegressionTest.swift
+++ b/MobiusExtras/Test/EventHandlerDisposalLogicalRaceRegressionTest.swift
@@ -111,7 +111,7 @@ private class EffectHandler: ConnectableClass<Effect, Event>, EffectPredicate {
         cancellationToken = nil
     }
 
-    typealias Effect = InputType
+    typealias Effect = Input
 }
 
 // Stand-in for an object that does something asynchronous and cancellable, e.g. fetch data.

--- a/MobiusTest/Source/FirstMatchers.swift
+++ b/MobiusTest/Source/FirstMatchers.swift
@@ -70,7 +70,7 @@ public func hasNoEffects<Model, Effect>(
     line: UInt = #line
 ) -> FirstPredicate<Model, Effect> {
     return { (first: First<Model, Effect>) in
-        if first.hasEffects {
+        if !first.effects.isEmpty {
             return .failure(
                 message: "Expected no effects, got <\(first.effects)>",
                 file: file,

--- a/MobiusTest/Source/NextMatchers.swift
+++ b/MobiusTest/Source/NextMatchers.swift
@@ -102,7 +102,7 @@ public func hasModel<Model: Equatable, Effect>(_ expected: Model, file: StaticSt
 /// - Returns: a `Predicate` that matches `Next` instances with no effects.
 public func hasNoEffects<Model, Effect>(file: StaticString = #file, line: UInt = #line) -> NextPredicate<Model, Effect> {
     return { (next: Next<Model, Effect>) in
-        if next.hasEffects {
+        if !next.effects.isEmpty {
             return .failure(
                 message: "Expected no effects. Got: <\(next.effects)>",
                 file: file,


### PR DESCRIPTION
* Documents some simple stuff
* Consistently wraps touched documentation at 120 columns
* Deprecates some low-value typedefs and methods
  - I don’t feel that `next. hasEffects` is significantly more expressive than `!next.effects.isEmpty`. If `isEmpty` didn’t exist and you had to use `count != 0` it would perhaps carry its weight.
  - I don’t see any reason for `BrokenConnection.accept` and `.dispose` to be accessed directly.
  - `ConnectClosure` was used in one place in API. `Connection.ValueType` was identical to `Connection.Value` and not used at all.
  - Names like `ValueType` and `InputType` are non-idiomatic.

@jeppes 