### PR TITLE
Alternative Automatic MobiusController lifecycle management in `UIViewController`s

### DIFF
--- a/Mobius.xcodeproj/project.pbxproj
+++ b/Mobius.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		020415FD242226C0009EE9BB /* MobiusViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020415FC242226C0009EE9BB /* MobiusViewController.swift */; };
 		0204160024222B8E009EE9BB /* MobiusViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020415FE24222A47009EE9BB /* MobiusViewControllerTests.swift */; };
+		0204160124223E38009EE9BB /* MobiusViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020415FC242226C0009EE9BB /* MobiusViewController.swift */; };
 		02BED1BB21DD20D20093FB47 /* ConnectableContramap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B9CE80421197FE000DB79A7 /* ConnectableContramap.swift */; };
 		02C4061D2373078400BD7ED8 /* EffectExecutor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02C4061C2373078400BD7ED8 /* EffectExecutor.swift */; };
 		02C40621237422EF00BD7ED8 /* EffectRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02C40620237422EF00BD7ED8 /* EffectRouter.swift */; };
@@ -1154,6 +1155,7 @@
 				3EE5AF052110BF2E00CF8CA8 /* ConnectableClass.swift in Sources */,
 				2DF4C42420DBDF1B00A4B6DE /* SimpleLogger.swift in Sources */,
 				02BED1BB21DD20D20093FB47 /* ConnectableContramap.swift in Sources */,
+				0204160124223E38009EE9BB /* MobiusViewController.swift in Sources */,
 				5B1F104E21105CB10067193C /* EventSource+Extensions.swift in Sources */,
 				2D3A696D2355AED90053C95E /* Lock.swift in Sources */,
 			);

--- a/Mobius.xcodeproj/project.pbxproj
+++ b/Mobius.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		020415FD242226C0009EE9BB /* MobiusViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020415FC242226C0009EE9BB /* MobiusViewController.swift */; };
+		0204160024222B8E009EE9BB /* MobiusViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020415FE24222A47009EE9BB /* MobiusViewControllerTests.swift */; };
 		02BED1BB21DD20D20093FB47 /* ConnectableContramap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B9CE80421197FE000DB79A7 /* ConnectableContramap.swift */; };
 		02C4061D2373078400BD7ED8 /* EffectExecutor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02C4061C2373078400BD7ED8 /* EffectExecutor.swift */; };
 		02C40621237422EF00BD7ED8 /* EffectRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02C40620237422EF00BD7ED8 /* EffectRouter.swift */; };
@@ -266,6 +268,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		020415FC242226C0009EE9BB /* MobiusViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobiusViewController.swift; sourceTree = "<group>"; };
+		020415FE24222A47009EE9BB /* MobiusViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobiusViewControllerTests.swift; sourceTree = "<group>"; };
 		02C4061C2373078400BD7ED8 /* EffectExecutor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EffectExecutor.swift; sourceTree = "<group>"; };
 		02C40620237422EF00BD7ED8 /* EffectRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EffectRouter.swift; sourceTree = "<group>"; };
 		02C40622237425E100BD7ED8 /* EffectRouterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EffectRouterTests.swift; sourceTree = "<group>"; };
@@ -692,6 +696,7 @@
 				5BB287E8209995420043B530 /* SimpleLogger.swift */,
 				DD748322212DB525008EEECD /* Copyable.swift */,
 				5B1F104C21105CAD0067193C /* EventSource+Extensions.swift */,
+				020415FC242226C0009EE9BB /* MobiusViewController.swift */,
 			);
 			path = Source;
 			sourceTree = "<group>";
@@ -787,6 +792,7 @@
 				DD748324212DEEC1008EEECD /* CopyableTests.swift */,
 				5B1F104F21105CC00067193C /* EventSource+ExtensionsTests.swift */,
 				2D896045238C14DF00BBC372 /* EventHandlerDisposalLogicalRaceRegressionTest.swift */,
