### PR TITLE
[WIP] Improved equatability errors in Swift 5.2 when using the EffectRouter

### DIFF
--- a/MobiusCore/Source/EffectHandlers/EnumRoute.swift
+++ b/MobiusCore/Source/EffectHandlers/EnumRoute.swift
@@ -29,12 +29,12 @@ public extension EffectRouter {
     }
 }
 
-public extension EffectRouter where Effect: Equatable {
-    func routeCase(
-        _ enumCase: Effect
+public extension EffectRouter {
+    func routeCase<EquatableCase: Equatable>(
+        _ enumCase: EquatableCase
     ) -> _PartialEffectRouter<Effect, Void, Event> {
         return routeEffects(withPayload: { effect in
-            if enumCase == effect {
+            if let effect = effect as? EquatableCase, enumCase == effect {
                 return ()
             } else {
                 return nil

--- a/MobiusCore/Source/EffectHandlers/EnumRoute.swift
+++ b/MobiusCore/Source/EffectHandlers/EnumRoute.swift
@@ -20,16 +20,18 @@
 import Darwin
 
 public extension EffectRouter {
-    func routeCase<Payload>(
-        _ enumCase: @escaping (Payload) -> Effect
+    func routeCase<EnumCase, Payload>(
+        _ enumCase: @escaping (Payload) -> EnumCase
     ) -> _PartialEffectRouter<Effect, Payload, Event> {
         return routeEffects(withPayload: { effect in
-            UnwrapEnum<Effect, Payload>.extract(case: enumCase, from: effect)
+            if let effect = effect as? EnumCase {
+                return UnwrapEnum<EnumCase, Payload>.extract(case: enumCase, from: effect)
+            } else {
+                return nil
+            }
         })
     }
-}
 
-public extension EffectRouter {
     func routeCase<EquatableCase: Equatable>(
         _ enumCase: EquatableCase
     ) -> _PartialEffectRouter<Effect, Void, Event> {


### PR DESCRIPTION
Using the `EffectRouter` with non-equatable enums in Swift 5.2 results in very unhelpful error messages. This PR tries to resolve that issue.

Pre Swift 5.2:
<img width="1328" alt="pre-swift-5_2" src="https://user-images.githubusercontent.com/6968065/78238310-b9f9bb80-74dc-11ea-93ea-ec3c01f7ac9a.png">
Swift 5.2:
![swift-5_2](https://user-images.githubusercontent.com/6968065/78238338-c120c980-74dc-11ea-8cb8-13c968c75981.png)

After this change we are back to the correct error message:
![swift-5_2-post-change](https://user-images.githubusercontent.com/6968065/78238373-cbdb5e80-74dc-11ea-9a51-523cafa62789.png)
