### PR TITLE
Idea: Allow EffectRouter to be passed to Mobius.loop directly

### DIFF
--- a/MobiusCore/Source/Connectable.swift
+++ b/MobiusCore/Source/Connectable.swift
@@ -26,7 +26,7 @@ import Foundation
 ///
 /// Alternatively used in `MobiusController.connectView(_:)` to connect a view to the controller. In that case, the
 /// incoming values will be models, and the outgoing values will be events.
-public protocol Connectable {
+public protocol Connectable: _EffectHandlerConvertible {
     associatedtype Input
     associatedtype Output
 
@@ -42,6 +42,12 @@ public protocol Connectable {
     /// - Parameter consumer: the consumer that the new connection should use to emit values
     /// - Returns: a new connection
     func connect(_ consumer: @escaping Consumer<Output>) -> Connection<Input>
+}
+
+public extension Connectable {
+    func _asEffectHandlerConnectable() -> AnyConnectable<Input, Output> {
+        return AnyConnectable(self)
+    }
 }
 
 /// Type-erased wrapper for `Connectable`s

--- a/MobiusCore/Source/EffectHandlers/EffectRouter.swift
+++ b/MobiusCore/Source/EffectHandlers/EffectRouter.swift
@@ -72,6 +72,12 @@ public struct EffectRouter<Effect, Event> {
     }
 }
 
+extension EffectRouter: _EffectHandlerConvertible {
+    public func _asEffectHandlerConnectable() -> AnyConnectable<Effect, Event> {
+        return compose(routes: routes)
+    }
+}
+
 public struct _PartialEffectRouter<Effect, Payload, Event> {
     fileprivate let routes: [Route<Effect, Event>]
     fileprivate let path: (Effect) -> Payload?

--- a/MobiusCore/Test/MobiusLoopTests.swift
+++ b/MobiusCore/Test/MobiusLoopTests.swift
@@ -290,7 +290,6 @@ class MobiusLoopTests: QuickSpec {
                 let payload: (Int) -> Int? = { $0 }
                 let effectConnectable = EffectRouter<Int, Int>()
                     .routeEffects(withPayload: payload).to(effectHandler)
-                    .asConnectable
                 let update = Update { (_: Int, _: Int) -> Next<Int, Int> in Next.dispatchEffects([1]) }
                 loop = Mobius
                     .loop(update: update, effectHandler: effectConnectable)

--- a/MobiusCore/Test/NonReentrancyTests.swift
+++ b/MobiusCore/Test/NonReentrancyTests.swift
@@ -75,11 +75,10 @@ class NonReentrancyTests: QuickSpec {
                     return AnonymousDisposable {}
                 }
 
-                let effectConnectable = EffectRouter<Effect, Event>()
+                let effectRouter = EffectRouter<Effect, Event>()
                     .routeEffects(equalTo: .testEffect).to(testEffectHandler)
-                    .asConnectable
 
-                loop = Mobius.loop(update: update, effectHandler: effectConnectable)
+                loop = Mobius.loop(update: update, effectHandler: effectRouter)
                     .start(from: 0)
             }
 


### PR DESCRIPTION
The `asConnectable` at the end of an `EffectRouter` setup is an annoying abstraction leak. Supporting an array of multiple `update` types _and_ multiple `effectHandler` types is pretty unattractive, though.

Here’s a third option: use an underscored protocol to provide a common supertype to `EffectRouter<Effect, Event>` and `Connectable where Input == Effect, Output == Event`. I’m not convinced myself, the extra associated types are a pain, but I thought it was worth looking at.

@jeppes 