### PR TITLE
Non returning assertions

### DIFF
--- a/Mobius.xcodeproj/project.pbxproj
+++ b/Mobius.xcodeproj/project.pbxproj
@@ -23,6 +23,9 @@
 		02D6755723D20507008200AF /* EnumRouteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02D6755423D2049E008200AF /* EnumRouteTests.swift */; };
 		2D15DF73238EA4DD00E78B27 /* LoggingAdaptors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D15DF72238EA4DD00E78B27 /* LoggingAdaptors.swift */; };
 		2D24D15323FAE746005D175E /* AnonymousDisposableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D24D15123FAE728005D175E /* AnonymousDisposableTests.swift */; };
+		2D25B99924337B0E0077FB07 /* TestingErrorHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D25B99824337B0E0077FB07 /* TestingErrorHandler.swift */; };
+		2D25B9AE24337C690077FB07 /* libMobiusThrowableAssertion.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 2D25B99E24337BCC0077FB07 /* libMobiusThrowableAssertion.a */; };
+		2D25B9B124337C720077FB07 /* libMobiusThrowableAssertion.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 2D25B99E24337BCC0077FB07 /* libMobiusThrowableAssertion.a */; };
 		2D3A69662354AC820053C95E /* ConcurrentAccessDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D3A69652354AC820053C95E /* ConcurrentAccessDetector.swift */; };
 		2D3A69672354AC820053C95E /* ConcurrentAccessDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D3A69652354AC820053C95E /* ConcurrentAccessDetector.swift */; };
 		2D3A696D2355AED90053C95E /* Lock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BB287CA209995410043B530 /* Lock.swift */; };
@@ -32,6 +35,9 @@
 		2D3A69772359EAAA0053C95E /* WorkBagTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D3A69752359EAA00053C95E /* WorkBagTests.swift */; };
 		2D3EEB9623FADA9E006E478A /* AsyncStartStopStateMachine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D3EEB9523FADA9E006E478A /* AsyncStartStopStateMachine.swift */; };
 		2D3F26ED237B02B8004C2B75 /* AsyncDispatchQueueConnectable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D3F26EC237B02B8004C2B75 /* AsyncDispatchQueueConnectable.swift */; };
+		2D405B7624337E5600A39BD4 /* MobiusThrowableAssertion.m in Sources */ = {isa = PBXBuildFile; fileRef = 2D25B9AB24337C580077FB07 /* MobiusThrowableAssertion.m */; };
+		2D405B7824337E9F00A39BD4 /* MobiusThrowableAssertion.h in Headers */ = {isa = PBXBuildFile; fileRef = 2D25B9AA24337C580077FB07 /* MobiusThrowableAssertion.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2D405B7924337EAB00A39BD4 /* module.modulemap in Headers */ = {isa = PBXBuildFile; fileRef = 2D25B9A724337C580077FB07 /* module.modulemap */; settings = {ATTRIBUTES = (Public, ); }; };
 		2D587360238EC60F001F21ED /* EventRouterDisposalLogicalRaceRegressionTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D58735F238EC60F001F21ED /* EventRouterDisposalLogicalRaceRegressionTest.swift */; };
 		2D896047238C150A00BBC372 /* EventHandlerDisposalLogicalRaceRegressionTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D896045238C14DF00BBC372 /* EventHandlerDisposalLogicalRaceRegressionTest.swift */; };
 		2DA9A41E23FAEA4800BF5534 /* AnyEffectHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DA9A41D23FAEA4800BF5534 /* AnyEffectHandlerTests.swift */; };
@@ -179,6 +185,20 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		2D25B9AC24337C650077FB07 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 2D9A2FAC205C06FA00B1A332 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 2D25B99D24337BCC0077FB07;
+			remoteInfo = MobiusThrowableAssertion;
+		};
+		2D25B9AF24337C700077FB07 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 2D9A2FAC205C06FA00B1A332 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 2D25B99D24337BCC0077FB07;
+			remoteInfo = MobiusThrowableAssertion;
+		};
 		2DF4C53B20DBE08E00A4B6DE /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 2D9A2FAC205C06FA00B1A332 /* Project object */;
@@ -265,6 +285,18 @@
 		};
 /* End PBXContainerItemProxy section */
 
+/* Begin PBXCopyFilesBuildPhase section */
+		2D25B99C24337BCC0077FB07 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "include/$(PRODUCT_NAME)";
+			dstSubfolderSpec = 16;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
 /* Begin PBXFileReference section */
 		02C4061C2373078400BD7ED8 /* EffectExecutor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EffectExecutor.swift; sourceTree = "<group>"; };
 		02C40620237422EF00BD7ED8 /* EffectRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EffectRouter.swift; sourceTree = "<group>"; };
@@ -280,6 +312,11 @@
 		02D6755423D2049E008200AF /* EnumRouteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnumRouteTests.swift; sourceTree = "<group>"; };
 		2D15DF72238EA4DD00E78B27 /* LoggingAdaptors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggingAdaptors.swift; sourceTree = "<group>"; };
 		2D24D15123FAE728005D175E /* AnonymousDisposableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnonymousDisposableTests.swift; sourceTree = "<group>"; };
+		2D25B99824337B0E0077FB07 /* TestingErrorHandler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestingErrorHandler.swift; sourceTree = "<group>"; };
+		2D25B99E24337BCC0077FB07 /* libMobiusThrowableAssertion.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libMobiusThrowableAssertion.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		2D25B9A724337C580077FB07 /* module.modulemap */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.module-map"; path = module.modulemap; sourceTree = "<group>"; };
+		2D25B9AA24337C580077FB07 /* MobiusThrowableAssertion.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MobiusThrowableAssertion.h; sourceTree = "<group>"; };
+		2D25B9AB24337C580077FB07 /* MobiusThrowableAssertion.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MobiusThrowableAssertion.m; sourceTree = "<group>"; };
 		2D3A69652354AC820053C95E /* ConcurrentAccessDetector.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConcurrentAccessDetector.swift; sourceTree = "<group>"; };
 		2D3A6972235737430053C95E /* WorkBag.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkBag.swift; sourceTree = "<group>"; };
 		2D3A69752359EAA00053C95E /* WorkBagTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkBagTests.swift; sourceTree = "<group>"; };
@@ -391,10 +428,18 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		2D25B99B24337BCC0077FB07 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		5B3AA33820975248003F35C3 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				2D25B9AE24337C690077FB07 /* libMobiusThrowableAssertion.a in Frameworks */,
 				5BB28845209997BF0043B530 /* Quick.framework in Frameworks */,
 				5B3AA3C120975635003F35C3 /* Nimble.framework in Frameworks */,
 				5B3AA3C5209757AC003F35C3 /* Foundation.framework in Frameworks */,
