### PR TITLE
Rename the associated types in the EffectHandler

### DIFF
--- a/MobiusCore/Source/EffectHandlers/EffectHandler.swift
+++ b/MobiusCore/Source/EffectHandlers/EffectHandler.swift
@@ -20,9 +20,9 @@
 /// This protocol defines the contract for an Effect Handler which takes `EffectParameters` as input, and produces
 /// `Event`s as output.
 ///
-/// For each incoming effect parameter, zero or more `Event`s can be sent as output using `callback.send(Event)`. Once
-/// the effect parameters have been completely handled (i.e. when the handler will not produce any more events) call
-/// `callback.end()`.
+/// For each input to the `handle` function, zero or more `Event`s can be sent as output using `callback.send(Event)`.
+/// Once the effect parameters have been completely handled (i.e. when the handler will not produce any more events)
+/// call `callback.end()`.
 ///
 /// Note: `EffectHandler` should be used in conjunction with an `EffectRouter`.
 public protocol EffectHandler {

--- a/MobiusCore/Source/EffectHandlers/EffectHandler.swift
+++ b/MobiusCore/Source/EffectHandlers/EffectHandler.swift
@@ -21,7 +21,7 @@
 /// `Event`s as output.
 ///
 /// For each input to the `handle` function, zero or more `Event`s can be sent as output using `callback.send(Event)`.
-/// Once the effect parameters have been completely handled (i.e. when the handler will not produce any more events)
+/// Once the effect has been completely handled (i.e. when the handler will not produce any more events)
 /// call `callback.end()`.
 ///
 /// Note: `EffectHandler` should be used in conjunction with an `EffectRouter`.
@@ -74,7 +74,7 @@ public struct AnyEffectHandler<EffectParameters, Event>: EffectHandler {
         self.init(handle: handleClosure)
     }
 
-    public func handle(_ input: EffectParameters, _ callback: EffectCallback<Event>) -> Disposable {
-        return self.handleClosure(input, callback)
+    public func handle(_ parameters: EffectParameters, _ callback: EffectCallback<Event>) -> Disposable {
+        return self.handleClosure(parameters, callback)
     }
 }

--- a/MobiusCore/Source/EffectHandlers/EffectHandler.swift
+++ b/MobiusCore/Source/EffectHandlers/EffectHandler.swift
@@ -20,8 +20,8 @@
 /// This protocol defines the contract for an Effect Handler which takes `EffectParameters` as input, and produces
 /// `Event`s as output.
 ///
-/// For each incoming effect parameter, zero or more `Event`s can be sent as output using `callback.send(Event)`. When
-/// an the effect parameters have been completely handled, i.e. that effect will not result in any more events, call
+/// For each incoming effect parameter, zero or more `Event`s can be sent as output using `callback.send(Event)`. Once
+/// the effect parameters have been completely handled (i.e. when the handler will not produce any more events) call
 /// `callback.end()`.
 ///
 /// Note: `EffectHandler` should be used in conjunction with an `EffectRouter`.
@@ -29,20 +29,21 @@ public protocol EffectHandler {
     associatedtype EffectParameters
     associatedtype Event
 
-    /// Handle an `Effect`.
+    /// Handle some `EffectParameters`.
     ///
     /// To output events, call `callback.send`.
-    /// Call `callback.end()` once the effect has been handled to prevent memory leaks.
+    /// Call `callback.end()` once the input has been handled to prevent memory leaks.
     ///
     /// This returns a `Disposable` which cancels the handling of this effect. This `Disposable` will
     /// not be called if `callback.end()` has already been called.
     ///
-    /// Note: If it does not make sense to finish handling an effect, you should be using a `Connectable` instead of this protocol.
+    /// Note: If it does not make sense to finish handling an effect, you should be using a `Connectable` instead of
+    /// this protocol.
     /// Note: Mobius will not dispose the returned `Disposable` if `callback.end()` has already been called.
-    /// - Parameter input: The effect being handled
+    /// - Parameter effectParameters: The associated values of the loop `Effect` being handled.
     /// - Parameter callback: The `EffectCallback` used to communicate with the associated Mobius loop.
     func handle(
-        _ input: EffectParameters,
+        _ effectParameters: EffectParameters,
         _ callback: EffectCallback<Event>
     ) -> Disposable
 }

--- a/MobiusCore/Source/EffectHandlers/EffectHandler.swift
+++ b/MobiusCore/Source/EffectHandlers/EffectHandler.swift
@@ -25,8 +25,10 @@
 ///
 /// Note: `EffectHandler` should be used in conjunction with an `EffectRouter`.
 public protocol EffectHandler {
-    associatedtype Effect
-    associatedtype Event
+    associatedtype Input
+    associatedtype Output
+    typealias Effect = Input
+    typealias Event = Output
 
     /// Handle an `Effect`.
     ///

--- a/MobiusCore/Source/EffectHandlers/EffectHandler.swift
+++ b/MobiusCore/Source/EffectHandlers/EffectHandler.swift
@@ -29,7 +29,7 @@ public protocol EffectHandler {
     associatedtype EffectParameters
     associatedtype Event
 
-    /// Handle some `EffectParameters`.
+    /// Handle an effect with `EffectParameters` as its associated values.
     ///
     /// To output events, call `callback.send`.
     /// Call `callback.end()` once the input has been handled to prevent memory leaks.

--- a/MobiusCore/Source/EffectHandlers/EffectRouter.swift
+++ b/MobiusCore/Source/EffectHandlers/EffectRouter.swift
@@ -81,7 +81,7 @@ public struct _PartialEffectRouter<Effect, Payload, Event> {
     /// - Parameter effectHandler: the `EffectHandler` for the route in question.
     public func to<Handler: EffectHandler>(
         _ effectHandler: Handler
-    ) -> EffectRouter<Effect, Event> where Handler.Effect == Payload, Handler.Event == Event {
+    ) -> EffectRouter<Effect, Event> where Handler.EffectParameters == Payload, Handler.Event == Event {
         let connectable = EffectExecutor(handleInput: effectHandler.handle)
         let route = Route<Effect, Event>(extractPayload: path, connectable: connectable)
         return EffectRouter(routes: routes + [route])


### PR DESCRIPTION
There has been a lot of confusion about the names of the associated types in the `EffectHandler` protocol, specifically the `Effect` name.
Renaming these to `Input` and `Output` should help with this.