### PR TITLE
Add dependency system tests for SPM on Apple platforms

### DIFF
--- a/Tools/BuildSystemTests/MobiusSPMTest/MobiusSPMTest.xcodeproj/project.pbxproj
+++ b/Tools/BuildSystemTests/MobiusSPMTest/MobiusSPMTest.xcodeproj/project.pbxproj
@@ -1,0 +1,680 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 52;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		2D35A2B8241F8C2700C344AC /* Test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D35A2B7241F8C2700C344AC /* Test.swift */; };
+		2D35A2C0241F8C6000C344AC /* MobiusCore in Frameworks */ = {isa = PBXBuildFile; productRef = 2D35A2BF241F8C6000C344AC /* MobiusCore */; };
+		2D35A2C2241F8C6000C344AC /* MobiusExtras in Frameworks */ = {isa = PBXBuildFile; productRef = 2D35A2C1241F8C6000C344AC /* MobiusExtras */; };
+		2D35A2C5241F8CFD00C344AC /* MobiusNimble in Frameworks */ = {isa = PBXBuildFile; productRef = 2D35A2C4241F8CFD00C344AC /* MobiusNimble */; };
+		2D35A2C7241F8CFD00C344AC /* MobiusTest in Frameworks */ = {isa = PBXBuildFile; productRef = 2D35A2C6241F8CFD00C344AC /* MobiusTest */; };
+		2D35A2CA241F8D3E00C344AC /* Nimble in Frameworks */ = {isa = PBXBuildFile; productRef = 2D35A2C9241F8D3E00C344AC /* Nimble */; };
+		2D35A2D4241F8FE400C344AC /* Test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D35A2B7241F8C2700C344AC /* Test.swift */; };
+		2D35A2D6241F8FE400C344AC /* Nimble in Frameworks */ = {isa = PBXBuildFile; productRef = 2D35A2D1241F8FE400C344AC /* Nimble */; };
+		2D35A2D7241F8FE400C344AC /* MobiusExtras in Frameworks */ = {isa = PBXBuildFile; productRef = 2D35A2CE241F8FE400C344AC /* MobiusExtras */; };
+		2D35A2D8241F8FE400C344AC /* MobiusTest in Frameworks */ = {isa = PBXBuildFile; productRef = 2D35A2D0241F8FE400C344AC /* MobiusTest */; };
+		2D35A2D9241F8FE400C344AC /* MobiusNimble in Frameworks */ = {isa = PBXBuildFile; productRef = 2D35A2CF241F8FE400C344AC /* MobiusNimble */; };
+		2D35A2DA241F8FE400C344AC /* MobiusCore in Frameworks */ = {isa = PBXBuildFile; productRef = 2D35A2CC241F8FE400C344AC /* MobiusCore */; };
+		2D35A2E9241F910200C344AC /* Test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D35A2B7241F8C2700C344AC /* Test.swift */; };
+		2D35A2EB241F910200C344AC /* Nimble in Frameworks */ = {isa = PBXBuildFile; productRef = 2D35A2E6241F910200C344AC /* Nimble */; };
+		2D35A2EC241F910200C344AC /* MobiusExtras in Frameworks */ = {isa = PBXBuildFile; productRef = 2D35A2E3241F910200C344AC /* MobiusExtras */; };
+		2D35A2ED241F910200C344AC /* MobiusTest in Frameworks */ = {isa = PBXBuildFile; productRef = 2D35A2E5241F910200C344AC /* MobiusTest */; };
+		2D35A2EE241F910200C344AC /* MobiusNimble in Frameworks */ = {isa = PBXBuildFile; productRef = 2D35A2E4241F910200C344AC /* MobiusNimble */; };
+		2D35A2EF241F910200C344AC /* MobiusCore in Frameworks */ = {isa = PBXBuildFile; productRef = 2D35A2E1241F910200C344AC /* MobiusCore */; };
+		2D35A2FE241F911700C344AC /* Test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D35A2B7241F8C2700C344AC /* Test.swift */; };
+		2D35A301241F911700C344AC /* MobiusExtras in Frameworks */ = {isa = PBXBuildFile; productRef = 2D35A2F8241F911700C344AC /* MobiusExtras */; };
+		2D35A304241F911700C344AC /* MobiusCore in Frameworks */ = {isa = PBXBuildFile; productRef = 2D35A2F6241F911700C344AC /* MobiusCore */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		2D35A2B2241F8C2700C344AC /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "include/$(PRODUCT_NAME)";
+			dstSubfolderSpec = 16;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		2D35A2DB241F8FE400C344AC /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "include/$(PRODUCT_NAME)";
+			dstSubfolderSpec = 16;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		2D35A2F0241F910200C344AC /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "include/$(PRODUCT_NAME)";
+			dstSubfolderSpec = 16;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		2D35A305241F911700C344AC /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "include/$(PRODUCT_NAME)";
+			dstSubfolderSpec = 16;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
+/* Begin PBXFileReference section */
+		2D35A2B4241F8C2700C344AC /* libMobiusSPMTest_macOS.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libMobiusSPMTest_macOS.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		2D35A2B7241F8C2700C344AC /* Test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Test.swift; sourceTree = "<group>"; };
+		2D35A2DF241F8FE400C344AC /* libMobiusSPMTest_iOS.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libMobiusSPMTest_iOS.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		2D35A2F4241F910200C344AC /* libMobiusSPMTest_tvOS.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libMobiusSPMTest_tvOS.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		2D35A309241F911700C344AC /* libMobiusSPMTest_watchOS.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libMobiusSPMTest_watchOS.a; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		2D35A2B1241F8C2700C344AC /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				2D35A2CA241F8D3E00C344AC /* Nimble in Frameworks */,
+				2D35A2C2241F8C6000C344AC /* MobiusExtras in Frameworks */,
+				2D35A2C7241F8CFD00C344AC /* MobiusTest in Frameworks */,
+				2D35A2C5241F8CFD00C344AC /* MobiusNimble in Frameworks */,
+				2D35A2C0241F8C6000C344AC /* MobiusCore in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		2D35A2D5241F8FE400C344AC /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				2D35A2D6241F8FE400C344AC /* Nimble in Frameworks */,
+				2D35A2D7241F8FE400C344AC /* MobiusExtras in Frameworks */,
+				2D35A2D8241F8FE400C344AC /* MobiusTest in Frameworks */,
+				2D35A2D9241F8FE400C344AC /* MobiusNimble in Frameworks */,
+				2D35A2DA241F8FE400C344AC /* MobiusCore in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		2D35A2EA241F910200C344AC /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				2D35A2EB241F910200C344AC /* Nimble in Frameworks */,
+				2D35A2EC241F910200C344AC /* MobiusExtras in Frameworks */,
+				2D35A2ED241F910200C344AC /* MobiusTest in Frameworks */,
+				2D35A2EE241F910200C344AC /* MobiusNimble in Frameworks */,
+				2D35A2EF241F910200C344AC /* MobiusCore in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		2D35A2FF241F911700C344AC /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				2D35A301241F911700C344AC /* MobiusExtras in Frameworks */,
+				2D35A304241F911700C344AC /* MobiusCore in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		2D35A2AB241F8C2700C344AC = {
+			isa = PBXGroup;
+			children = (
+				2D35A2B6241F8C2700C344AC /* SharedSource */,
+				2D35A2B5241F8C2700C344AC /* Products */,
+				2D35A2C3241F8CFD00C344AC /* Frameworks */,
+			);
+			sourceTree = "<group>";
+		};
+		2D35A2B5241F8C2700C344AC /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				2D35A2B4241F8C2700C344AC /* libMobiusSPMTest_macOS.a */,
+				2D35A2DF241F8FE400C344AC /* libMobiusSPMTest_iOS.a */,
+				2D35A2F4241F910200C344AC /* libMobiusSPMTest_tvOS.a */,
+				2D35A309241F911700C344AC /* libMobiusSPMTest_watchOS.a */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		2D35A2B6241F8C2700C344AC /* SharedSource */ = {
+			isa = PBXGroup;
+			children = (
+				2D35A2B7241F8C2700C344AC /* Test.swift */,
+			);
+			name = SharedSource;
+			path = ../SharedSource;
+			sourceTree = "<group>";
+		};
+		2D35A2C3241F8CFD00C344AC /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		2D35A2B3241F8C2700C344AC /* MobiusSPMTest_macOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 2D35A2BB241F8C2700C344AC /* Build configuration list for PBXNativeTarget "MobiusSPMTest_macOS" */;
+			buildPhases = (
+				2D35A2B0241F8C2700C344AC /* Sources */,
+				2D35A2B1241F8C2700C344AC /* Frameworks */,
+				2D35A2B2241F8C2700C344AC /* CopyFiles */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = MobiusSPMTest_macOS;
+			packageProductDependencies = (
+				2D35A2BF241F8C6000C344AC /* MobiusCore */,
+				2D35A2C1241F8C6000C344AC /* MobiusExtras */,
+				2D35A2C4241F8CFD00C344AC /* MobiusNimble */,
+				2D35A2C6241F8CFD00C344AC /* MobiusTest */,
+				2D35A2C9241F8D3E00C344AC /* Nimble */,
+			);
+			productName = MobiusSPMTest;
+			productReference = 2D35A2B4241F8C2700C344AC /* libMobiusSPMTest_macOS.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		2D35A2CB241F8FE400C344AC /* MobiusSPMTest_iOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 2D35A2DC241F8FE400C344AC /* Build configuration list for PBXNativeTarget "MobiusSPMTest_iOS" */;
+			buildPhases = (
+				2D35A2D3241F8FE400C344AC /* Sources */,
+				2D35A2D5241F8FE400C344AC /* Frameworks */,
+				2D35A2DB241F8FE400C344AC /* CopyFiles */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = MobiusSPMTest_iOS;
+			packageProductDependencies = (
+				2D35A2CC241F8FE400C344AC /* MobiusCore */,
+				2D35A2CE241F8FE400C344AC /* MobiusExtras */,
+				2D35A2CF241F8FE400C344AC /* MobiusNimble */,
+				2D35A2D0241F8FE400C344AC /* MobiusTest */,
+				2D35A2D1241F8FE400C344AC /* Nimble */,
+			);
+			productName = MobiusSPMTest;
+			productReference = 2D35A2DF241F8FE400C344AC /* libMobiusSPMTest_iOS.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		2D35A2E0241F910200C344AC /* MobiusSPMTest_tvOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 2D35A2F1241F910200C344AC /* Build configuration list for PBXNativeTarget "MobiusSPMTest_tvOS" */;
+			buildPhases = (
+				2D35A2E8241F910200C344AC /* Sources */,
+				2D35A2EA241F910200C344AC /* Frameworks */,
+				2D35A2F0241F910200C344AC /* CopyFiles */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = MobiusSPMTest_tvOS;
+			packageProductDependencies = (
+				2D35A2E1241F910200C344AC /* MobiusCore */,
+				2D35A2E3241F910200C344AC /* MobiusExtras */,
+				2D35A2E4241F910200C344AC /* MobiusNimble */,
+				2D35A2E5241F910200C344AC /* MobiusTest */,
+				2D35A2E6241F910200C344AC /* Nimble */,
+			);
+			productName = MobiusSPMTest;
+			productReference = 2D35A2F4241F910200C344AC /* libMobiusSPMTest_tvOS.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		2D35A2F5241F911700C344AC /* MobiusSPMTest_watchOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 2D35A306241F911700C344AC /* Build configuration list for PBXNativeTarget "MobiusSPMTest_watchOS" */;
+			buildPhases = (
+				2D35A2FD241F911700C344AC /* Sources */,
+				2D35A2FF241F911700C344AC /* Frameworks */,
+				2D35A305241F911700C344AC /* CopyFiles */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = MobiusSPMTest_watchOS;
+			packageProductDependencies = (
+				2D35A2F6241F911700C344AC /* MobiusCore */,
+				2D35A2F8241F911700C344AC /* MobiusExtras */,
+			);
+			productName = MobiusSPMTest;
+			productReference = 2D35A309241F911700C344AC /* libMobiusSPMTest_watchOS.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		2D35A2AC241F8C2700C344AC /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastSwiftUpdateCheck = 1140;
+				LastUpgradeCheck = 1140;
+				ORGANIZATIONNAME = Spotify;
+				TargetAttributes = {
+					2D35A2B3241F8C2700C344AC = {
+						CreatedOnToolsVersion = 11.4;
+					};
+				};
+			};
+			buildConfigurationList = 2D35A2AF241F8C2700C344AC /* Build configuration list for PBXProject "MobiusSPMTest" */;
+			compatibilityVersion = "Xcode 9.3";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 2D35A2AB241F8C2700C344AC;
+			packageReferences = (
+				2D35A2BE241F8C6000C344AC /* XCRemoteSwiftPackageReference "Mobius.swift" */,
+				2D35A2C8241F8D3E00C344AC /* XCRemoteSwiftPackageReference "Nimble" */,
+			);
+			productRefGroup = 2D35A2B5241F8C2700C344AC /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				2D35A2CB241F8FE400C344AC /* MobiusSPMTest_iOS */,
+				2D35A2B3241F8C2700C344AC /* MobiusSPMTest_macOS */,
+				2D35A2E0241F910200C344AC /* MobiusSPMTest_tvOS */,
+				2D35A2F5241F911700C344AC /* MobiusSPMTest_watchOS */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXSourcesBuildPhase section */
+		2D35A2B0241F8C2700C344AC /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				2D35A2B8241F8C2700C344AC /* Test.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		2D35A2D3241F8FE400C344AC /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				2D35A2D4241F8FE400C344AC /* Test.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		2D35A2E8241F910200C344AC /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				2D35A2E9241F910200C344AC /* Test.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		2D35A2FD241F911700C344AC /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				2D35A2FE241F911700C344AC /* Test.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		2D35A2B9241F8C2700C344AC /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_TESTABILITY = YES;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				MACOSX_DEPLOYMENT_TARGET = 10.12;
+				ONLY_ACTIVE_ARCH = YES;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				TVOS_DEPLOYMENT_TARGET = 10.0;
+				WATCHOS_DEPLOYMENT_TARGET = 3.0;
+			};
+			name = Debug;
+		};
+		2D35A2BA241F8C2700C344AC /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				GCC_NO_COMMON_BLOCKS = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				MACOSX_DEPLOYMENT_TARGET = 10.12;
+				SKIP_INSTALL = YES;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				TVOS_DEPLOYMENT_TARGET = 10.0;
+				VALIDATE_PRODUCT = YES;
+				WATCHOS_DEPLOYMENT_TARGET = 3.0;
+			};
+			name = Release;
+		};
+		2D35A2BC241F8C2700C344AC /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 2FNC3A47ZF;
+				OTHER_LDFLAGS = "-ObjC";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		2D35A2BD241F8C2700C344AC /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 2FNC3A47ZF;
+				OTHER_LDFLAGS = "-ObjC";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		2D35A2DD241F8FE400C344AC /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 2FNC3A47ZF;
+				OTHER_LDFLAGS = "-ObjC";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SUPPORTS_MACCATALYST = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		2D35A2DE241F8FE400C344AC /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 2FNC3A47ZF;
+				OTHER_LDFLAGS = "-ObjC";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SUPPORTS_MACCATALYST = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		2D35A2F2241F910200C344AC /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 2FNC3A47ZF;
+				OTHER_LDFLAGS = "-ObjC";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = appletvos;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		2D35A2F3241F910200C344AC /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 2FNC3A47ZF;
+				OTHER_LDFLAGS = "-ObjC";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = appletvos;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		2D35A307241F911700C344AC /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 2FNC3A47ZF;
+				OTHER_LDFLAGS = "-ObjC";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = watchos;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		2D35A308241F911700C344AC /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 2FNC3A47ZF;
+				OTHER_LDFLAGS = "-ObjC";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = watchos;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		2D35A2AF241F8C2700C344AC /* Build configuration list for PBXProject "MobiusSPMTest" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				2D35A2B9241F8C2700C344AC /* Debug */,
+				2D35A2BA241F8C2700C344AC /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		2D35A2BB241F8C2700C344AC /* Build configuration list for PBXNativeTarget "MobiusSPMTest_macOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				2D35A2BC241F8C2700C344AC /* Debug */,
+				2D35A2BD241F8C2700C344AC /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		2D35A2DC241F8FE400C344AC /* Build configuration list for PBXNativeTarget "MobiusSPMTest_iOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				2D35A2DD241F8FE400C344AC /* Debug */,
+				2D35A2DE241F8FE400C344AC /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		2D35A2F1241F910200C344AC /* Build configuration list for PBXNativeTarget "MobiusSPMTest_tvOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				2D35A2F2241F910200C344AC /* Debug */,
+				2D35A2F3241F910200C344AC /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		2D35A306241F911700C344AC /* Build configuration list for PBXNativeTarget "MobiusSPMTest_watchOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				2D35A307241F911700C344AC /* Debug */,
+				2D35A308241F911700C344AC /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		2D35A2BE241F8C6000C344AC /* XCRemoteSwiftPackageReference "Mobius.swift" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/spotify/Mobius.swift.git";
+			requirement = {
+				branch = master;
+				kind = branch;
+			};
+		};
+		2D35A2C8241F8D3E00C344AC /* XCRemoteSwiftPackageReference "Nimble" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/Quick/Nimble";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 8.0.5;
+			};
+		};
+		2D35A2CD241F8FE400C344AC /* XCRemoteSwiftPackageReference "Mobius.swift" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/spotify/Mobius.swift.git";
+			requirement = {
+				branch = master;
+				kind = branch;
+			};
+		};
+		2D35A2D2241F8FE400C344AC /* XCRemoteSwiftPackageReference "Nimble" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/Quick/Nimble";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 8.0.5;
+			};
+		};
+		2D35A2E2241F910200C344AC /* XCRemoteSwiftPackageReference "Mobius.swift" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/spotify/Mobius.swift.git";
+			requirement = {
+				branch = master;
+				kind = branch;
+			};
+		};
+		2D35A2E7241F910200C344AC /* XCRemoteSwiftPackageReference "Nimble" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/Quick/Nimble";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 8.0.5;
+			};
+		};
+		2D35A2F7241F911700C344AC /* XCRemoteSwiftPackageReference "Mobius.swift" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/spotify/Mobius.swift.git";
+			requirement = {
+				branch = master;
+				kind = branch;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		2D35A2BF241F8C6000C344AC /* MobiusCore */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 2D35A2BE241F8C6000C344AC /* XCRemoteSwiftPackageReference "Mobius.swift" */;
+			productName = MobiusCore;
+		};
+		2D35A2C1241F8C6000C344AC /* MobiusExtras */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 2D35A2BE241F8C6000C344AC /* XCRemoteSwiftPackageReference "Mobius.swift" */;
+			productName = MobiusExtras;
+		};
+		2D35A2C4241F8CFD00C344AC /* MobiusNimble */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 2D35A2BE241F8C6000C344AC /* XCRemoteSwiftPackageReference "Mobius.swift" */;
+			productName = MobiusNimble;
+		};
+		2D35A2C6241F8CFD00C344AC /* MobiusTest */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 2D35A2BE241F8C6000C344AC /* XCRemoteSwiftPackageReference "Mobius.swift" */;
+			productName = MobiusTest;
+		};
+		2D35A2C9241F8D3E00C344AC /* Nimble */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 2D35A2C8241F8D3E00C344AC /* XCRemoteSwiftPackageReference "Nimble" */;
+			productName = Nimble;
+		};
+		2D35A2CC241F8FE400C344AC /* MobiusCore */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 2D35A2CD241F8FE400C344AC /* XCRemoteSwiftPackageReference "Mobius.swift" */;
+			productName = MobiusCore;
+		};
+		2D35A2CE241F8FE400C344AC /* MobiusExtras */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 2D35A2CD241F8FE400C344AC /* XCRemoteSwiftPackageReference "Mobius.swift" */;
+			productName = MobiusExtras;
+		};
+		2D35A2CF241F8FE400C344AC /* MobiusNimble */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 2D35A2CD241F8FE400C344AC /* XCRemoteSwiftPackageReference "Mobius.swift" */;
+			productName = MobiusNimble;
+		};
+		2D35A2D0241F8FE400C344AC /* MobiusTest */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 2D35A2CD241F8FE400C344AC /* XCRemoteSwiftPackageReference "Mobius.swift" */;
+			productName = MobiusTest;
+		};
+		2D35A2D1241F8FE400C344AC /* Nimble */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 2D35A2D2241F8FE400C344AC /* XCRemoteSwiftPackageReference "Nimble" */;
+			productName = Nimble;
+		};
+		2D35A2E1241F910200C344AC /* MobiusCore */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 2D35A2E2241F910200C344AC /* XCRemoteSwiftPackageReference "Mobius.swift" */;
+			productName = MobiusCore;
+		};
+		2D35A2E3241F910200C344AC /* MobiusExtras */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 2D35A2E2241F910200C344AC /* XCRemoteSwiftPackageReference "Mobius.swift" */;
+			productName = MobiusExtras;
+		};
+		2D35A2E4241F910200C344AC /* MobiusNimble */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 2D35A2E2241F910200C344AC /* XCRemoteSwiftPackageReference "Mobius.swift" */;
+			productName = MobiusNimble;
+		};
+		2D35A2E5241F910200C344AC /* MobiusTest */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 2D35A2E2241F910200C344AC /* XCRemoteSwiftPackageReference "Mobius.swift" */;
+			productName = MobiusTest;
+		};
+		2D35A2E6241F910200C344AC /* Nimble */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 2D35A2E7241F910200C344AC /* XCRemoteSwiftPackageReference "Nimble" */;
+			productName = Nimble;
+		};
+		2D35A2F6241F911700C344AC /* MobiusCore */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 2D35A2F7241F911700C344AC /* XCRemoteSwiftPackageReference "Mobius.swift" */;
+			productName = MobiusCore;
+		};
+		2D35A2F8241F911700C344AC /* MobiusExtras */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 2D35A2F7241F911700C344AC /* XCRemoteSwiftPackageReference "Mobius.swift" */;
+			productName = MobiusExtras;
+		};
+/* End XCSwiftPackageProductDependency section */
+	};
+	rootObject = 2D35A2AC241F8C2700C344AC /* Project object */;
+}