@@ -455,6 +500,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				2D25B9B124337C720077FB07 /* libMobiusThrowableAssertion.a in Frameworks */,
 				69C12F7C222F25B400DC4F9E /* MobiusCore.framework in Frameworks */,
 				DD710DCA20A0BCEC0047A7EC /* Quick.framework in Frameworks */,
 				DD710DCB20A0BCEC0047A7EC /* Nimble.framework in Frameworks */,
@@ -493,6 +539,32 @@
 			path = EffectHandlers;
 			sourceTree = "<group>";
 		};
+		2D25B99F24337BCC0077FB07 /* MobiusThrowableAssertion */ = {
+			isa = PBXGroup;
+			children = (
+				2D25B9A824337C580077FB07 /* Source */,
+			);
+			path = MobiusThrowableAssertion;
+			sourceTree = "<group>";
+		};
+		2D25B9A824337C580077FB07 /* Source */ = {
+			isa = PBXGroup;
+			children = (
+				2D25B9A924337C580077FB07 /* include */,
+				2D25B9AB24337C580077FB07 /* MobiusThrowableAssertion.m */,
+			);
+			path = Source;
+			sourceTree = "<group>";
+		};
+		2D25B9A924337C580077FB07 /* include */ = {
+			isa = PBXGroup;
+			children = (
+				2D25B9A724337C580077FB07 /* module.modulemap */,
+				2D25B9AA24337C580077FB07 /* MobiusThrowableAssertion.h */,
+			);
+			path = include;
+			sourceTree = "<group>";
+		};
 		2D9A2FAB205C06FA00B1A332 = {
 			isa = PBXGroup;
 			children = (
@@ -500,6 +572,7 @@
 				5BB287E3209995420043B530 /* MobiusExtras */,
 				5BB2888B20999B2E0043B530 /* MobiusTest */,
 				5B80EDD02125A18800F87129 /* MobiusNimble */,
+				2D25B99F24337BCC0077FB07 /* MobiusThrowableAssertion */,
 				DDC7035820A0A30800DBD519 /* Build System */,
 				5B3AA33320975248003F35C3 /* Products */,
 				5B3AA3B820975510003F35C3 /* Frameworks */,
@@ -542,6 +615,7 @@
 				5B80EDCF2125A18800F87129 /* MobiusNimble.framework */,
 				5B80EDD72125A18800F87129 /* MobiusNimbleTests.xctest */,
 				5B80EDF52125A32200F87129 /* libMobiusNimble.a */,
+				2D25B99E24337BCC0077FB07 /* libMobiusThrowableAssertion.a */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -729,6 +803,7 @@
 				5BB2885820999ACE0043B530 /* MobiusLoopTests.swift */,
 				5BB2885420999ACE0043B530 /* NextTests.swift */,
 				2DB61AFC23A8F485009E55DB /* NonReentrancyTests.swift */,
+				2D25B99824337B0E0077FB07 /* TestingErrorHandler.swift */,
 				5BB2884D20999ACE0043B530 /* TestingUtil.swift */,
 				2D3A69752359EAA00053C95E /* WorkBagTests.swift */,
 			);
@@ -804,7 +879,37 @@
 		};
 /* End PBXGroup section */
 
+/* Begin PBXHeadersBuildPhase section */
+		2D405B7724337E9A00A39BD4 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				2D405B7824337E9F00A39BD4 /* MobiusThrowableAssertion.h in Headers */,
+				2D405B7924337EAB00A39BD4 /* module.modulemap in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
 /* Begin PBXNativeTarget section */
+		2D25B99D24337BCC0077FB07 /* MobiusThrowableAssertion */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 2D25B9A624337BCC0077FB07 /* Build configuration list for PBXNativeTarget "MobiusThrowableAssertion" */;
+			buildPhases = (
+				2D405B7724337E9A00A39BD4 /* Headers */,
+				2D25B99A24337BCC0077FB07 /* Sources */,
+				2D25B99B24337BCC0077FB07 /* Frameworks */,
+				2D25B99C24337BCC0077FB07 /* CopyFiles */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = MobiusThrowableAssertion;
+			productName = MobiusThrowableAssertion;
+			productReference = 2D25B99E24337BCC0077FB07 /* libMobiusThrowableAssertion.a */;
+			productType = "com.apple.product-type.library.static";
+		};
 		2DF4C2F420DBDD4700A4B6DE /* MobiusCore-static-ios */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 2DF4C2FB20DBDD4700A4B6DE /* Build configuration list for PBXNativeTarget "MobiusCore-static-ios" */;
@@ -877,6 +982,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				2D25B9AD24337C650077FB07 /* PBXTargetDependency */,
 				5B3AA33E20975248003F35C3 /* PBXTargetDependency */,
 			);
 			name = MobiusCoreTests;
@@ -997,6 +1103,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				2D25B9B024337C700077FB07 /* PBXTargetDependency */,
 				DD710DD720A0BD240047A7EC /* PBXTargetDependency */,
 			);
 			name = MobiusExtrasTests;
