### PR TITLE
Make MobiusController view connection optional

### DIFF
--- a/MobiusCore/Source/MobiusController.swift
+++ b/MobiusCore/Source/MobiusController.swift
@@ -17,8 +17,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// swiftlint:disable:file_length
-
 import Foundation
 
 /// Defines a controller that can be used to start and stop MobiusLoops.
@@ -49,30 +47,6 @@ public final class MobiusController<Model, Event, Effect> {
         loopQueue loopTargetQueue: DispatchQueue,
         viewQueue: DispatchQueue
     ) {
-        /*
-         Ownership graph after initing:
-
-                     ┏━━━━━━━━━━━━┓
-                ┌────┨ controller ┠────────┬──┐
-                │    ┗━━━━━━━━━━┯━┛        │  │
-         ┏━━━━━━┷━━━━━━┓    ┏━━━┷━━━━━━━┓  │  │
-         ┃ loopFactory ┃    ┃ viewQueue ┃  │  │
-         ┗━━━━━━━━━┯━━━┛    ┗━━━━━━━━━━━┛  │  │
-              ┏━━━━┷━━━━━━━━━━━━━━━━━━┓    │  │
-              ┃ flipEventsToLoopQueue ┃ ┌──┘  │
-              ┗━━━━━━━━━━━━━━┯━━━━━━┯━┛ │     │
-                             │    ┏━┷━━━┷━┓   │
-                             │    ┃ state ┃   │
-                             │    ┗━┯━━━━━┛   │
-                             │      │ ┌───────┘
-                           ┏━┷━━━━━━┷━┷┓
-                           ┃ loopQueue ┃
-                           ┗━━━━━━━━━━━┛
-
-         In order to construct this bottom-up and fulfil definitive initialization requirements, state and loopQueue are
-         duplicated in local variables.
-         */
-
         // The internal loopQueue is a serial queue targeting the provided queue, so that targeting a concurrent queue
         // doesn’t result in concurrent work on the underlying MobiusLoop. This behaviour is documented on
         // `Mobius.Builder.makeController`.

--- a/MobiusCore/Source/MobiusController.swift
+++ b/MobiusCore/Source/MobiusController.swift
@@ -17,6 +17,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+// swiftlint:disable:file_length
+
 import Foundation
 
 /// Defines a controller that can be used to start and stop MobiusLoops.

--- a/MobiusCore/Test/MobiusControllerTests.swift
+++ b/MobiusCore/Test/MobiusControllerTests.swift
@@ -261,6 +261,12 @@ class MobiusControllerTests: QuickSpec {
                         controller.connectView(view)
                         controller.start()
                         controller.stop()
+                        expect(errorThrown).to(beFalse())
+                    }
+                    it("should allow starting a stopping without a connected view") {
+                        controller.start()
+                        controller.stop()
+                        expect(errorThrown).to(beFalse())
                     }
                     it("should allow dispatching an event from the event source immediately") {
                         controller.connectView(view)
@@ -287,10 +293,6 @@ class MobiusControllerTests: QuickSpec {
                 }
                 #if arch(x86_64) || arch(arm64)
                 describe("error handling") {
-                    it("should not allow starting initially") {
-                        controller.start()
-                        expect(errorThrown).to(beTrue())
-                    }
                     it("should not allow starting a running controller") {
                         controller.connectView(view)
                         controller.start()


### PR DESCRIPTION
Since `MobiusController` now represents “starty-stoppy MobiusLoop running on a background queue” rather than “ViewController glue for MobiusLoop”, it no longer makes sense to require `connectView`.

@jeppes 