### PR TITLE
Swift 5.2 updates

### DIFF
--- a/MobiusCore/Source/Mobius.swift
+++ b/MobiusCore/Source/Mobius.swift
@@ -30,6 +30,11 @@ public struct Update<Model, Event, Effect> {
     public func update(model: Model, event: Event) -> Next<Model, Effect> {
         return self.update(model, event)
     }
+
+    @inlinable
+    public func callAsFunction(model: Model, event: Event) -> Next<Model, Effect> {
+        return update(model: model, event: event)
+    }
 }
 
 public typealias Initiate<Model, Effect> = (Model) -> First<Model, Effect>

--- a/MobiusCore/Test/EventRouterDisposalLogicalRaceRegressionTest.swift
+++ b/MobiusCore/Test/EventRouterDisposalLogicalRaceRegressionTest.swift
@@ -101,7 +101,7 @@ private class EffectCollaborator {
         var cancelled = false
 
         DispatchQueue.global().asyncAfter(deadline: .now()) {
-            if !cancelLock.sync { cancelled } {
+            if !cancelLock.sync(execute: { cancelled }) {
                 closure()
             }
         }

--- a/MobiusExtras/Test/EventHandlerDisposalLogicalRaceRegressionTest.swift
+++ b/MobiusExtras/Test/EventHandlerDisposalLogicalRaceRegressionTest.swift
@@ -121,7 +121,7 @@ private class EffectCollaborator {
         var cancelled = false
 
         DispatchQueue.global().asyncAfter(deadline: .now()) {
-            if !cancelLock.sync { cancelled } {
+            if !cancelLock.sync(execute: { cancelled }) {
                 closure()
             }
         }


### PR DESCRIPTION
Suppress this warning in two tests:
> Trailing closure in this context is confusable with the body of the statement; pass as a parenthesized argument to silence this warning

Also adds `callAsFunction()` to `Update`.