@@ -1013,6 +1120,10 @@
 				LastSwiftUpdateCheck = 0940;
 				LastUpgradeCheck = 0940;
 				TargetAttributes = {
+					2D25B99D24337BCC0077FB07 = {
+						CreatedOnToolsVersion = 11.4;
+						ProvisioningStyle = Automatic;
+					};
 					2DF4C2F420DBDD4700A4B6DE = {
 						CreatedOnToolsVersion = 10.0;
 						ProvisioningStyle = Automatic;
@@ -1090,11 +1201,20 @@
 				5B80EDCE2125A18800F87129 /* MobiusNimble */,
 				5B80EDF42125A32200F87129 /* MobiusNimble-static-ios */,
 				5B80EDD62125A18800F87129 /* MobiusNimbleTests */,
+				2D25B99D24337BCC0077FB07 /* MobiusThrowableAssertion */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXSourcesBuildPhase section */
+		2D25B99A24337BCC0077FB07 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				2D405B7624337E5600A39BD4 /* MobiusThrowableAssertion.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		2DF4C2F120DBDD4700A4B6DE /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -1240,6 +1360,7 @@
 				2DA9A41E23FAEA4800BF5534 /* AnyEffectHandlerTests.swift in Sources */,
 				5BB2887A20999AD60043B530 /* MobiusLoopTests.swift in Sources */,
 				5BB2886C20999AD60043B530 /* AnyMobiusLoggerTests.swift in Sources */,
+				2D25B99924337B0E0077FB07 /* TestingErrorHandler.swift in Sources */,
 				5BB9346620D3CAA600A1FE3A /* EffectRouterBuilderTests.swift in Sources */,
 				02CAE47423C76FA3009DFF9A /* CallbackTests.swift in Sources */,
 				5BB2887920999AD60043B530 /* CompositeDisposableTests.swift in Sources */,
@@ -1328,6 +1449,16 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		2D25B9AD24337C650077FB07 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 2D25B99D24337BCC0077FB07 /* MobiusThrowableAssertion */;
+			targetProxy = 2D25B9AC24337C650077FB07 /* PBXContainerItemProxy */;
+		};
+		2D25B9B024337C700077FB07 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 2D25B99D24337BCC0077FB07 /* MobiusThrowableAssertion */;
+			targetProxy = 2D25B9AF24337C700077FB07 /* PBXContainerItemProxy */;
+		};
 		2DF4C53C20DBE08E00A4B6DE /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 2DF4C2F420DBDD4700A4B6DE /* MobiusCore-static-ios */;
@@ -1391,6 +1522,128 @@
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
+		2D25B9A424337BCC0077FB07 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_STYLE = Automatic;
+				COPY_PHASE_STRIP = NO;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = 2FNC3A47ZF;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.4;
+				MODULEMAP_FILE = MobiusThrowableAssertion/Source/module.modulemap;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_LDFLAGS = "-ObjC";
+				PRIVATE_HEADERS_FOLDER_PATH = include;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PUBLIC_HEADERS_FOLDER_PATH = include;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		2D25B9A524337BCC0077FB07 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_STYLE = Automatic;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = 2FNC3A47ZF;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.4;
+				MODULEMAP_FILE = MobiusThrowableAssertion/Source/module.modulemap;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				OTHER_LDFLAGS = "-ObjC";
+				PRIVATE_HEADERS_FOLDER_PATH = include;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PUBLIC_HEADERS_FOLDER_PATH = include;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
 		2D9A2FB0205C06FB00B1A332 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 69C12F76222F223700DC4F9E /* Debug.xcconfig */;