+				020415FE24222A47009EE9BB /* MobiusViewControllerTests.swift */,
 			);
 			path = Test;
 			sourceTree = "<group>";
@@ -1256,6 +1262,7 @@
 				5B9CE80521197FE000DB79A7 /* ConnectableContramap.swift in Sources */,
 				5B1F104D21105CAD0067193C /* EventSource+Extensions.swift in Sources */,
 				DDA64A6720A0AD2D00150355 /* SimpleLogger.swift in Sources */,
+				020415FD242226C0009EE9BB /* MobiusViewController.swift in Sources */,
 				5BCF5F0120F3620700721C0D /* ConnectableClass.swift in Sources */,
 				2D3A696E2355AED90053C95E /* Lock.swift in Sources */,
 			);
@@ -1320,6 +1327,7 @@
 				DD748325212DEEC1008EEECD /* CopyableTests.swift in Sources */,
 				2D896047238C150A00BBC372 /* EventHandlerDisposalLogicalRaceRegressionTest.swift in Sources */,
 				5B1F105121105CC50067193C /* EventSource+ExtensionsTests.swift in Sources */,
+				0204160024222B8E009EE9BB /* MobiusViewControllerTests.swift in Sources */,
 				5BCF5F0420F3636800721C0D /* ConnectableClassTests.swift in Sources */,
 				5B9CE80721199D4400DB79A7 /* ConnectableContramapTests.swift in Sources */,
 			);