--- a/Tools/BuildSystemTests/MobiusSPMTest/MobiusSPMTest.xcodeproj/xcshareddata/xcschemes/MobiusSPMTest_iOS.xcscheme
+++ b/Tools/BuildSystemTests/MobiusSPMTest/MobiusSPMTest.xcodeproj/xcshareddata/xcschemes/MobiusSPMTest_iOS.xcscheme
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1140"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "2D35A2CB241F8FE400C344AC"
+               BuildableName = "libMobiusSPMTest_iOS.a"
+               BlueprintName = "MobiusSPMTest_iOS"
+               ReferencedContainer = "container:MobiusSPMTest.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "2D35A2CB241F8FE400C344AC"
+            BuildableName = "libMobiusSPMTest_iOS.a"
+            BlueprintName = "MobiusSPMTest_iOS"
+            ReferencedContainer = "container:MobiusSPMTest.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Tools/BuildSystemTests/MobiusSPMTest/MobiusSPMTest.xcodeproj/xcshareddata/xcschemes/MobiusSPMTest_macOS.xcscheme
+++ b/Tools/BuildSystemTests/MobiusSPMTest/MobiusSPMTest.xcodeproj/xcshareddata/xcschemes/MobiusSPMTest_macOS.xcscheme
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1140"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "2D35A2B3241F8C2700C344AC"
+               BuildableName = "libMobiusSPMTest_macOS.a"
+               BlueprintName = "MobiusSPMTest_macOS"
+               ReferencedContainer = "container:MobiusSPMTest.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "2D35A2B3241F8C2700C344AC"
+            BuildableName = "libMobiusSPMTest_macOS.a"
+            BlueprintName = "MobiusSPMTest_macOS"
+            ReferencedContainer = "container:MobiusSPMTest.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Tools/BuildSystemTests/MobiusSPMTest/MobiusSPMTest.xcodeproj/xcshareddata/xcschemes/MobiusSPMTest_tvOS.xcscheme
+++ b/Tools/BuildSystemTests/MobiusSPMTest/MobiusSPMTest.xcodeproj/xcshareddata/xcschemes/MobiusSPMTest_tvOS.xcscheme
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1140"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "2D35A2E0241F910200C344AC"
+               BuildableName = "libMobiusSPMTest_tvOS.a"
+               BlueprintName = "MobiusSPMTest_tvOS"
+               ReferencedContainer = "container:MobiusSPMTest.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "2D35A2E0241F910200C344AC"
+            BuildableName = "libMobiusSPMTest_tvOS.a"
+            BlueprintName = "MobiusSPMTest_tvOS"
+            ReferencedContainer = "container:MobiusSPMTest.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Tools/BuildSystemTests/MobiusSPMTest/MobiusSPMTest.xcodeproj/xcshareddata/xcschemes/MobiusSPMTest_watchOS.xcscheme
+++ b/Tools/BuildSystemTests/MobiusSPMTest/MobiusSPMTest.xcodeproj/xcshareddata/xcschemes/MobiusSPMTest_watchOS.xcscheme
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1140"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "2D35A2F5241F911700C344AC"
+               BuildableName = "libMobiusSPMTest_watchOS.a"
+               BlueprintName = "MobiusSPMTest_watchOS"
+               ReferencedContainer = "container:MobiusSPMTest.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "2D35A2F5241F911700C344AC"
+            BuildableName = "libMobiusSPMTest_watchOS.a"
+            BlueprintName = "MobiusSPMTest_watchOS"
+            ReferencedContainer = "container:MobiusSPMTest.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Tools/BuildSystemTests/MobiusSPMTest/run-test.sh
+++ b/Tools/BuildSystemTests/MobiusSPMTest/run-test.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+root=`dirname $0`
+source "$root/../../helpers.sh"
+
+project=$root/MobiusSPMTest.xcodeproj
+platforms=(iOS macOS tvOS watchOS)
+
+for platform in ${platforms[@]}; do
+    heading "Building for $platform using Swift Package Manager"
+    scheme=MobiusSPMTest_$platform
+
+    xcb -project $project -scheme $scheme || \
+        fail "Swift Package Manager build for $platform failed"
+done