@@ -1800,6 +2053,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		2D25B9A624337BCC0077FB07 /* Build configuration list for PBXNativeTarget "MobiusThrowableAssertion" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				2D25B9A424337BCC0077FB07 /* Debug */,
+				2D25B9A524337BCC0077FB07 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		2D9A2FAF205C06FA00B1A332 /* Build configuration list for PBXProject "Mobius" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/MobiusCore/Source/BackwardsCompatibility.swift
+++ b/MobiusCore/Source/BackwardsCompatibility.swift
@@ -182,18 +182,6 @@ public extension Connectable {
     typealias OutputType = Output
 }
 
-public extension BrokenConnection {
-    @available(*, deprecated)
-    static func accept(_ value: Value) {
-        _accept(value)
-    }
-
-    @available(*, deprecated)
-    static func dispose() {
-        _dispose()
-    }
-}
-
 @available(*, deprecated)
 public typealias ConnectClosure<InputType, OutputType> = (@escaping Consumer<OutputType>) -> Connection<InputType>
 

--- a/MobiusCore/Source/BrokenConnection.swift
+++ b/MobiusCore/Source/BrokenConnection.swift
@@ -23,12 +23,13 @@ import Foundation
 ///
 /// `BrokenConnection.connection()` is used when functions return `Connection` fail an assertion. The resulting
 /// connection will trigger an assertion whenever its `accept` or `dispose` methods are called.
+@available(*, deprecated)
 public enum BrokenConnection<Value> {
-    static func _accept(_ value: Value) {
+    public static func accept(_ value: Value) {
         MobiusHooks.errorHandler("'accept' called on invalid connection of \(Value.self)", #file, #line)
     }
 
-    static func _dispose() {
+    public static func dispose() {
         MobiusHooks.errorHandler("'dispose' called on invalid connection of \(Value.self)", #file, #line)
     }
 
@@ -37,6 +38,6 @@ public enum BrokenConnection<Value> {
     /// The resulting connection will trigger an assertion whenever its `accept` or `dispose` methods are
     /// called.
     public static func connection() -> Connection<Value> {
-        return Connection(acceptClosure: _accept, disposeClosure: _dispose)
+        return Connection(acceptClosure: accept, disposeClosure: dispose)
     }
 }

--- a/MobiusCore/Source/ConnectableConvenienceClasses/AsyncDispatchQueueConnectable.swift
+++ b/MobiusCore/Source/ConnectableConvenienceClasses/AsyncDispatchQueueConnectable.swift
@@ -80,7 +80,6 @@ final class AsyncDispatchQueueConnectable<Input, Output>: Connectable {
             disposeClosure: { [acceptQueue] in
                 guard disposalStatus.compareAndSwap(expected: .notDisposed, with: .pendingDispose) else {
                     MobiusHooks.errorHandler("cannot dispose more than once", #file, #line)
-                    return
                 }
 
                 acceptQueue.async {

--- a/MobiusCore/Source/ConnectablePublisher.swift
+++ b/MobiusCore/Source/ConnectablePublisher.swift
@@ -45,7 +45,6 @@ final class ConnectablePublisher<Value>: Disposable {
                     #file,
                     #line
                 )
-                return []
             }
 
             currentValue = value
@@ -68,7 +67,6 @@ final class ConnectablePublisher<Value>: Disposable {
                     #file,
                     #line
                 )
-                return BrokenConnection<Value>.connection()
             }
 
             let uuid = UUID()

--- a/MobiusCore/Source/EffectHandlers/EffectExecutor.swift
+++ b/MobiusCore/Source/EffectHandlers/EffectExecutor.swift
@@ -44,7 +44,6 @@ final class EffectExecutor<Effect, Event>: Connectable {
                     #file,
                     #line
                 )
-                return BrokenConnection.connection()
             }
 
             output = consumer

--- a/MobiusCore/Source/EffectHandlers/ThreadSafeConnectable.swift
+++ b/MobiusCore/Source/EffectHandlers/ThreadSafeConnectable.swift
@@ -39,7 +39,6 @@ final class ThreadSafeConnectable<Event, Effect>: Connectable {
                     #file,
                     #line
                 )
-                return BrokenConnection.connection()
             }
             self.output = output
             connection = connectable.connect(self.dispatch)

--- a/MobiusCore/Source/EffectRouterBuilder.swift
+++ b/MobiusCore/Source/EffectRouterBuilder.swift
@@ -100,12 +100,10 @@ private func dispatchAccept<Input>(_ connections: [PredicatedConnection<Input>],
 
     if responders.count > 1 {
         MobiusHooks.errorHandler("More than one effect handler handling effect: \(input)", #file, #line)
-        return
     }
 
     guard let (connection, _) = responders.first else {
         MobiusHooks.errorHandler("No effect handler is handling the effect: \(input)", #file, #line)
-        return
     }
 
     connection.accept(input)

--- a/MobiusCore/Source/MobiusController.swift
+++ b/MobiusCore/Source/MobiusController.swift
@@ -108,7 +108,6 @@ public final class MobiusController<Model, Event, Effect> {
             return { event in
                 guard state.running else {
                     MobiusHooks.errorHandler("\(Self.debugTag): cannot accept events when stopped", #file, #line)
-                    return
                 }
 
                 loopQueue.async {

--- a/MobiusCore/Source/MobiusHooks.swift
+++ b/MobiusCore/Source/MobiusHooks.swift
@@ -25,7 +25,7 @@ import Foundation
 /// The default behaviour is to crash the application through invoking the `defaultErrorHandler` function defined in
 /// this enum. If that is not the desired behaviour, you can override it through the `setErrorHandler` method.
 public enum MobiusHooks {
-    public typealias ErrorHandler = (String, StaticString, UInt) -> Void
+    public typealias ErrorHandler = (String, StaticString, UInt) -> Never
 
     /// Internal: we prefer to call `errorHandler` directly, without abstractions, to minimize the depth of crash
     /// stack traces. This requires that `#file` and `#line` are passed explicitly.
@@ -39,7 +39,7 @@ public enum MobiusHooks {
         errorHandler = defaultErrorHandler
     }
 
-    public static func defaultErrorHandler(_ message: String = "", file: StaticString = #file, line: UInt = #line) {
+    public static func defaultErrorHandler(_ message: String = "", file: StaticString, line: UInt) -> Never {
         Thread.callStackSymbols.forEach { (symbol: String) in
             print(symbol)
         }

--- a/MobiusCore/Source/MobiusHooks.swift
+++ b/MobiusCore/Source/MobiusHooks.swift
@@ -29,7 +29,7 @@ public enum MobiusHooks {
 
     /// Internal: we prefer to call `errorHandler` directly, without abstractions, to minimize the depth of crash
     /// stack traces. This requires that `#file` and `#line` are passed explicitly.
-    static private(set) var errorHandler: ErrorHandler = MobiusHooks.defaultErrorHandler
+    public private(set) static var errorHandler: ErrorHandler = MobiusHooks.defaultErrorHandler
 
     public static func setErrorHandler(_ newErrorHandler: @escaping ErrorHandler) {
         errorHandler = newErrorHandler

--- a/MobiusCore/Source/MobiusLoop.swift
+++ b/MobiusCore/Source/MobiusLoop.swift
@@ -92,7 +92,6 @@ public final class MobiusLoop<Model, Event, Effect>: Disposable, CustomDebugStri
             guard !disposed else {
                 // Callers are responsible for ensuring dispatchEvent is never entered after dispose.
                 MobiusHooks.errorHandler("\(Self.debugTag): event submitted after dispose", #file, #line)
-                return
             }
 
             unguardedDispatchEvent(event)

--- a/MobiusCore/Test/BrokenConnectionTests.swift
+++ b/MobiusCore/Test/BrokenConnectionTests.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Spotify AB.
+// Copyright (c) 2020 Spotify AB.
 //
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
@@ -24,32 +24,21 @@ import Quick
 class BrokenConnectionTests: QuickSpec {
     override func spec() {
         var connection: Connection<Int>!
-        var errorThrown: Bool!
 
-        describe("BrokenAnyConnection") {
+        describe("BrokenConnection") {
             beforeEach {
                 connection = BrokenConnection<Int>.connection()
-                errorThrown = false
-                MobiusHooks.setErrorHandler({ _, _, _ in
-                    errorThrown = true
-                })
-            }
-
-            afterEach {
-                MobiusHooks.setDefaultErrorHandler()
             }
 
             context("when calling accept value") {
                 it("should trigger the error handler") {
-                    connection.accept(3)
-                    expect(errorThrown).to(beTrue())
+                    expect(connection.accept(3)).to(raiseError())
                 }
             }
 
             context("when attempting to dispose") {
                 it("should trigger the error handler") {
-                    connection.dispose()
-                    expect(errorThrown).to(beTrue())
+                    expect(connection.dispose()).to(raiseError())
                 }
             }
         }

--- a/MobiusCore/Test/ConnectablePublisherTests.swift
+++ b/MobiusCore/Test/ConnectablePublisherTests.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Spotify AB.
+// Copyright (c) 2020 Spotify AB.
 //
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
@@ -29,7 +29,6 @@ class ConnectablePublisherTests: QuickSpec {
             var publisher: ConnectablePublisher<String>!
             var received: [String]!
             var consumer: Consumer<String>!
-            var errorThrown: Bool!
 
             beforeEach {
                 publisher = ConnectablePublisher()
@@ -38,15 +37,6 @@ class ConnectablePublisherTests: QuickSpec {
                 consumer = {
                     received.append($0)
                 }
-
-                errorThrown = false
-                MobiusHooks.setErrorHandler({ _, _, _ in
-                    errorThrown = true
-                })
-            }
-
-            afterEach {
-                MobiusHooks.setDefaultErrorHandler()
             }
 
             describe("connections") {
@@ -138,9 +128,7 @@ class ConnectablePublisherTests: QuickSpec {
 
                     context("when trying to connect") {
                         it("should refuse connections") {
-                            publisher.connect(to: consumer)
-
-                            expect(errorThrown).to(beTrue())
+                            expect(_ = publisher.connect(to: consumer)).to(raiseError())
                         }
 
                         context("when error handling does not cause a crash") {
@@ -169,9 +157,7 @@ class ConnectablePublisherTests: QuickSpec {
 
                     context("when trying to post") {
                         it("should refuse values") {
-                            publisher.post("crashme")
-
-                            expect(errorThrown).to(beTrue())
+                            expect(publisher.post("crashme")).to(raiseError())
                         }
                     }
 

--- a/MobiusCore/Test/ConnectablePublisherTests.swift
+++ b/MobiusCore/Test/ConnectablePublisherTests.swift
@@ -130,29 +130,6 @@ class ConnectablePublisherTests: QuickSpec {
                         it("should refuse connections") {
                             expect(_ = publisher.connect(to: consumer)).to(raiseError())
                         }
-
-                        context("when error handling does not cause a crash") {
-                            var errorMessage: String?
-                            beforeEach {
-                                MobiusHooks.setErrorHandler({ (message: String?, _, _) in
-                                    errorMessage = message
-                                })
-                            }
-
-                            afterEach {
-                                MobiusHooks.setDefaultErrorHandler()
-                            }
-
-                            it("should return a broken connection") {
-                                let connection = publisher.connect(to: consumer)
-                                connection.dispose()
-                                expect(errorMessage).toNot(beNil())
-
-                                errorMessage = nil
-                                connection.accept("Some string")
-                                expect(errorMessage).toNot(beNil())
-                            }
-                        }
                     }
 
                     context("when trying to post") {

--- a/MobiusCore/Test/EffectHandlers/EffectRouterDSLTests.swift
+++ b/MobiusCore/Test/EffectHandlers/EffectRouterDSLTests.swift
@@ -253,7 +253,6 @@ class EffectRouterDSLTests: QuickSpec {
                     }
 
                 dslHandler.accept(.effect1)
-                dslHandler.accept(.effect2)
                 expect(dispatchedEvents).to(equal([.eventForEffect1]))
             }
         }

--- a/MobiusCore/Test/EffectRouterBuilderTests.swift
+++ b/MobiusCore/Test/EffectRouterBuilderTests.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Spotify AB.
+// Copyright (c) 2020 Spotify AB.
 //
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
@@ -103,36 +103,20 @@ class EffectRouterBuilderTests: QuickSpec {
                 }
 
                 context("when that effect is dispatched") {
-                    var mobiusError: String?
-                    beforeEach {
-                        MobiusHooks.setErrorHandler({ (error: String, _, _) in
-                            mobiusError = error
-                        })
-
-                        sut.build().connect(outputHandler).accept(effect)
-                    }
-
                     it("should generate an error in the error handler") {
-                        expect(mobiusError).toNot(beNil())
+                        let connection = sut.build().connect(outputHandler)
+                        expect(connection.accept(effect)).to(raiseError())
                     }
                 }
             }
 
             context("when adding no effect handler for an effect") {
                 context("when that effect is dispatched") {
-                    var mobiusError: String?
-
                     let effect = "Effect"
-                    beforeEach {
-                        MobiusHooks.setErrorHandler({ (error: String, _, _) in
-                            mobiusError = error
-                        })
-
-                        sut.build().connect(outputHandler).accept(effect)
-                    }
 
                     it("should generate an error in the error handler") {
-                        expect(mobiusError).toNot(beNil())
+                        let connection = sut.build().connect(outputHandler)
+                        expect(connection.accept(effect)).to(raiseError())
                     }
                 }
             }

--- a/MobiusCore/Test/EventRouterDisposalLogicalRaceRegressionTest.swift
+++ b/MobiusCore/Test/EventRouterDisposalLogicalRaceRegressionTest.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Spotify AB.
+// Copyright (c) 2020 Spotify AB.
 //
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
@@ -51,7 +51,6 @@ class EventRouterDisposalLogicalRaceRegressionTest: QuickSpec {
         describe("Effect Handler connection") {
             var controller: MobiusController<Model, Event, Effect>!
             var collaborator: EffectCollaborator!
-            var errorThrown: Bool!
             var eventSource: TestEventSource<Event>!
 
             beforeEach {
@@ -64,11 +63,6 @@ class EventRouterDisposalLogicalRaceRegressionTest: QuickSpec {
 
                 eventSource = TestEventSource()
 
-                errorThrown = false
-                MobiusHooks.setErrorHandler({ _, _, _ in
-                    errorThrown = true
-                })
-
                 let update = Update<Model, Event, Effect> { _, _ in
                     .dispatchEffects([.effect1])
                 }
@@ -80,15 +74,10 @@ class EventRouterDisposalLogicalRaceRegressionTest: QuickSpec {
                 controller.connectView(ActionConnectable {})
             }
 
-            afterEach {
-                MobiusHooks.setDefaultErrorHandler()
-            }
-
             it("allows stopping a loop immediately after dispatching an event") {
                 controller.start()
                 eventSource.dispatch(.event1)
                 controller.stop()
-                expect(errorThrown).to(beFalse())
             }
         }
     }

--- a/MobiusCore/Test/MobiusHooksTests.swift
+++ b/MobiusCore/Test/MobiusHooksTests.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Spotify AB.
+// Copyright (c) 2020 Spotify AB.
 //
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
@@ -34,15 +34,14 @@ class MobiusHooksTests: QuickSpec {
                 var errorCalledOnLine: UInt!
 
                 beforeEach {
-                    MobiusHooks.setErrorHandler({ (message: String, file: StaticString, line: UInt) in
+                    errorCalledOnLine = #line + 1
+                    expect(MobiusHooks.errorHandler(someString, #file, #line)).to(raiseError { message, file, line in
                         errorMessage = message
-                        errorFile = String(file)
+                        errorFile = file
                         errorLine = line
                     })
-
-                    errorCalledOnLine = #line + 1
-                    MobiusHooks.errorHandler(someString, #file, #line)
                 }
+
                 it("should use that error handler when an error occurs") {
                     expect(errorMessage).to(match(someString))
                 }
@@ -56,14 +55,6 @@ class MobiusHooksTests: QuickSpec {
                     expect(errorLine).to(equal(errorCalledOnLine))
                 }
             }
-        }
-    }
-}
-
-private extension String {
-    init(_ staticString: StaticString) {
-        self = staticString.withUTF8Buffer {
-            String(decoding: $0, as: UTF8.self)
         }
     }
 }

--- a/MobiusCore/Test/MobiusLoopTests.swift
+++ b/MobiusCore/Test/MobiusLoopTests.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Spotify AB.
+// Copyright (c) 2020 Spotify AB.
 //
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
@@ -117,24 +117,13 @@ class MobiusLoopTests: QuickSpec {
             }
 
             describe("dispose integration tests") {
-                var errorThrown: Bool!
                 beforeEach {
                     loop = builder.start(from: "disposable")
-                    errorThrown = false
-                    MobiusHooks.setErrorHandler({ _, _, _ in
-                        errorThrown = true
-                    })
-                }
-
-                afterEach {
-                    MobiusHooks.setDefaultErrorHandler()
                 }
 
                 it("should allow disposing immediately after an effect") {
                     loop.dispatchEvent("event")
                     loop.dispose()
-
-                    expect(errorThrown).to(beFalse())
                 }
 
                 it("should dispose effect handler connection on dispose") {
@@ -145,9 +134,7 @@ class MobiusLoopTests: QuickSpec {
 
                 it("should disallow events post dispose") {
                     loop.dispose()
-                    loop.dispatchEvent("nnooooo!!!")
-
-                    expect(errorThrown).to(beTrue())
+                    expect(loop.dispatchEvent("nnooooo!!!")).to(raiseError())
                 }
             }
 

--- a/MobiusCore/Test/TestingErrorHandler.swift
+++ b/MobiusCore/Test/TestingErrorHandler.swift
@@ -1,0 +1,54 @@
+import Foundation
+import MobiusCore
+import MobiusThrowableAssertion
+import Nimble
+import Quick
+
+/// Nimble predicate which passes if the expression invokes `MobiusHooks.effectHandler`.
+///
+/// The effect handler is overridden before each test in a QuickConfiguration object. If the test has its own override,
+/// for example in `beforeEach`, that will take precedence and this predicate won’t work.
+///
+/// - Parameter capture: An optional block which is invoked with the message, file and line of the error invocation.
+public func raiseError<Out>(capture: ((String, String, UInt) -> Void)? = nil) -> Predicate<Out> {
+    // This is a simplified version of Nimble’s throwAssertion() that piggybacks on Objective-C exceptions.
+    return Predicate { actualExpression in
+        let message = ExpectationMessage.expectedTo("throw an assertion")
+
+        var thrownError: Error?
+        let assertion = MobiusThrowableAssertion.catch {
+            do {
+                _ = try actualExpression.evaluate()
+            } catch {
+                thrownError = error
+            }
+        }
+
+        if let assertion = assertion, let capture = capture {
+            capture(assertion.message, assertion.file, assertion.line)
+        }
+
+        if let error = thrownError {
+            return PredicateResult(
+                bool: false,
+                message: message.appended(message: "; threw error instead <\(error)>")
+            )
+        }
+
+        return PredicateResult(bool: assertion != nil, message: message)
+    }
+}
+
+private class ErrorHandlerConfiguration: QuickConfiguration {
+    override class func configure(_ configuration: Configuration) {
+        configuration.beforeEach {
+            MobiusHooks.setErrorHandler { message, file, line in
+                MobiusThrowableAssertion(message: message, file: String(file), line: line).throw()
+            }
+        }
+
+        configuration.afterEach {
+            MobiusHooks.setDefaultErrorHandler()
+        }
+    }
+}

--- a/MobiusCore/Test/TestingErrorHandler.swift
+++ b/MobiusCore/Test/TestingErrorHandler.swift
@@ -4,9 +4,9 @@ import MobiusThrowableAssertion
 import Nimble
 import Quick
 
-/// Nimble predicate which passes if the expression invokes `MobiusHooks.effectHandler`.
+/// Nimble predicate which passes if the expression invokes `MobiusHooks.errorHandler`.
 ///
-/// The effect handler is overridden before each test in a QuickConfiguration object. If the test has its own override,
+/// The error handler is overridden before each test in a QuickConfiguration object. If the test has its own override,
 /// for example in `beforeEach`, that will take precedence and this predicate won’t work.
 ///
 /// - Parameter capture: An optional block which is invoked with the message, file and line of the error invocation.
@@ -15,6 +15,7 @@ public func raiseError<Out>(capture: ((String, String, UInt) -> Void)? = nil) ->
     return Predicate { actualExpression in
         let message = ExpectationMessage.expectedTo("throw an assertion")
 
+        // Evaluate the expression under test, and capture any assertion _or_ Swift error
         var thrownError: Error?
         let assertion = MobiusThrowableAssertion.catch {
             do {
@@ -24,10 +25,7 @@ public func raiseError<Out>(capture: ((String, String, UInt) -> Void)? = nil) ->
             }
         }
 
-        if let assertion = assertion, let capture = capture {
-            capture(assertion.message, assertion.file, assertion.line)
-        }
-
+        // If we got a Swift error, that’s not an assertion and the test failed
         if let error = thrownError {
             return PredicateResult(
                 bool: false,
@@ -35,11 +33,18 @@ public func raiseError<Out>(capture: ((String, String, UInt) -> Void)? = nil) ->
             )
         }
 
+        // If we got an assertion and a `capture` block was passed, invoke it
+        if let assertion = assertion, let capture = capture {
+            capture(assertion.message, assertion.file, assertion.line)
+        }
+
         return PredicateResult(bool: assertion != nil, message: message)
     }
 }
 
 private class ErrorHandlerConfiguration: QuickConfiguration {
+    /// This is run before any Quick tests and registers `beforeEach`/`afterEach` handlers that run “outside” those
+    /// set up by the tests.
     override class func configure(_ configuration: Configuration) {
         configuration.beforeEach {
             MobiusHooks.setErrorHandler { message, file, line in

--- a/MobiusCore/Test/TestingErrorHandler.swift
+++ b/MobiusCore/Test/TestingErrorHandler.swift
@@ -52,3 +52,11 @@ private class ErrorHandlerConfiguration: QuickConfiguration {
         }
     }
 }
+
+private extension String {
+    init(_ staticString: StaticString) {
+        self = staticString.withUTF8Buffer {
+            String(decoding: $0, as: UTF8.self)
+        }
+    }
+}

--- a/MobiusCore/Test/TestingUtil.swift
+++ b/MobiusCore/Test/TestingUtil.swift
@@ -219,11 +219,3 @@ class TestEventSource<Event>: EventSource {
         }
     }
 }
-
-extension String {
-    init(_ staticString: StaticString) {
-        self = staticString.withUTF8Buffer {
-            String(decoding: $0, as: UTF8.self)
-        }
-    }
-}

--- a/MobiusCore/Test/TestingUtil.swift
+++ b/MobiusCore/Test/TestingUtil.swift
@@ -219,3 +219,11 @@ class TestEventSource<Event>: EventSource {
         }
     }
 }
+
+extension String {
+    init(_ staticString: StaticString) {
+        self = staticString.withUTF8Buffer {
+            String(decoding: $0, as: UTF8.self)
+        }
+    }
+}

--- a/MobiusExtras/Source/ConnectableClass.swift
+++ b/MobiusExtras/Source/ConnectableClass.swift
@@ -107,7 +107,6 @@ open class ConnectableClass<Input, Output>: Connectable {
                 #file,
                 #line
             )
-            return BrokenConnection.connection()
         }
 
         self.consumer = consumer
@@ -128,7 +127,6 @@ open class ConnectableClass<Input, Output>: Connectable {
                 #file,
                 #line
             )
-            return
         }
 
         handle(input)

--- a/MobiusExtras/Source/ConnectableClass.swift
+++ b/MobiusExtras/Source/ConnectableClass.swift
@@ -36,9 +36,6 @@ open class ConnectableClass<Input, Output>: Connectable {
     private var consumer: Consumer<Output>?
 
     private let lock = NSRecursiveLock()
-    var handleError = { (message: String) -> Void in
-        fatalError(message)
-    }
 
     public init() {}
 
@@ -54,9 +51,11 @@ open class ConnectableClass<Input, Output>: Connectable {
         }
         guard let consumer = consumer else {
             #if false // Disabled because of flakiness and because public use of this class is being phased out.
-            handleError(
+            MobiusHooks.errorHandler(
                 "\(type(of: self)) is unable to send \(type(of: output)) before any consumer has been set." +
-                "Send should only be used once the Connectable has been properly connected."
+                "Send should only be used once the Connectable has been properly connected.",
+                #file,
+                #line
             )
             #endif
             return
@@ -70,7 +69,11 @@ open class ConnectableClass<Input, Output>: Connectable {
     /// - Attention: This function has to be overridden by a subclass or an error will be thrown to the MobiusHooks
     /// error handler.
     open func handle(_ input: Input) {
-        handleError("The function `\(#function)` must be overridden in subclass \(type(of: self))")
+        MobiusHooks.errorHandler(
+            "The function `\(#function)` must be overridden in subclass \(type(of: self))",
+            #file,
+            #line
+        )
     }
 
     /// Called when the connection is being established. This function can be used to allocate and initialize any
@@ -84,7 +87,11 @@ open class ConnectableClass<Input, Output>: Connectable {
     /// - Attention: This function has to be overridden by a subclass or an error will be thrown to the MobiusHooks
     /// error handler.
     open func onDispose() {
-        handleError("The function `\(#function)` must be overridden in subclass \(type(of: self))")
+        MobiusHooks.errorHandler(
+            "The function `\(#function)` must be overridden in subclass \(type(of: self))",
+            #file,
+            #line
+        )
     }
 
     public final func connect(_ consumer: @escaping (Output) -> Void) -> Connection<Input> {
@@ -94,9 +101,11 @@ open class ConnectableClass<Input, Output>: Connectable {
         }
 
         guard self.consumer == nil else {
-            handleError(
+            MobiusHooks.errorHandler(
                 "Connection limit exceeded: The Connectable \(type(of: self)) is already connected. " +
-                "Unable to connect more than once"
+                "Unable to connect more than once",
+                #file,
+                #line
             )
             return BrokenConnection.connection()
         }
@@ -114,7 +123,11 @@ open class ConnectableClass<Input, Output>: Connectable {
         consumerSet = consumer != nil
         lock.unlock()
         guard consumerSet else {
-            handleError("\(type(of: self)) is unable to handle \(type(of: input)) before any consumer has been set")
+            MobiusHooks.errorHandler(
+                "\(type(of: self)) is unable to handle \(type(of: input)) before any consumer has been set",
+                #file,
+                #line
+            )
             return
         }
 

--- a/MobiusExtras/Test/EventHandlerDisposalLogicalRaceRegressionTest.swift
+++ b/MobiusExtras/Test/EventHandlerDisposalLogicalRaceRegressionTest.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Spotify AB.
+// Copyright (c) 2020 Spotify AB.
 //
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
@@ -50,17 +50,11 @@ class EventHandlerDisposalLogicalRaceRegressionTest: QuickSpec {
         describe("Effect Handler connection") {
             var controller: MobiusController<Model, Event, Effect>!
             var effectHandler: EffectHandler!
-            var errorThrown: Bool!
             var eventSource: TestEventSource!
 
             beforeEach {
                 effectHandler = EffectHandler()
                 eventSource = TestEventSource()
-
-                errorThrown = false
-                MobiusHooks.setErrorHandler({ _, _, _ in
-                    errorThrown = true
-                })
 
                 let update = Update<Model, Event, Effect> { _, _ in
                     .dispatchEffects([.effect1])
@@ -73,15 +67,10 @@ class EventHandlerDisposalLogicalRaceRegressionTest: QuickSpec {
                 controller.connectView(ActionConnectable {})
             }
 
-            afterEach {
-                MobiusHooks.setDefaultErrorHandler()
-            }
-
             it("allows stopping a loop immediately after dispatching an event") {
                 controller.start()
                 eventSource.dispatchEvent(.event1)
                 controller.stop()
-                expect(errorThrown).to(beFalse())
             }
         }
     }

--- a/MobiusThrowableAssertion/Source/MobiusThrowableAssertion.m
+++ b/MobiusThrowableAssertion/Source/MobiusThrowableAssertion.m
@@ -1,0 +1,32 @@
+#import "MobiusThrowableAssertion.h"
+
+@implementation MobiusThrowableAssertion
+
+- (instancetype)initWithMessage:(NSString *)message file:(NSString *)file line:(NSUInteger)line
+{
+    self = [super init];
+    if (self != nil) {
+        _message = message;
+        _file = file;
+        _line = line;
+    }
+    return self;
+}
+
+- (void)throw
+{
+    @throw(self);
+}
+
++ (nullable MobiusThrowableAssertion *)catchInBlock:(NS_NOESCAPE void(^)(void))block
+{
+    @try {
+        block();
+    }
+    @catch(MobiusThrowableAssertion *assertion) {
+        return assertion;
+    }
+    return nil;
+}
+
+@end

--- a/MobiusThrowableAssertion/Source/include/MobiusThrowableAssertion.h
+++ b/MobiusThrowableAssertion/Source/include/MobiusThrowableAssertion.h
@@ -1,0 +1,28 @@
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ Class that wraps the Objective-C exception handling system for use by Swift tests.
+
+ @c throw() raises an exception that will be cought by an enclosing @c MobiusThrowableAssertion.catch(in:) invocation.
+ If an exception is uncaught, the process will crash.
+
+ @note Since Swift doesn’t have a concept of exception unwinding, this will generally result in memory leaks.
+ */
+@interface MobiusThrowableAssertion : NSObject
+
+@property (nonatomic, readonly, strong) NSString *message;
+@property (nonatomic, readonly, strong) NSString *file;
+@property (nonatomic, readonly) NSUInteger line;
+
+- (instancetype)initWithMessage:(NSString *)message file:(NSString *)file line:(NSUInteger)line;
+
+- (void)throw OS_NORETURN;
+
++ (nullable MobiusThrowableAssertion *)catchInBlock:(NS_NOESCAPE void(^)(void))block
+NS_SWIFT_NAME(catch(in:));
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/MobiusThrowableAssertion/Source/include/module.modulemap
+++ b/MobiusThrowableAssertion/Source/include/module.modulemap
@@ -1,0 +1,4 @@
+module MobiusThrowableAssertion {
+    header "MobiusThrowableAssertion.h"
+    export *
+}

