### PR TITLE
Add onConnect to ConnectableClass

### DIFF
--- a/MobiusExtras/Source/ConnectableClass.swift
+++ b/MobiusExtras/Source/ConnectableClass.swift
@@ -73,7 +73,13 @@ open class ConnectableClass<Input, Output>: Connectable {
         handleError("The function `\(#function)` must be overridden in subclass \(type(of: self))")
     }
 
-    /// Called when its being disposed. This function should release any resources used by the subclass.
+    /// Called when the connection is being established. This function can be used to allocate and initialize any
+    /// resources used by the subclass.
+    ///
+    /// - Note: This function is optional to override by subclasses.
+    open func onConnect() {}
+
+    /// Called when the connection is being disposed. This function should release any resources used by the subclass.
     ///
     /// - Attention: This function has to be overridden by a subclass or an error will be thrown to the MobiusHooks
     /// error handler.
@@ -96,6 +102,7 @@ open class ConnectableClass<Input, Output>: Connectable {
         }
 
         self.consumer = consumer
+        onConnect()
         return Connection(acceptClosure: self.accept, disposeClosure: self.dispose)
     }
 

--- a/MobiusExtras/Source/ConnectableClass.swift
+++ b/MobiusExtras/Source/ConnectableClass.swift
@@ -63,7 +63,6 @@ open class ConnectableClass<Input, Output>: Connectable {
         }
 
         consumer(output)
-
     }
 
     /// Called when the `Connectable` receives input to allow the subclass to react to it.

--- a/MobiusExtras/Test/ConnectableClassTests.swift
+++ b/MobiusExtras/Test/ConnectableClassTests.swift
@@ -69,6 +69,10 @@ class ConnectableTests: QuickSpec {
                     sut.handleError = handleError
                 }
 
+                it("should call onConnect") {
+                    expect(sut.connectCounter).to(equal(1))
+                }
+
                 context("when a connection has already been created") {
                     it("should fail") {
                         _ = sut.connect({ _ in })
@@ -139,6 +143,11 @@ private class SubclassedConnectableClass: ConnectableClass<String, String> {
     var handledStrings = [String]()
     override func handle(_ input: String) {
         handledStrings.append(input)
+    }
+
+    var connectCounter = 0
+    override func onConnect() {
+        connectCounter += 1
     }
 
     var disposeCounter = 0

--- a/MobiusExtras/Test/ConnectableClassTests.swift
+++ b/MobiusExtras/Test/ConnectableClassTests.swift
@@ -76,7 +76,7 @@ class ConnectableTests: QuickSpec {
                     }
                 }
 
-                context("to which some input is sent") {
+                context("when some input is sent") {
                     it("should call handle in the subclass with the input") {
                         let testData = "a string"
                         connection.accept(testData)
@@ -84,8 +84,8 @@ class ConnectableTests: QuickSpec {
                     }
                 }
 
-                context("on which dispose is called") {
-                    it("should call disposed in the subclass") {
+                context("when dispose is called") {
+                    it("should call onDispose in the subclass") {
                         connection.dispose()
                         expect(sut.disposeCounter).to(equal(1))
                     }


### PR DESCRIPTION
This PR aims to resolve the issue of “where do I allocate my resources for my `ConnectableClass` subclass. Right now there isn’t a good place:

- Allocating the resources in `init` has the benefit of avoiding optionals, and IUOs. It comes with the downside that resources can’t be cleaned up as expected by Mobius since it’s not matched with `onDispose`.
- Allocating the resources in `handle` has the benefit of being cleaned up by `onDispose`. It comes with the downside of being, potentially, much more wasteful as resources would be allocated and hooked up every time the model changes.

My proposal is that we add an `onConnect` method. This will be called from `connect` when a successful connection is made. Since `connect` acts as the matched pair for disposing the connecting `onConnect` will naturally be paired with `onDispose`. So that resources can be allocated and disposed.

Also note that this change retains backwards compatibility as `onConnect` is optional to override.