--- a/Tools/BuildSystemTests/SharedSource/Test.swift
+++ b/Tools/BuildSystemTests/SharedSource/Test.swift
@@ -1,0 +1,24 @@
+import MobiusCore
+import MobiusExtras
+#if !os(watchOS)
+import MobiusNimble
+import MobiusTest
+import Nimble
+#endif
+
+typealias Model = String
+typealias Event = Int
+typealias Effect = UInt
+
+public class MobiusSPMTest {
+    public func verifyLinkage() {
+        let update = Update<Model, Event, Effect> { _, _ in
+            .noChange
+        }
+        let effectHandler = EffectRouter<Effect, Event>()
+            .asConnectable
+
+        let _ = Mobius.loop(update: update, effectHandler: effectHandler)
+            .start(from: "")
+    }
+}

--- a/Tools/run-build-system-tests.sh
+++ b/Tools/run-build-system-tests.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -e
+
+source `dirname $0`/helpers.sh
+tests=Tools/BuildSystemTests/*/run-test.sh
+
+for test_script in $tests; do
+    $test_script
+done


### PR DESCRIPTION
Adds test cases for depending on Mobius using Xcode SPM integration.

**Note:** Requires Xcode 11.3 or later.

This test is currently not run in CI. Doing so premerge might be messy because we’d need to fiddle with the Xcode project to fetch from the right fork and commit. Right now it just fetches master from the main repo.

I intend to add similar tests for Carthage and CocoaPods, hence the structure with a meta-runner.

@dflems @jeppes 