--- a/Mobius.xcodeproj/xcshareddata/xcschemes/MobiusExtrasTests.xcscheme
+++ b/Mobius.xcodeproj/xcshareddata/xcschemes/MobiusExtrasTests.xcscheme
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1100"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "DD710DB420A0BCEC0047A7EC"
+               BuildableName = "MobiusExtrasTests.xctest"
+               BlueprintName = "MobiusExtrasTests"
+               ReferencedContainer = "container:Mobius.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/MobiusExtras/Source/MobiusViewController.swift
+++ b/MobiusExtras/Source/MobiusViewController.swift
@@ -29,7 +29,7 @@ public extension UIViewController {
     /// Note: You should not be calling `start`, `connectView`, `stop`, or `disconnectView` on the `MobiusController`
     /// when using this extension.
     ///
-    /// - Parameter controller: The `MobiusController` that shuold be attached
+    /// - Parameter controller: The `MobiusController` that should be attached
     /// - Parameter onModelChange: A closure which is called whenever the loop's model changes.
     func useMobius<Model, Event, Effect>(
         controller: MobiusController<Model, Event, Effect>,

--- a/MobiusExtras/Source/MobiusViewController.swift
+++ b/MobiusExtras/Source/MobiusViewController.swift
@@ -1,0 +1,112 @@
+// Copyright (c) 2019 Spotify AB.
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import MobiusCore
+import UIKit
+
+public extension UIViewController {
+    /// Attach a `MobiusController` to this `UIViewController`.
+    /// A `Connection` is returned which can be used to post events to the loop.
+    /// The `MobiusController` will start when this function is called, and stop when this `UIViewController` is
+    /// initialized or when the returned `Connection` is disposed.
+    ///
+    /// Note: You should not be calling `start`, `connectView`, `stop`, or `disconnectView` on the `MobiusController`
+    /// when using this extension.
+    ///
+    /// Note: The `MobiusController` will be placed in a `UIViewController` and added as a child `UIViewController` to
+    ///  this `UIViewController`.
+    ///
+    /// - Parameter controller: The `MobiusController` that shuold be attached
+    /// - Parameter onModelChange: A closure which is called whenever the loop's model changes.
+    func useMobius<Model, Event, Effect>(
+        controller: MobiusController<Model, Event, Effect>,
+        modelChanged onModelChange: @escaping (Model) -> Void
+    ) -> Connection<Event> {
+        let holder = MobiusHolder(controller: controller, onModelChange: onModelChange)
+        addChild(holder)
+        holder.didMove(toParent: self)
+        return Connection(
+            acceptClosure: { [unowned holder] event in
+                holder.handleEvent(event)
+            },
+            disposeClosure: { [unowned holder] in
+                holder.willMove(toParent: nil)
+                holder.removeFromParent()
+            }
+        )
+    }
+}
+
+private class MobiusHolder<Model, Event, Effect>: UIViewController {
+    private let controller: MobiusController<Model, Event, Effect>
+    private let weakConnectableDelegate: WeakConnectableDelegate<Model>
+    private let weakConnectable: WeakConnectable<Model, Event>
+
+    init(
+        controller: MobiusController<Model, Event, Effect>,
+        onModelChange: @escaping (Model) -> Void
+    ) {
+        self.controller = controller
+        self.weakConnectable = WeakConnectable()
+        self.weakConnectableDelegate = WeakConnectableDelegate<Model>(
+            onModelChange: { model in
+                onModelChange(model)
+            }
+        )
+        self.weakConnectable.delegate = self.weakConnectableDelegate
+        super.init(nibName: nil, bundle: nil)
+        controller.connectView(weakConnectable)
+        controller.start()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func handleEvent(_ event: Event) {
+        weakConnectable.send(event)
+    }
+
+    deinit {
+        if controller.running {
+            controller.stop()
+            controller.disconnectView()
+        }
+    }
+}
+
+private final class WeakConnectable<Model, Event>: ConnectableClass<Model, Event> {
+    weak var delegate: WeakConnectableDelegate<Model>?
+
+    override func handle(_ model: Model) {
+        delegate?.onModelChange(model)
+    }
+
+    override func onDispose() {
+        delegate = nil
+    }
+}
+
+private final class WeakConnectableDelegate<Model> {
+    let onModelChange: (Model) -> Void
+
+    init(onModelChange: @escaping (Model) -> Void) {
+        self.onModelChange = onModelChange
+    }
+}

--- a/MobiusExtras/Source/MobiusViewController.swift
+++ b/MobiusExtras/Source/MobiusViewController.swift
@@ -17,6 +17,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#if canImport(UIKit)
+
 import MobiusCore
 import UIKit
 
@@ -112,3 +114,5 @@ private final class WeakConnectableDelegate<Model> {
         self.onModelChange = onModelChange
     }
 }
+
+#endif

--- a/MobiusExtras/Source/MobiusViewController.swift
+++ b/MobiusExtras/Source/MobiusViewController.swift
@@ -55,23 +55,24 @@ public extension UIViewController {
 
 private class MobiusHolder<Model, Event, Effect>: UIViewController {
     private let controller: MobiusController<Model, Event, Effect>
-    private let weakConnectableDelegate: WeakConnectableDelegate<Model>
-    private let weakConnectable: WeakConnectable<Model, Event>
+    // swiftlint:disable weak_delegate
+    private let connectableDelegate: WeakConnectableDelegate<Model>
+    private let connectable: WeakConnectable<Model, Event>
 
     init(
         controller: MobiusController<Model, Event, Effect>,
         onModelChange: @escaping (Model) -> Void
     ) {
         self.controller = controller
-        self.weakConnectable = WeakConnectable()
-        self.weakConnectableDelegate = WeakConnectableDelegate<Model>(
+        self.connectable = WeakConnectable()
+        self.connectableDelegate = WeakConnectableDelegate<Model>(
             onModelChange: { model in
                 onModelChange(model)
             }
         )
-        self.weakConnectable.delegate = self.weakConnectableDelegate
+        self.connectable.delegate = self.connectableDelegate
         super.init(nibName: nil, bundle: nil)
-        controller.connectView(weakConnectable)
+        controller.connectView(connectable)
         controller.start()
     }
 
@@ -80,7 +81,7 @@ private class MobiusHolder<Model, Event, Effect>: UIViewController {
     }
 
     func handleEvent(_ event: Event) {
-        weakConnectable.send(event)
+        connectable.send(event)
     }
 
     deinit {

--- a/MobiusExtras/Test/MobiusViewControllerTests.swift
+++ b/MobiusExtras/Test/MobiusViewControllerTests.swift
@@ -40,7 +40,7 @@ final class MobiusViewControllerTests: QuickSpec {
                 expect(viewController.controller.running).to(beFalse())
                 expect(viewController.children.count).to(equal(0))
             }
- 
+
             it("forwards model changes to `onModelChange`") {
                 var model = ""
                 let viewController = ViewController(onModelChange: { newModel in

--- a/MobiusExtras/Test/MobiusViewControllerTests.swift
+++ b/MobiusExtras/Test/MobiusViewControllerTests.swift
@@ -1,0 +1,80 @@
+// Copyright (c) 2019 Spotify AB.
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import Foundation
+import MobiusCore
+import MobiusExtras
+import Nimble
+import Quick
+
+final class MobiusViewControllerTests: QuickSpec {
+    override func spec() {
+        context("View Controller using Mobius") {
+            it("starts the Mobius Controller when the View Controller is initialized") {
+                let viewController = ViewController(onModelChange: { _ in })
+
+                expect(viewController.controller.running).to(beTrue())
+                expect(viewController.children.count).to(equal(1))
+            }
+
+            it("stops the Mobius Controller when the View Controller's connection is disposed") {
+                let viewController = ViewController(onModelChange: { _ in })
+
+                viewController.connection.dispose()
+                expect(viewController.controller.running).to(beFalse())
+                expect(viewController.children.count).to(equal(0))
+            }
+ 
+            it("forwards model changes to `onModelChange`") {
+                var model = ""
+                let viewController = ViewController(onModelChange: { newModel in
+                    model = newModel
+                })
+
+                viewController.connection.accept("1")
+                viewController.connection.accept("2")
+                viewController.connection.accept("3")
+
+                expect(model).toEventually(equal("123"))
+            }
+        }
+    }
+}
+
+private let update = Update<String, String, String> { model, event in
+    .next(model + event)
+}
+private let effectHandler = EffectRouter<String, String>().asConnectable
+private class ViewController: UIViewController {
+    let controller = Mobius.loop(update: update, effectHandler: effectHandler)
+        .makeController(from: "")
+    var connection: Connection<String>!
+
+    init(onModelChange: @escaping (String) -> Void) {
+        super.init(nibName: nil, bundle: nil)
+        connection = useMobius(
+            controller: controller,
+            modelChanged: onModelChange
+        )
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}

--- a/MobiusExtras/Test/MobiusViewControllerTests.swift
+++ b/MobiusExtras/Test/MobiusViewControllerTests.swift
@@ -30,7 +30,15 @@ final class MobiusViewControllerTests: QuickSpec {
                 let viewController = ViewController(onModelChange: { _ in })
 
                 expect(viewController.controller.running).to(beTrue())
-                expect(viewController.children.count).to(equal(1))
+            }
+
+            it("stops the Mobius Controller when the View Controller is deinitialized") {
+                var viewController: ViewController? = ViewController(onModelChange: { _ in })
+                let controller = viewController!.controller
+
+                viewController = nil
+
+                expect(controller.running).to(beFalse())
             }
 
             it("stops the Mobius Controller when the View Controller's connection is disposed") {

--- a/MobiusExtras/Test/MobiusViewControllerTests.swift
+++ b/MobiusExtras/Test/MobiusViewControllerTests.swift
@@ -17,6 +17,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#if canImport(UIKit)
+
 import Foundation
 import MobiusCore
 import MobiusExtras
@@ -86,3 +88,4 @@ private class ViewController: UIViewController {
         fatalError("init(coder:) has not been implemented")
     }
 }
+#endif


### PR DESCRIPTION
This is an alternative to https://github.com/spotify/Mobius.swift/pull/131

In this version, the MobiusController will be started when the view is visible and stopped when the view disappears.