### PR TITLE
Reorganize error messages

### DIFF
--- a/MobiusCore/Source/BrokenConnection.swift
+++ b/MobiusCore/Source/BrokenConnection.swift
@@ -25,11 +25,11 @@ import Foundation
 /// connection will trigger an assertion whenever its `accept` or `dispose` methods are called.
 public enum BrokenConnection<Value> {
     static func _accept(_ value: Value) {
-        MobiusHooks.errorHandler("'accept' called on invalid connection", #file, #line)
+        MobiusHooks.errorHandler("'accept' called on invalid connection of \(Value.self)", #file, #line)
     }
 
     static func _dispose() {
-        MobiusHooks.errorHandler("'dispose' called on invalid connection", #file, #line)
+        MobiusHooks.errorHandler("'dispose' called on invalid connection of \(Value.self)", #file, #line)
     }
 
     /// Construct a broken connection.

--- a/MobiusCore/Source/BrokenConnection.swift
+++ b/MobiusCore/Source/BrokenConnection.swift
@@ -25,11 +25,11 @@ import Foundation
 /// connection will trigger an assertion whenever its `accept` or `dispose` methods are called.
 public enum BrokenConnection<Value> {
     static func _accept(_ value: Value) {
-        MobiusHooks.onError("'accept' called on invalid connection")
+        MobiusHooks.errorHandler("'accept' called on invalid connection", #file, #line)
     }
 
     static func _dispose() {
-        MobiusHooks.onError("'dispose' called on invalid connection")
+        MobiusHooks.errorHandler("'dispose' called on invalid connection", #file, #line)
     }
 
     /// Construct a broken connection.

--- a/MobiusCore/Source/ConnectableConvenienceClasses/AsyncDispatchQueueConnectable.swift
+++ b/MobiusCore/Source/ConnectableConvenienceClasses/AsyncDispatchQueueConnectable.swift
@@ -79,7 +79,7 @@ final class AsyncDispatchQueueConnectable<Input, Output>: Connectable {
             },
             disposeClosure: { [acceptQueue] in
                 guard disposalStatus.compareAndSwap(expected: .notDisposed, with: .pendingDispose) else {
-                    MobiusHooks.onError("cannot dispose more than once")
+                    MobiusHooks.errorHandler("cannot dispose more than once", #file, #line)
                     return
                 }
 

--- a/MobiusCore/Source/ConnectablePublisher.swift
+++ b/MobiusCore/Source/ConnectablePublisher.swift
@@ -40,7 +40,11 @@ final class ConnectablePublisher<Value>: Disposable {
         let connections: [Connection<Value>] = access.guard {
             guard !disposed else {
                 // Callers are responsible for ensuring post is never entered after dispose.
-                MobiusHooks.errorHandler("cannot accept values when disposed", #file, #line)
+                MobiusHooks.errorHandler(
+                    "ConnectablePublisher<\(Value.self)> cannot accept values when disposed",
+                    #file,
+                    #line
+                )
                 return []
             }
 
@@ -59,7 +63,11 @@ final class ConnectablePublisher<Value>: Disposable {
         return access.guard { () -> Connection<Value> in
             guard !_disposed else {
                 // Callers are responsible for ensuring connect is never entered after dispose.
-                MobiusHooks.errorHandler("cannot add connections when disposed", #file, #line)
+                MobiusHooks.errorHandler(
+                    "ConnectablePublisher<\(Value.self)> cannot add connections when disposed",
+                    #file,
+                    #line
+                )
                 return BrokenConnection<Value>.connection()
             }
 

--- a/MobiusCore/Source/ConnectablePublisher.swift
+++ b/MobiusCore/Source/ConnectablePublisher.swift
@@ -40,7 +40,7 @@ final class ConnectablePublisher<Value>: Disposable {
         let connections: [Connection<Value>] = access.guard {
             guard !disposed else {
                 // Callers are responsible for ensuring post is never entered after dispose.
-                MobiusHooks.onError("cannot accept values when disposed")
+                MobiusHooks.errorHandler("cannot accept values when disposed", #file, #line)
                 return []
             }
 
@@ -59,7 +59,7 @@ final class ConnectablePublisher<Value>: Disposable {
         return access.guard { () -> Connection<Value> in
             guard !_disposed else {
                 // Callers are responsible for ensuring connect is never entered after dispose.
-                MobiusHooks.onError("cannot add connections when disposed")
+                MobiusHooks.errorHandler("cannot add connections when disposed", #file, #line)
                 return BrokenConnection<Value>.connection()
             }
 

--- a/MobiusCore/Source/EffectHandlers/EffectExecutor.swift
+++ b/MobiusCore/Source/EffectHandlers/EffectExecutor.swift
@@ -38,9 +38,11 @@ final class EffectExecutor<Effect, Event>: Connectable {
     func connect(_ consumer: @escaping Consumer<Event>) -> Connection<Effect> {
         return lock.synchronized {
             guard output == nil else {
-                MobiusHooks.onError(
+                MobiusHooks.errorHandler(
                     "Connection limit exceeded: The Connectable \(type(of: self)) is already connected. " +
-                    "Unable to connect more than once"
+                    "Unable to connect more than once",
+                    #file,
+                    #line
                 )
                 return BrokenConnection.connection()
             }

--- a/MobiusCore/Source/EffectHandlers/EffectRouter.swift
+++ b/MobiusCore/Source/EffectHandlers/EffectRouter.swift
@@ -142,9 +142,11 @@ private func compose<Input, Output>(
                 if let handleEffect = handlers.first, handlers.count == 1 {
                     handleEffect()
                 } else {
-                    MobiusHooks.onError(
+                    MobiusHooks.errorHandler(
                         "Error: \(handlers.count) EffectHandlers could be found for effect: \(effect). " +
-                        "Exactly 1 is required."
+                        "Exactly 1 is required.",
+                        #file,
+                        #line
                     )
                 }
             },

--- a/MobiusCore/Source/EffectHandlers/ThreadSafeConnectable.swift
+++ b/MobiusCore/Source/EffectHandlers/ThreadSafeConnectable.swift
@@ -33,9 +33,11 @@ final class ThreadSafeConnectable<Event, Effect>: Connectable {
     func connect(_ output: @escaping (Event) -> Void) -> Connection<Effect> {
         return lock.synchronized {
             guard self.output == nil, connection == nil else {
-                MobiusHooks.onError(
+                MobiusHooks.errorHandler(
                     "Connection limit exceeded: The Connectable \(type(of: self)) is already connected. " +
-                    "Unable to connect more than once"
+                    "Unable to connect more than once",
+                    #file,
+                    #line
                 )
                 return BrokenConnection.connection()
             }

--- a/MobiusCore/Source/EffectRouterBuilder.swift
+++ b/MobiusCore/Source/EffectRouterBuilder.swift
@@ -99,12 +99,12 @@ private func dispatchAccept<Input>(_ connections: [PredicatedConnection<Input>],
     let responders = selectConnections(connections, respondingTo: input)
 
     if responders.count > 1 {
-        MobiusHooks.onError("More than one effect handler handling effect: \(input)")
+        MobiusHooks.errorHandler("More than one effect handler handling effect: \(input)", #file, #line)
         return
     }
 
     guard let (connection, _) = responders.first else {
-        MobiusHooks.onError("No effect handler is handling the effect: \(input)")
+        MobiusHooks.errorHandler("No effect handler is handling the effect: \(input)", #file, #line)
         return
     }
 

--- a/MobiusCore/Source/MobiusController.swift
+++ b/MobiusCore/Source/MobiusController.swift
@@ -156,7 +156,7 @@ public final class MobiusController<Model, Event, Effect> {
         do {
             try state.mutate { stoppedState in
                 guard stoppedState.viewConnectable == nil else {
-                    throw Error.message("\(Self.debugTag): only one view may be connected at a time")
+                    throw ErrorMessage(message: "\(Self.debugTag): only one view may be connected at a time")
                 }
 
                 stoppedState.viewConnectable = AsyncDispatchQueueConnectable(connectable, acceptQueue: viewQueue)
@@ -180,7 +180,7 @@ public final class MobiusController<Model, Event, Effect> {
         do {
             try state.mutate { stoppedState in
                 guard stoppedState.viewConnectable != nil else {
-                    throw Error.message("\(Self.debugTag): no view connected, cannot disconnect")
+                    throw ErrorMessage(message: "\(Self.debugTag): no view connected, cannot disconnect")
                 }
 
                 stoppedState.viewConnectable = nil
@@ -293,17 +293,14 @@ public final class MobiusController<Model, Event, Effect> {
     }
 
     /// Simple error that just carries an error message out of a closure for us
-    private enum Error: Swift.Error {
-        case message(String)
+    private struct ErrorMessage: Error {
+        let message: String
     }
 
-    /// If `error` is an `Error.message`, return its payload; otherwise, return the provided default message.
+    /// If `error` is an `ErrorMessage`, return its payload; otherwise, return the provided default message.
     private func errorMessage(_ error: Swift.Error, default defaultMessage: String) -> String {
-        if let myError = error as? Error {
-            switch myError {
-            case .message(let content):
-                return content
-            }
+        if let errorMessage = error as? ErrorMessage {
+            return errorMessage.message
         } else {
             return defaultMessage
         }

--- a/MobiusCore/Source/MobiusController.swift
+++ b/MobiusCore/Source/MobiusController.swift
@@ -107,7 +107,7 @@ public final class MobiusController<Model, Event, Effect> {
         func flipEventsToLoopQueue(consumer: @escaping Consumer<Event>) -> Consumer<Event> {
             return { event in
                 guard state.running else {
-                    MobiusHooks.errorHandler("cannot accept events when stopped", #file, #line)
+                    MobiusHooks.errorHandler("\(Self.debugTag): cannot accept events when stopped", #file, #line)
                     return
                 }
 
@@ -156,14 +156,14 @@ public final class MobiusController<Model, Event, Effect> {
         do {
             try state.mutate { stoppedState in
                 guard stoppedState.viewConnectable == nil else {
-                    throw Error.message("controller only supports connecting one view")
+                    throw Error.message("\(Self.debugTag): only one view may be connected at a time")
                 }
 
                 stoppedState.viewConnectable = AsyncDispatchQueueConnectable(connectable, acceptQueue: viewQueue)
             }
         } catch {
            MobiusHooks.errorHandler(
-               errorMessage(error, default: "cannot connect to a running controller"),
+               errorMessage(error, default: "\(Self.debugTag): cannot connect a view while running"),
                #file,
                #line
            )
@@ -180,14 +180,14 @@ public final class MobiusController<Model, Event, Effect> {
         do {
             try state.mutate { stoppedState in
                 guard stoppedState.viewConnectable != nil else {
-                    throw Error.message("not connected, cannot disconnect view from controller")
+                    throw Error.message("\(Self.debugTag): no view connected, cannot disconnect")
                 }
 
                 stoppedState.viewConnectable = nil
             }
         } catch {
             MobiusHooks.errorHandler(
-                errorMessage(error, default: "cannot disconnect from a running controller; call stop first"),
+                errorMessage(error, default: "\(Self.debugTag): cannot disconnect view while running; call stop first"),
                 #file,
                 #line
             )
@@ -222,7 +222,7 @@ public final class MobiusController<Model, Event, Effect> {
             }
         } catch {
             MobiusHooks.errorHandler(
-                errorMessage(error, default: "cannot start a running controller"),
+                errorMessage(error, default: "\(Self.debugTag): cannot start a while already running"),
                 #file,
                 #line
             )
@@ -249,7 +249,7 @@ public final class MobiusController<Model, Event, Effect> {
             }
         } catch {
             MobiusHooks.errorHandler(
-                errorMessage(error, default: "cannot stop a controller that isn't running"),
+                errorMessage(error, default: "\(Self.debugTag): cannot stop a controller while not running"),
                 #file,
                 #line
             )
@@ -269,7 +269,7 @@ public final class MobiusController<Model, Event, Effect> {
             }
         } catch {
             MobiusHooks.errorHandler(
-                errorMessage(error, default: "cannot replace the model of a running loop"),
+                errorMessage(error, default: "\(Self.debugTag): cannot replace model while running"),
                 #file,
                 #line
             )
@@ -307,5 +307,9 @@ public final class MobiusController<Model, Event, Effect> {
         } else {
             return defaultMessage
         }
+    }
+
+    private static var debugTag: String {
+        return "MobiusController<\(Model.self), \(Event.self), \(Effect.self)>"
     }
 }

--- a/MobiusCore/Source/MobiusController.swift
+++ b/MobiusCore/Source/MobiusController.swift
@@ -107,7 +107,7 @@ public final class MobiusController<Model, Event, Effect> {
         func flipEventsToLoopQueue(consumer: @escaping Consumer<Event>) -> Consumer<Event> {
             return { event in
                 guard state.running else {
-                    MobiusHooks.onError("cannot accept events when stopped")
+                    MobiusHooks.errorHandler("cannot accept events when stopped", #file, #line)
                     return
                 }
 
@@ -148,38 +148,49 @@ public final class MobiusController<Model, Event, Effect> {
     /// The view should also return a `Connection` that accepts models and renders them. Disposing the connection should
     /// make the view stop emitting events.
     ///
-    /// - Attention: fails via `MobiusHooks.onError` if the loop is running or if the controller already is connected
+    /// - Attention: fails via `MobiusHooks.errorHandler` if the loop is running or if the controller already is
+    ///              connected
     public func connectView<ViewConnectable: Connectable>(
         _ connectable: ViewConnectable
     ) where ViewConnectable.Input == Model, ViewConnectable.Output == Event {
-        state.mutateIfStopped(elseError: "cannot connect to a running controller") { state in
-            guard state.viewConnectable == nil else {
-                MobiusHooks.onError("controller only supports connecting one view")
-                return
-            }
+        do {
+            try state.mutate { stoppedState in
+                guard stoppedState.viewConnectable == nil else {
+                    throw Error.message("controller only supports connecting one view")
+                }
 
-            state.viewConnectable = AsyncDispatchQueueConnectable(
-                connectable,
-                acceptQueue: viewQueue
-            )
-        }
+                stoppedState.viewConnectable = AsyncDispatchQueueConnectable(connectable, acceptQueue: viewQueue)
+            }
+        } catch {
+           MobiusHooks.errorHandler(
+               errorMessage(error, default: "cannot connect to a running controller"),
+               #file,
+               #line
+           )
+       }
     }
 
     /// Disconnect the connected view from this controller.
     ///
     /// May not be called directly from an effect handler running on the controller’s loop queue.
     ///
-    /// - Attention: fails via `MobiusHooks.onError` if the loop is running or if there isn't anything to disconnect
+    /// - Attention: fails via `MobiusHooks.errorHandler` if the loop is running or if there isn't anything to
+    /// disconnect
     public func disconnectView() {
-        state.mutateIfStopped(
-            elseError: "cannot disconnect from a running controller; call stop first"
-        ) { stoppedState in
-            guard stoppedState.viewConnectable != nil else {
-                MobiusHooks.onError("not connected, cannot disconnect view from controller")
-                return
-            }
+        do {
+            try state.mutate { stoppedState in
+                guard stoppedState.viewConnectable != nil else {
+                    throw Error.message("not connected, cannot disconnect view from controller")
+                }
 
-            stoppedState.viewConnectable = nil
+                stoppedState.viewConnectable = nil
+            }
+        } catch {
+            MobiusHooks.errorHandler(
+                errorMessage(error, default: "cannot disconnect from a running controller; call stop first"),
+                #file,
+                #line
+            )
         }
     }
 
@@ -187,25 +198,33 @@ public final class MobiusController<Model, Event, Effect> {
     ///
     /// May not be called directly from an effect handler running on the controller’s loop queue.
     ///
-    /// - Attention: fails via `MobiusHooks.onError` if the loop already is running.
+    /// - Attention: fails via `MobiusHooks.errorHandler` if the loop already is running.
     public func start() {
-        state.transitionToRunning(elseError: "cannot start a running controller") { stoppedState in
-            let loop = loopFactory(stoppedState.modelToStartFrom)
+        do {
+            try state.transitionToRunning { stoppedState in
+                let loop = loopFactory(stoppedState.modelToStartFrom)
 
-            var disposables: [Disposable] = [loop]
+                var disposables: [Disposable] = [loop]
 
-            if let viewConnectable = stoppedState.viewConnectable {
-                // Note: loop.unguardedDispatchEvent will call our flipEventsToLoopQueue, which implements the assertion
-                // that “unguarded” refers to, and also (of course) flips to the loop queue.
-                let viewConnection = viewConnectable.connect(loop.unguardedDispatchEvent)
-                loop.addObserver(viewConnection.accept)
-                disposables.append(viewConnection)
+                if let viewConnectable = stoppedState.viewConnectable {
+                    // Note: loop.unguardedDispatchEvent will call our flipEventsToLoopQueue, which implements the assertion
+                    // that “unguarded” refers to, and also (of course) flips to the loop queue.
+                    let viewConnection = viewConnectable.connect(loop.unguardedDispatchEvent)
+                    loop.addObserver(viewConnection.accept)
+                    disposables.append(viewConnection)
+                }
+
+                return RunningState(
+                    loop: loop,
+                    viewConnectable: stoppedState.viewConnectable,
+                    disposables: CompositeDisposable(disposables: disposables)
+                )
             }
-
-            return RunningState(
-                loop: loop,
-                viewConnectable: stoppedState.viewConnectable,
-                disposables: CompositeDisposable(disposables: disposables)
+        } catch {
+            MobiusHooks.errorHandler(
+                errorMessage(error, default: "cannot start a running controller"),
+                #file,
+                #line
             )
         }
     }
@@ -218,14 +237,22 @@ public final class MobiusController<Model, Event, Effect> {
     /// May not be called directly from an effect handler running on the controller’s loop queue.
     /// To stop the loop as an effect, dispatch to a different queue.
     ///
-    /// - Attention: fails via `MobiusHooks.onError` if the loop isn't running
+    /// - Attention: fails via `MobiusHooks.errorHandler` if the loop isn't running
     public func stop() {
-        state.transitionToStopped(elseError: "cannot stop a controller that isn't running") { runningState in
-            let model = runningState.loop.latestModel
+        do {
+            try state.transitionToStopped { runningState in
+                let model = runningState.loop.latestModel
 
-            runningState.disposables.dispose()
+                runningState.disposables.dispose()
 
-            return StoppedState(modelToStartFrom: model, viewConnectable: runningState.viewConnectable)
+                return StoppedState(modelToStartFrom: model, viewConnectable: runningState.viewConnectable)
+            }
+        } catch {
+            MobiusHooks.errorHandler(
+                errorMessage(error, default: "cannot stop a controller that isn't running"),
+                #file,
+                #line
+            )
         }
     }
 
@@ -234,10 +261,18 @@ public final class MobiusController<Model, Event, Effect> {
     /// May not be called directly from an effect handler running on the controller’s loop queue.
     ///
     /// - Parameter model: the model with the state the controller should start from
-    /// - Attention: fails via `MobiusHooks.onError` if the loop is running
+    /// - Attention: fails via `MobiusHooks.errorHandler` if the loop is running
     public func replaceModel(_ model: Model) {
-        state.mutateIfStopped(elseError: "cannot replace the model of a running loop") { state in
-            state.modelToStartFrom = model
+        do {
+            try state.mutate { stoppedState in
+                stoppedState.modelToStartFrom = model
+            }
+        } catch {
+            MobiusHooks.errorHandler(
+                errorMessage(error, default: "cannot replace the model of a running loop"),
+                #file,
+                #line
+            )
         }
     }
 
@@ -254,6 +289,23 @@ public final class MobiusController<Model, Event, Effect> {
             case .running(let state):
                 return state.loop.latestModel
             }
+        }
+    }
+
+    /// Simple error that just carries an error message out of a closure for us
+    private enum Error: Swift.Error {
+        case message(String)
+    }
+
+    /// If `error` is an `Error.message`, return its payload; otherwise, return the provided default message.
+    private func errorMessage(_ error: Swift.Error, default defaultMessage: String) -> String {
+        if let myError = error as? Error {
+            switch myError {
+            case .message(let content):
+                return content
+            }
+        } else {
+            return defaultMessage
         }
     }
 }

--- a/MobiusCore/Source/MobiusHooks.swift
+++ b/MobiusCore/Source/MobiusHooks.swift
@@ -27,7 +27,9 @@ import Foundation
 public enum MobiusHooks {
     public typealias ErrorHandler = (String, StaticString, UInt) -> Void
 
-    private static var errorHandler: ErrorHandler = MobiusHooks.defaultErrorHandler
+    /// Internal: we prefer to call `errorHandler` directly, without abstractions, to minimize the depth of crash
+    /// stack traces. This requires that `#file` and `#line` are passed explicitly.
+    static private(set) var errorHandler: ErrorHandler = MobiusHooks.defaultErrorHandler
 
     public static func setErrorHandler(_ newErrorHandler: @escaping ErrorHandler) {
         errorHandler = newErrorHandler
@@ -35,10 +37,6 @@ public enum MobiusHooks {
 
     public static func setDefaultErrorHandler() {
         errorHandler = defaultErrorHandler
-    }
-
-    static func onError(_ message: String = "", file: StaticString = #file, line: UInt = #line) {
-        errorHandler(message, file, line)
     }
 
     public static func defaultErrorHandler(_ message: String = "", file: StaticString = #file, line: UInt = #line) {

--- a/MobiusCore/Source/MobiusLoop.swift
+++ b/MobiusCore/Source/MobiusLoop.swift
@@ -91,7 +91,7 @@ public final class MobiusLoop<Model, Event, Effect>: Disposable, CustomDebugStri
         return access.guard {
             guard !disposed else {
                 // Callers are responsible for ensuring dispatchEvent is never entered after dispose.
-                MobiusHooks.onError("event submitted after dispose")
+                MobiusHooks.errorHandler("event submitted after dispose", #file, #line)
                 return
             }
 

--- a/MobiusCore/Source/MobiusLoop.swift
+++ b/MobiusCore/Source/MobiusLoop.swift
@@ -91,7 +91,7 @@ public final class MobiusLoop<Model, Event, Effect>: Disposable, CustomDebugStri
         return access.guard {
             guard !disposed else {
                 // Callers are responsible for ensuring dispatchEvent is never entered after dispose.
-                MobiusHooks.errorHandler("event submitted after dispose", #file, #line)
+                MobiusHooks.errorHandler("\(Self.debugTag): event submitted after dispose", #file, #line)
                 return
             }
 
@@ -178,5 +178,9 @@ public final class MobiusLoop<Model, Event, Effect>: Disposable, CustomDebugStri
             accessGuard: accessGuard,
             workBag: workBag
         )
+    }
+
+    private static var debugTag: String {
+        return "MobiusLoop<\(Model.self), \(Event.self), \(Effect.self)>"
     }
 }

--- a/MobiusCore/Test/MobiusHooksTests.swift
+++ b/MobiusCore/Test/MobiusHooksTests.swift
@@ -41,7 +41,7 @@ class MobiusHooksTests: QuickSpec {
                     })
 
                     errorCalledOnLine = #line + 1
-                    MobiusHooks.onError(someString)
+                    MobiusHooks.errorHandler(someString, #file, #line)
                 }
                 it("should use that error handler when an error occurs") {
                     expect(errorMessage).to(match(someString))


### PR DESCRIPTION
We’ve seen that stack traces from crashes in `MobiusController` are so deep, our crash analytics merges them into a single report. This PR seeks to flatten those stacks as far as practical.

(We’d be able to get a step further if `ErrorHandler` returned `Never` instead of `Void`, which would also make some call sites nicer. I tried to get us there a while ago, but got stuck because Nimble uses different types for file names depending on the build system in use. I’ll try to revisit that soon.)

(Edit: reading that back I don’t even understand why that was a problem, trying again)

@jeppes 