### PR TITLE
Documentation comment review and line wrapping

### DIFF
--- a/MobiusCore/Source/ConnectableConvenienceClasses/ActionConnectable.swift
+++ b/MobiusCore/Source/ConnectableConvenienceClasses/ActionConnectable.swift
@@ -19,14 +19,15 @@
 
 import Foundation
 
-/// Baseclass for creating an action based `connectable`. Invoking the `connection` functions
-/// will block the current thread until done.
+/// Base class for creating an action based `connectable`.
+///
+/// Invoking the `connection` functions will block the current thread until done.
 open class ActionConnectable<Input, Output>: Connectable {
     private var innerConnectable: ClosureConnectable<Input, Output>
 
-    /// Initialise with an action (no input, no output)
+    /// Initialise with an action (no input, no output).
     ///
-    /// - Parameter action: Called when the `connection` `accept` function is called
+    /// - Parameter action: Called when the `connection`’s `accept` function is called.
     public init(_ action: @escaping () -> Void) {
         innerConnectable = ClosureConnectable<Input, Output>({ _ in
             action()

--- a/MobiusCore/Source/ConnectableConvenienceClasses/BlockingFunctionConnectable.swift
+++ b/MobiusCore/Source/ConnectableConvenienceClasses/BlockingFunctionConnectable.swift
@@ -19,14 +19,15 @@
 
 import Foundation
 
-/// Baseclass for creating a function based `connectable`. Invoking the `connection` functions
-/// will block the current thread until done.
+/// Base class for creating a function based `connectable`.
+///
+/// Invoking the `connection` functions will block the current thread until done.
 open class BlockingFunctionConnectable<Input, Output>: Connectable {
     private var innerConnectable: ClosureConnectable<Input, Output>
 
     /// Initialise with a function (input, output).
     ///
-    /// - Parameter function: Called when the `connection` `accept` function is called
+    /// - Parameter function: Called when the `connection`’s `accept` function is called.
     public init(_ function: @escaping (Input) -> Output) {
         innerConnectable = ClosureConnectable<Input, Output>(function)
     }

--- a/MobiusCore/Source/ConnectableConvenienceClasses/ConsumerConnectable.swift
+++ b/MobiusCore/Source/ConnectableConvenienceClasses/ConsumerConnectable.swift
@@ -19,14 +19,15 @@
 
 import Foundation
 
-/// Baseclass for creating a consumer based `connectable`. Invoking the `connection` functions
-/// will block the current thread until done.
+/// Base class for creating a consumer based `connectable`.
+///
+/// Invoking the `connection` functions will block the current thread until done.
 open class ConsumerConnectable<Input, Output>: Connectable {
     private var innerConnectable: ClosureConnectable<Input, Output>
 
-    /// Initialise with a consumer (input, no output)
+    /// Initialise with a consumer (input, no output).
     ///
-    /// - Parameter consumer: Called when the `connection` `accept` function is called
+    /// - Parameter consumer: Called when the `connection`’s `accept` function is called.
     public init(_ consumer: @escaping Consumer<Input>) {
         innerConnectable = ClosureConnectable<Input, Output>(consumer)
     }

--- a/MobiusCore/Source/Disposables/AnonymousDisposable.swift
+++ b/MobiusCore/Source/Disposables/AnonymousDisposable.swift
@@ -32,7 +32,7 @@ public final class AnonymousDisposable: MobiusCore.Disposable {
 
     /// Create an `AnonymousDisposable` that will run the provided closure when disposed.
     ///
-    /// - Warning: The given _disposer_ **closure will be discarded** as soon as the resources have been disposed.
+    /// - Warning: The given `disposer` closure **will be discarded** as soon as the resources have been disposed.
     ///
     /// - Parameter disposer: The code which disposes of the resources.
     public init(disposer: @escaping () -> Void) {

--- a/MobiusCore/Source/Disposables/CompositeDisposable.swift
+++ b/MobiusCore/Source/Disposables/CompositeDisposable.swift
@@ -19,22 +19,22 @@
 
 import Foundation
 
-/// A CompositeDisposable holds onto the provided disposables and disposes
-/// all of them once its dispose() method is called.
+/// A CompositeDisposable holds onto the provided disposables and disposes all of them once its `dispose` method is
+/// called.
 public class CompositeDisposable {
     private var disposables: [Disposable]
     private let lock = DispatchQueue(label: "Mobius.CompositeDisposable")
 
-    /// Initialises a CompositeDisposable
+    /// Initialises a `CompositeDisposable`.
     ///
-    /// - Parameter disposables: an array of disposables
+    /// - Parameter disposables: an array of disposables.
     init(disposables: [Disposable]) {
         self.disposables = disposables
     }
 }
 
 extension CompositeDisposable: MobiusCore.Disposable {
-    /// Dispose function disposes all of the internal disposables
+    /// Dispose function disposes all of the internal disposables.
     public func dispose() {
         var disposables = [Disposable]()
 

--- a/MobiusCore/Source/Disposables/Disposable.swift
+++ b/MobiusCore/Source/Disposables/Disposable.swift
@@ -17,14 +17,15 @@
 // specific language governing permissions and limitations
 // under the License.
 
-/// Types adopting the `Disposable` protocol can be disposed, cleaning up the resources referenced. The resouces can be
-/// anything; ranging from a network request, task on the CPU or an observation of another resource.
+/// Types adopting the `Disposable` protocol can be disposed, cleaning up the resources referenced.
 ///
-/// - SeeAlso: `AnonymousDisposable` for a concrete anonymous implementation.
+/// The resouces can be anything; ranging from a network request, task on the CPU or an observation of another resource.
+///
+/// See also `AnonymousDisposable` for a concrete anonymous implementation.
 public protocol Disposable: AnyObject {
     /// Dispose of all resources associated with the `Disposable` object.
     ///
-    /// The `Disposable` will no longer be valid after `dispose()` has been called, and any further calls to
-    /// `dispose()` won’t have any effect.
+    /// The `Disposable` will no longer be valid after `dispose` has been called, and any further calls to `dispose`
+    /// should not have any effect.
     func dispose()
 }

--- a/MobiusCore/Source/EffectHandlers/EffectCallback.swift
+++ b/MobiusCore/Source/EffectHandlers/EffectCallback.swift
@@ -20,11 +20,12 @@
 import Foundation
 
 /// An `EffectCallback` can send output and signal completion.
-/// Sending output is done with `.send` and signaling completion is done with `.end`.
-/// You can also end in conjunction with sending output using `.end(with:)`
 ///
-/// Note: Once `.end` has been called (from any thread), the closure you provide in `onSend` will no longer be called.
-/// Note: The closure you provide in `onEnd` will only be called once when `.end` is called on this object.
+/// Sending output is done with `.send` and signaling completion is done with `.end`. You can also end in conjunction
+/// with sending output using `.end(with:)`.
+///
+/// - Note: Once `.end` has been called (from any thread), the closure you provide in `onSend` will no longer be called.
+/// - Note: The closure you provide in `onEnd` will only be called once when `.end` is called on this object.
 public final class EffectCallback<Output> {
     private let onSend: (Output) -> Void
     private let onEnd: () -> Void

--- a/MobiusCore/Source/EffectHandlers/EffectExecutor.swift
+++ b/MobiusCore/Source/EffectHandlers/EffectExecutor.swift
@@ -38,7 +38,10 @@ class EffectExecutor<Effect, Event>: Connectable {
     func connect(_ consumer: @escaping Consumer<Event>) -> Connection<Effect> {
         return lock.synchronized {
             guard output == nil else {
-                MobiusHooks.onError("ConnectionLimitExceeded: The Connectable \(type(of: self)) is already connected. Unable to connect more than once")
+                MobiusHooks.onError(
+                    "Connection limit exceeded: The Connectable \(type(of: self)) is already connected. " +
+                    "Unable to connect more than once"
+                )
                 return BrokenConnection.connection()
             }
 

--- a/MobiusCore/Source/EffectHandlers/EffectHandler.swift
+++ b/MobiusCore/Source/EffectHandlers/EffectHandler.swift
@@ -17,9 +17,11 @@
 // specific language governing permissions and limitations
 // under the License.
 
-/// This protocol defines the contract for an Effect Handler which takes `Effect`s as input, and produces `Event`s as output.
-/// For each incoming `Effect`, zero or more `Event`s can be sent as output using `callback.send(Event)`.
-/// When an `Effect` has been completely handled, i.e. that effect will not result in any more events, call `callback.end()`.
+/// This protocol defines the contract for an Effect Handler which takes `Effect`s as input, and produces `Event`s as
+/// output.
+///
+/// For each incoming `Effect`, zero or more `Event`s can be sent as output using `callback.send(Event)`. When an
+/// `Effect` has been completely handled, i.e. that effect will not result in any more events, call `callback.end()`.
 ///
 /// Note: `EffectHandler` should be used in conjunction with an `EffectRouter`.
 public protocol EffectHandler {
@@ -27,12 +29,15 @@ public protocol EffectHandler {
     associatedtype Event
 
     /// Handle an `Effect`.
-    /// To output events, call `callback.send`.
-    /// When you are done handling `input`, be sure to call `callback.end()` to prevent memory leaks.
-    /// If it does not make sense to finish handling an effect, you should be using a `Connectable` instead of this protocol.
     ///
-    /// Note: When being disposed by Mobius, the `Disposable` you return will be called before Mobius calls `callback.end()`.
-    /// Note: Mobius will not dispose the returned `Disposable` if `callback.end()` has already been called.
+    /// To output events, call `callback.send`.
+    ///
+    /// When you are done handling `input`, be sure to call `callback.end()` to prevent memory leaks. If it does not
+    /// make sense to finish handling an effect, you should be using a `Connectable` instead of this protocol.
+    ///
+    /// - Note: When being disposed by Mobius, the `Disposable` you return will be called before Mobius calls
+    /// `callback.end()`.
+    /// - Note: Mobius will not dispose the returned `Disposable` if `callback.end()` has already been called.
     ///
     /// Return a `Disposable` which tears down any resources that is being used by this effect handler.
     func handle(

--- a/MobiusCore/Source/EffectHandlers/EffectRouterDSL.swift
+++ b/MobiusCore/Source/EffectHandlers/EffectRouterDSL.swift
@@ -18,8 +18,9 @@
 // under the License.
 
 public extension EffectRouter where Effect: Equatable {
-    /// Add a route for effects which are equal to `equalTo`.
-    /// - Parameter `equalTo`: the effect that should be handled by this route
+    /// Add a route for effects which are equal to `constant`.
+    ///
+    /// - Parameter `constant`: the effect that should be handled by this route.
     func routeEffects(
         equalTo constant: Effect
     ) -> _PartialEffectRouter<Effect, Effect, Event> {
@@ -29,6 +30,7 @@ public extension EffectRouter where Effect: Equatable {
 
 public extension _PartialEffectRouter {
     /// Route to the anonymous  `EffectHandler` defined by the `handle` closure.
+    ///
     /// - Parameter handle: A closure which defines an `EffectHandler`.
     func to(
         _ handle: @escaping (Payload, EffectCallback<Event>) -> Disposable
@@ -37,6 +39,7 @@ public extension _PartialEffectRouter {
     }
 
     /// Route to a side-effecting closure.
+    ///
     /// - Parameter fireAndForget: a function which given some input carries out a side effect.
     func to(
         _ fireAndForget: @escaping (Payload) -> Void
@@ -49,8 +52,9 @@ public extension _PartialEffectRouter {
     }
 
     /// Route to a closure which returns an optional event when given the payload as input.
-    /// - Parameter eventFunction: a function which returns an optional event given some input. No events will be propagated if this function returns
-    /// `nil`.
+    ///
+    /// - Parameter eventClosure: a function which returns an optional event given some input. No events will be
+    ///   propagated if this function returns `nil`.
     func toEvent(
         _ eventClosure: @escaping (Payload) -> Event?
     ) -> EffectRouter<Effect, Event> {

--- a/MobiusCore/Source/EffectHandlers/ThreadSafeConnectable.swift
+++ b/MobiusCore/Source/EffectHandlers/ThreadSafeConnectable.swift
@@ -33,7 +33,10 @@ final class ThreadSafeConnectable<Event, Effect>: Connectable {
     func connect(_ output: @escaping (Event) -> Void) -> Connection<Effect> {
         return lock.synchronized {
             guard self.output == nil, connection == nil else {
-                MobiusHooks.onError("ConnectionLimitExceeded: The Connectable \(type(of: self)) is already connected. Unable to connect more than once")
+                MobiusHooks.onError(
+                    "Connection limit exceeded: The Connectable \(type(of: self)) is already connected. " +
+                    "Unable to connect more than once"
+                )
                 return BrokenConnection.connection()
             }
             self.output = output

--- a/MobiusCore/Source/EventProcessor.swift
+++ b/MobiusCore/Source/EventProcessor.swift
@@ -19,8 +19,8 @@
 
 import Foundation
 
-/// Internal class that manages the atomic state updates and notifications of model changes when processing of events via
-/// the Update function.
+/// Internal class that manages the atomic state updates and notifications of model changes when processing of events
+/// via the Update function.
 class EventProcessor<Model, Event, Effect>: Disposable, CustomDebugStringConvertible {
     let update: Update<Model, Event, Effect>
     let publisher: ConnectablePublisher<Next<Model, Effect>>

--- a/MobiusCore/Source/EventSources/EventSource.swift
+++ b/MobiusCore/Source/EventSources/EventSource.swift
@@ -32,7 +32,7 @@ public protocol EventSource: AnyObject {
     /// `Disposable` is disposed. Multiple such subscriptions can be in place concurrently for a
     /// given event source, without affecting each other.
     ///
-    /// - Parameter eventConsumer: the consumer that should receive events from the source
-    /// - Returns: a `Disposable` used to stop the source from emitting any more events to this consumer
+    /// - Parameter eventConsumer: the consumer that should receive events from the source.
+    /// - Returns: a `Disposable` used to stop the source from emitting any more events to this consumer.
     func subscribe(consumer: @escaping Consumer<Event>) -> Disposable
 }

--- a/MobiusCore/Source/MobiusController.swift
+++ b/MobiusCore/Source/MobiusController.swift
@@ -21,7 +21,8 @@ import Foundation
 
 /// Defines a controller that can be used to start and stop MobiusLoops.
 ///
-/// If a loop is stopped and then started again via the controller, the new loop will continue from where the last one left off.
+/// If a loop is stopped and then started again via the controller, the new loop will continue from where the last one
+/// left off.
 public final class MobiusController<Model, Event, Effect> {
     typealias Loop = MobiusLoop<Model, Event, Effect>
     typealias ViewConnectable = AsyncDispatchQueueConnectable<Model, Event>

--- a/MobiusCore/Source/MobiusLoop.swift
+++ b/MobiusCore/Source/MobiusLoop.swift
@@ -170,7 +170,11 @@ public final class MobiusLoop<Model, Event, Effect>: Disposable, CustomDebugStri
             eventProcessor: eventProcessor,
             consumeEvent: consumeEvent,
             modelPublisher: modelPublisher,
-            disposable: CompositeDisposable(disposables: [eventSourceDisposable, nextConnection, effectHandlerConnection]),
+            disposable: CompositeDisposable(disposables: [
+                eventSourceDisposable,
+                nextConnection,
+                effectHandlerConnection,
+            ]),
             accessGuard: accessGuard,
             workBag: workBag
         )

--- a/MobiusNimble/Source/NimbleFirstMatchers.swift
+++ b/MobiusNimble/Source/NimbleFirstMatchers.swift
@@ -26,7 +26,9 @@ import Nimble
 ///
 /// - Parameter predicates: Nimble `Predicate` that verifies a first. Can be produced through `FirstMatchers`
 /// - Returns: An `AssertFirst` function to be used with the `InitSpec`
-public func assertThatFirst<Model, Effect>(_ predicates: Nimble.Predicate<First<Model, Effect>>...) -> AssertFirst<Model, Effect> {
+public func assertThatFirst<Model, Effect>(
+    _ predicates: Nimble.Predicate<First<Model, Effect>>...
+) -> AssertFirst<Model, Effect> {
     return { (result: First<Model, Effect>) in
         predicates.forEach({ predicate in
             expect(result).to(predicate)
@@ -49,7 +51,10 @@ public func haveModel<Model: Equatable, Effect>(_ expected: Model) -> Nimble.Pre
 
         let expectedDescription = String(describing: expected)
         let actualDescription = String(describing: first.model)
-        return PredicateResult(bool: first.model == expected, message: .expectedCustomValueTo("be <\(expectedDescription)>", "<\(actualDescription)>"))
+        return PredicateResult(
+            bool: first.model == expected,
+            message: .expectedCustomValueTo("be <\(expectedDescription)>", "<\(actualDescription)>")
+        )
     })
 }
 
@@ -63,7 +68,10 @@ public func haveNoEffects<Model, Effect>() -> Nimble.Predicate<First<Model, Effe
         }
 
         let actualDescription = String(describing: first.effects)
-        return PredicateResult(bool: first.effects.isEmpty, message: .expectedCustomValueTo("have no effect", "<\(actualDescription)>"))
+        return PredicateResult(
+            bool: first.effects.isEmpty,
+            message: .expectedCustomValueTo("have no effect", "<\(actualDescription)>")
+        )
     })
 }
 
@@ -80,7 +88,13 @@ public func haveEffects<Model, Effect: Equatable>(_ effects: [Effect]) -> Nimble
 
         let expectedDescription = String(describing: effects)
         let actualDescription = String(describing: first.effects)
-        return PredicateResult(bool: effects.allSatisfy(first.effects.contains), message: .expectedCustomValueTo("contain <\(expectedDescription)>", "<\(actualDescription)> (order doesn't matter)"))
+        return PredicateResult(
+            bool: effects.allSatisfy(first.effects.contains),
+            message: .expectedCustomValueTo(
+                "contain <\(expectedDescription)>",
+                "<\(actualDescription)> (order doesn't matter)"
+            )
+        )
     })
 }
 

--- a/MobiusNimble/Source/NimbleNextMatchers.swift
+++ b/MobiusNimble/Source/NimbleNextMatchers.swift
@@ -26,7 +26,9 @@ import Nimble
 ///
 /// - Parameter predicates: matchers an array of `Predicate`, all of which must match
 /// - Returns: an `Assert` that applies all the matchers
-public func assertThatNext<Model, Event, Effect>(_ predicates: Nimble.Predicate<Next<Model, Effect>>...) -> UpdateSpec<Model, Event, Effect>.Assert {
+public func assertThatNext<Model, Event, Effect>(
+    _ predicates: Nimble.Predicate<Next<Model, Effect>>...
+) -> UpdateSpec<Model, Event, Effect>.Assert {
     return { (result: UpdateSpec.Result) in
         predicates.forEach({ predicate in
             expect(result.lastNext).to(predicate)
@@ -53,7 +55,10 @@ public func haveNoModel<Model, Effect>() -> Nimble.Predicate<Next<Model, Effect>
         if let model = next.model {
             actualDescription = String(describing: model)
         }
-        return Nimble.PredicateResult(bool: next.model == nil, message: .expectedCustomValueTo("have no model", "<\(actualDescription)>"))
+        return Nimble.PredicateResult(
+            bool: next.model == nil,
+            message: .expectedCustomValueTo("have no model", "<\(actualDescription)>")
+        )
     })
 }
 
@@ -82,7 +87,10 @@ public func haveModel<Model: Equatable, Effect>(_ expected: Model) -> Nimble.Pre
 
         let expectedDescription = String(describing: expected)
         let actualDescription = String(describing: nextModel)
-        return Nimble.PredicateResult(bool: nextModel == expected, message: .expectedCustomValueTo("be <\(expectedDescription)>", "<\(actualDescription)>"))
+        return Nimble.PredicateResult(
+            bool: nextModel == expected,
+            message: .expectedCustomValueTo("be <\(expectedDescription)>", "<\(actualDescription)>")
+        )
     })
 }
 
@@ -112,7 +120,10 @@ public func haveEffects<Model, Effect: Equatable>(_ expected: [Effect]) -> Nimbl
         let actualDescription = String(describing: next.effects)
         return Nimble.PredicateResult(
             bool: expected.allSatisfy(next.effects.contains),
-            message: .expectedCustomValueTo("contain <\(expectedDescription)>", "<\(actualDescription)> (order doesn't matter)")
+            message: .expectedCustomValueTo(
+                "contain <\(expectedDescription)>",
+                "<\(actualDescription)> (order doesn't matter)"
+            )
         )
     })
 }

--- a/MobiusTest/Source/NextMatchers.swift
+++ b/MobiusTest/Source/NextMatchers.swift
@@ -85,12 +85,17 @@ public func hasModel<Model, Effect>(file: StaticString = #file, line: UInt = #li
 
 /// - Parameter expected: the expected model
 /// - Returns: a `Predicate` that matches `Next` instances with a model that is equal to the supplied one.
-public func hasModel<Model: Equatable, Effect>(_ expected: Model, file: StaticString = #file, line: UInt = #line) -> NextPredicate<Model, Effect> {
+public func hasModel<Model: Equatable, Effect>(
+    _ expected: Model,
+    file: StaticString = #file,
+    line: UInt = #line
+) -> NextPredicate<Model, Effect> {
     return { (next: Next<Model, Effect>) in
         let actual = next.model
         if actual != expected {
             return .failure(
-                message: "Expected final Next to have model: <\(String(describing: expected))>. Got: <\(String(describing: actual))>",
+                message: "Expected final Next to have model: <\(String(describing: expected))>. " +
+                    "Got: <\(String(describing: actual))>",
                 file: file,
                 line: line
             )
@@ -100,7 +105,10 @@ public func hasModel<Model: Equatable, Effect>(_ expected: Model, file: StaticSt
 }
 
 /// - Returns: a `Predicate` that matches `Next` instances with no effects.
-public func hasNoEffects<Model, Effect>(file: StaticString = #file, line: UInt = #line) -> NextPredicate<Model, Effect> {
+public func hasNoEffects<Model, Effect>(
+    file: StaticString = #file,
+    line: UInt = #line
+) -> NextPredicate<Model, Effect> {
     return { (next: Next<Model, Effect>) in
         if !next.effects.isEmpty {
             return .failure(


### PR DESCRIPTION
Some general thoughts on documentation comments:
* A documentation comment should start with a single-line summary followed by an empty line. The summary is shown in a small space in code completion in Xcode.
* Punctuation was consistent; I went with fully punctuated sentences.
* Ideally, documentation comments should play nicely with Xcode’s formatting and read much the same way in the source; among other things, this means that paragraphs should be separated by an empty line and lines without separation should flow as one paragraph.
* `SeeAlso:` isn’t shown in Xcode’s standard documentation formatting (it’s only supported in playgrounds).

@jeppes 