--- a/Package.swift
+++ b/Package.swift
@@ -31,7 +31,11 @@ let package = Package(
             dependencies: ["MobiusCore", "Nimble", "Quick", "MobiusThrowableAssertion"],
             path: "MobiusCore/Test"
         ),
-        .testTarget(name: "MobiusExtrasTests", dependencies: ["MobiusExtras", "Nimble", "Quick"], path: "MobiusExtras/Test"),
+        .testTarget(
+            name: "MobiusExtrasTests",
+            dependencies: ["MobiusCore", "MobiusExtras", "Nimble", "Quick", "MobiusThrowableAssertion"],
+            path: "MobiusExtras/Test"
+        ),
         .testTarget(name: "MobiusNimbleTests", dependencies: ["MobiusNimble", "Quick"], path: "MobiusNimble/Test"),
         .testTarget(name: "MobiusTestTests", dependencies: ["MobiusTest", "Quick", "Nimble"], path: "MobiusTest/Test"),
     ],

--- a/Package.swift
+++ b/Package.swift
@@ -24,8 +24,13 @@ let package = Package(
         .target(name: "MobiusExtras", dependencies: ["MobiusCore"], path: "MobiusExtras/Source"),
         .target(name: "MobiusNimble", dependencies: ["MobiusCore", "MobiusTest", "Nimble"], path: "MobiusNimble/Source"),
         .target(name: "MobiusTest", dependencies: ["MobiusCore"], path: "MobiusTest/Source"),
+        .target(name: "MobiusThrowableAssertion", path: "MobiusThrowableAssertion/Source"),
 
-        .testTarget(name: "MobiusCoreTests", dependencies: ["MobiusCore", "Nimble", "Quick"], path: "MobiusCore/Test"),
+        .testTarget(
+            name: "MobiusCoreTests",
+            dependencies: ["MobiusCore", "Nimble", "Quick", "MobiusThrowableAssertion"],
+            path: "MobiusCore/Test"
+        ),
         .testTarget(name: "MobiusExtrasTests", dependencies: ["MobiusExtras", "Nimble", "Quick"], path: "MobiusExtras/Test"),
         .testTarget(name: "MobiusNimbleTests", dependencies: ["MobiusNimble", "Quick"], path: "MobiusNimble/Test"),
         .testTarget(name: "MobiusTestTests", dependencies: ["MobiusTest", "Quick", "Nimble"], path: "MobiusTest/Test"),


### PR DESCRIPTION
`MobiusHooks.ErrorHandler` now has a return type of `Never`, and so works like a `fatalError` or `preconditionFailure`.

As a result, `BrokenConnection` is no longer needed.

The infrastructure for this is a simple Objective-C library that wraps the Objective-C exception system. (It’s possible to throw an exception from Swift using `NSException.raise()`, but it can’t be caught in pure Swift.)

Nimble already has similar infrastructure, with bells and whistles to automatically catch Swift fatal errors, but that implementation is not thread safe (it triggers TSAN in our CI) and uses a different set of nasty hacks for each runtime environment.

I also use Quick’s `QuickConfiguration` mechanism to install a custom error hook around each test case and remove it afterwards. This is a bit on the magical side, but we had multiple tests that didn’t clean up their error hooks, which meant that the result of tests was order-dependent and one test was passing when it shouldn’t be.