### PR TITLE
Bump 0.3.0

### DIFF
--- a/MobiusCore.podspec.json
+++ b/MobiusCore.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "MobiusCore",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "summary": "A functional reactive framework for managing state evolution and side-effects",
   "authors": "Spotify AB",
   "homepage": "https://github.com/spotify/Mobius.swift",
@@ -11,7 +11,7 @@
   },
   "source": {
     "git": "https://github.com/spotify/Mobius.swift.git",
-    "tag": "0.2.0"
+    "tag": "0.3.0"
   },
   "platforms": {
     "ios": "10.0"

--- a/MobiusCore/Source/AsyncStartStopStateMachine.swift
+++ b/MobiusCore/Source/AsyncStartStopStateMachine.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Spotify AB.
+// Copyright (c) 2020 Spotify AB.
 //
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file

--- a/MobiusCore/Source/BackwardsCompatibility.swift
+++ b/MobiusCore/Source/BackwardsCompatibility.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Spotify AB.
+// Copyright (c) 2020 Spotify AB.
 //
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file

--- a/MobiusCore/Source/BrokenConnection.swift
+++ b/MobiusCore/Source/BrokenConnection.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Spotify AB.
+// Copyright (c) 2020 Spotify AB.
 //
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file

--- a/MobiusCore/Source/ConcurrentAccessDetector.swift
+++ b/MobiusCore/Source/ConcurrentAccessDetector.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Spotify AB.
+// Copyright (c) 2020 Spotify AB.
 //
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file

--- a/MobiusCore/Source/Connectable.swift
+++ b/MobiusCore/Source/Connectable.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Spotify AB.
+// Copyright (c) 2020 Spotify AB.
 //
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file

--- a/MobiusCore/Source/ConnectableConvenienceClasses/ActionConnectable.swift
+++ b/MobiusCore/Source/ConnectableConvenienceClasses/ActionConnectable.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Spotify AB.
+// Copyright (c) 2020 Spotify AB.
 //
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file

--- a/MobiusCore/Source/ConnectableConvenienceClasses/AsyncDispatchQueueConnectable.swift
+++ b/MobiusCore/Source/ConnectableConvenienceClasses/AsyncDispatchQueueConnectable.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Spotify AB.
+// Copyright (c) 2020 Spotify AB.
 //
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file

--- a/MobiusCore/Source/ConnectableConvenienceClasses/BlockingFunctionConnectable.swift
+++ b/MobiusCore/Source/ConnectableConvenienceClasses/BlockingFunctionConnectable.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Spotify AB.
+// Copyright (c) 2020 Spotify AB.
 //
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file

--- a/MobiusCore/Source/ConnectableConvenienceClasses/ClosureConnectable.swift
+++ b/MobiusCore/Source/ConnectableConvenienceClasses/ClosureConnectable.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Spotify AB.
+// Copyright (c) 2020 Spotify AB.
 //
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file

--- a/MobiusCore/Source/ConnectableConvenienceClasses/ConsumerConnectable.swift
+++ b/MobiusCore/Source/ConnectableConvenienceClasses/ConsumerConnectable.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Spotify AB.
+// Copyright (c) 2020 Spotify AB.
 //
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file

--- a/MobiusCore/Source/ConnectablePublisher.swift
+++ b/MobiusCore/Source/ConnectablePublisher.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Spotify AB.
+// Copyright (c) 2020 Spotify AB.
 //
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file

--- a/MobiusCore/Source/Connection.swift
+++ b/MobiusCore/Source/Connection.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Spotify AB.
+// Copyright (c) 2020 Spotify AB.
 //
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file

--- a/MobiusCore/Source/Consumer.swift
+++ b/MobiusCore/Source/Consumer.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Spotify AB.
+// Copyright (c) 2020 Spotify AB.
 //
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file

--- a/MobiusCore/Source/Disposables/AnonymousDisposable.swift
+++ b/MobiusCore/Source/Disposables/AnonymousDisposable.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Spotify AB.
+// Copyright (c) 2020 Spotify AB.
 //
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file

--- a/MobiusCore/Source/Disposables/CompositeDisposable.swift
+++ b/MobiusCore/Source/Disposables/CompositeDisposable.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Spotify AB.
+// Copyright (c) 2020 Spotify AB.
 //
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file

--- a/MobiusCore/Source/Disposables/Disposable.swift
+++ b/MobiusCore/Source/Disposables/Disposable.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Spotify AB.
+// Copyright (c) 2020 Spotify AB.
 //
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file

--- a/MobiusCore/Source/EffectHandlers/EffectCallback.swift
+++ b/MobiusCore/Source/EffectHandlers/EffectCallback.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Spotify AB.
+// Copyright (c) 2020 Spotify AB.
 //
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file

--- a/MobiusCore/Source/EffectHandlers/EffectExecutor.swift
+++ b/MobiusCore/Source/EffectHandlers/EffectExecutor.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Spotify AB.
+// Copyright (c) 2020 Spotify AB.
 //
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file

--- a/MobiusCore/Source/EffectHandlers/EffectHandler.swift
+++ b/MobiusCore/Source/EffectHandlers/EffectHandler.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Spotify AB.
+// Copyright (c) 2020 Spotify AB.
 //
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file

--- a/MobiusCore/Source/EffectHandlers/EffectRouter.swift
+++ b/MobiusCore/Source/EffectHandlers/EffectRouter.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Spotify AB.
+// Copyright (c) 2020 Spotify AB.
 //
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file

--- a/MobiusCore/Source/EffectHandlers/EffectRouterDSL.swift
+++ b/MobiusCore/Source/EffectHandlers/EffectRouterDSL.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Spotify AB.
+// Copyright (c) 2020 Spotify AB.
 //
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file

--- a/MobiusCore/Source/EffectHandlers/EnumRoute.swift
+++ b/MobiusCore/Source/EffectHandlers/EnumRoute.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Spotify AB.
+// Copyright (c) 2020 Spotify AB.
 //
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file

--- a/MobiusCore/Source/EffectHandlers/ThreadSafeConnectable.swift
+++ b/MobiusCore/Source/EffectHandlers/ThreadSafeConnectable.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Spotify AB.
+// Copyright (c) 2020 Spotify AB.
 //
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file

--- a/MobiusCore/Source/EffectRouterBuilder.swift
+++ b/MobiusCore/Source/EffectRouterBuilder.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Spotify AB.
+// Copyright (c) 2020 Spotify AB.
 //
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file

--- a/MobiusCore/Source/EventProcessor.swift
+++ b/MobiusCore/Source/EventProcessor.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Spotify AB.
+// Copyright (c) 2020 Spotify AB.
 //
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file

--- a/MobiusCore/Source/EventSources/AnyEventSource.swift
+++ b/MobiusCore/Source/EventSources/AnyEventSource.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Spotify AB.
+// Copyright (c) 2020 Spotify AB.
 //
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file

--- a/MobiusCore/Source/EventSources/CompositeEventSourceBuilder.swift
+++ b/MobiusCore/Source/EventSources/CompositeEventSourceBuilder.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Spotify AB.
+// Copyright (c) 2020 Spotify AB.
 //
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file

--- a/MobiusCore/Source/EventSources/EventSource.swift
+++ b/MobiusCore/Source/EventSources/EventSource.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Spotify AB.
+// Copyright (c) 2020 Spotify AB.
 //
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file

--- a/MobiusCore/Source/First.swift
+++ b/MobiusCore/Source/First.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Spotify AB.
+// Copyright (c) 2020 Spotify AB.
 //
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file

--- a/MobiusCore/Source/Lock.swift
+++ b/MobiusCore/Source/Lock.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Spotify AB.
+// Copyright (c) 2020 Spotify AB.
 //
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file

--- a/MobiusCore/Source/LoggingAdaptors.swift
+++ b/MobiusCore/Source/LoggingAdaptors.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Spotify AB.
+// Copyright (c) 2020 Spotify AB.
 //
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file

--- a/MobiusCore/Source/Mobius.swift
+++ b/MobiusCore/Source/Mobius.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Spotify AB.
+// Copyright (c) 2020 Spotify AB.
 //
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file

--- a/MobiusCore/Source/MobiusController.swift
+++ b/MobiusCore/Source/MobiusController.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Spotify AB.
+// Copyright (c) 2020 Spotify AB.
 //
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file

--- a/MobiusCore/Source/MobiusHooks.swift
+++ b/MobiusCore/Source/MobiusHooks.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Spotify AB.
+// Copyright (c) 2020 Spotify AB.
 //
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file

--- a/MobiusCore/Source/MobiusLogger.swift
+++ b/MobiusCore/Source/MobiusLogger.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Spotify AB.
+// Copyright (c) 2020 Spotify AB.
 //
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file

--- a/MobiusCore/Source/MobiusLoop.swift
+++ b/MobiusCore/Source/MobiusLoop.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Spotify AB.
+// Copyright (c) 2020 Spotify AB.
 //
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file

--- a/MobiusCore/Source/Next.swift
+++ b/MobiusCore/Source/Next.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Spotify AB.
+// Copyright (c) 2020 Spotify AB.
 //
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file

--- a/MobiusCore/Source/WorkBag.swift
+++ b/MobiusCore/Source/WorkBag.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Spotify AB.
+// Copyright (c) 2020 Spotify AB.
 //
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file

--- a/MobiusCore/Test/AnonymousDisposableTests.swift
+++ b/MobiusCore/Test/AnonymousDisposableTests.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Spotify AB.
+// Copyright (c) 2020 Spotify AB.
 //
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file

--- a/MobiusCore/Test/AnyConnectionTests.swift
+++ b/MobiusCore/Test/AnyConnectionTests.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Spotify AB.
+// Copyright (c) 2020 Spotify AB.
 //
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file

--- a/MobiusCore/Test/AnyMobiusLoggerTests.swift
+++ b/MobiusCore/Test/AnyMobiusLoggerTests.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Spotify AB.
+// Copyright (c) 2020 Spotify AB.
 //
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file

--- a/MobiusCore/Test/CompositeDisposableTests.swift
+++ b/MobiusCore/Test/CompositeDisposableTests.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Spotify AB.
+// Copyright (c) 2020 Spotify AB.
 //
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file

--- a/MobiusCore/Test/ConnectableConvenienceClassesTests/ActionConnectableTest.swift
+++ b/MobiusCore/Test/ConnectableConvenienceClassesTests/ActionConnectableTest.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Spotify AB.
+// Copyright (c) 2020 Spotify AB.
 //
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file

--- a/MobiusCore/Test/ConnectableConvenienceClassesTests/BlockingFunctionConnectableTests.swift
+++ b/MobiusCore/Test/ConnectableConvenienceClassesTests/BlockingFunctionConnectableTests.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Spotify AB.
+// Copyright (c) 2020 Spotify AB.
 //
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file

--- a/MobiusCore/Test/ConnectableConvenienceClassesTests/ConsumerConnectableTests.swift
+++ b/MobiusCore/Test/ConnectableConvenienceClassesTests/ConsumerConnectableTests.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Spotify AB.
+// Copyright (c) 2020 Spotify AB.
 //
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file

--- a/MobiusCore/Test/EffectHandlers/AnyEffectHandlerTests.swift
+++ b/MobiusCore/Test/EffectHandlers/AnyEffectHandlerTests.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Spotify AB.
+// Copyright (c) 2020 Spotify AB.
 //
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file

--- a/MobiusCore/Test/EffectHandlers/CallbackTests.swift
+++ b/MobiusCore/Test/EffectHandlers/CallbackTests.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Spotify AB.
+// Copyright (c) 2020 Spotify AB.
 //
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file

--- a/MobiusCore/Test/EffectHandlers/EffectHandlerTests.swift
+++ b/MobiusCore/Test/EffectHandlers/EffectHandlerTests.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Spotify AB.
+// Copyright (c) 2020 Spotify AB.
 //
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file

--- a/MobiusCore/Test/EffectHandlers/EffectRouterDSLTests.swift
+++ b/MobiusCore/Test/EffectHandlers/EffectRouterDSLTests.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Spotify AB.
+// Copyright (c) 2020 Spotify AB.
 //
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file

--- a/MobiusCore/Test/EffectHandlers/EnumRouteTests.swift
+++ b/MobiusCore/Test/EffectHandlers/EnumRouteTests.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Spotify AB.
+// Copyright (c) 2020 Spotify AB.
 //
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file

--- a/MobiusCore/Test/EventProcessorTests.swift
+++ b/MobiusCore/Test/EventProcessorTests.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Spotify AB.
+// Copyright (c) 2020 Spotify AB.
 //
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file

--- a/MobiusCore/Test/EventSources/AnyEventSourceTests.swift
+++ b/MobiusCore/Test/EventSources/AnyEventSourceTests.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Spotify AB.
+// Copyright (c) 2020 Spotify AB.
 //
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file

--- a/MobiusCore/Test/EventSources/CompositeEventSourceBuilderTests.swift
+++ b/MobiusCore/Test/EventSources/CompositeEventSourceBuilderTests.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Spotify AB.
+// Copyright (c) 2020 Spotify AB.
 //
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file

--- a/MobiusCore/Test/FirstTests.swift
+++ b/MobiusCore/Test/FirstTests.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Spotify AB.
+// Copyright (c) 2020 Spotify AB.
 //
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file

--- a/MobiusCore/Test/LoggingInitiateTests.swift
+++ b/MobiusCore/Test/LoggingInitiateTests.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Spotify AB.
+// Copyright (c) 2020 Spotify AB.
 //
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file

--- a/MobiusCore/Test/LoggingUpdateTests.swift
+++ b/MobiusCore/Test/LoggingUpdateTests.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Spotify AB.
+// Copyright (c) 2020 Spotify AB.
 //
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file

--- a/MobiusCore/Test/MobiusControllerTests.swift
+++ b/MobiusCore/Test/MobiusControllerTests.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Spotify AB.
+// Copyright (c) 2020 Spotify AB.
 //
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file

--- a/MobiusCore/Test/MobiusIntegrationTests.swift
+++ b/MobiusCore/Test/MobiusIntegrationTests.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Spotify AB.
+// Copyright (c) 2020 Spotify AB.
 //
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file

--- a/MobiusCore/Test/NextTests.swift
+++ b/MobiusCore/Test/NextTests.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Spotify AB.
+// Copyright (c) 2020 Spotify AB.
 //
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file

--- a/MobiusCore/Test/NonReentrancyTests.swift
+++ b/MobiusCore/Test/NonReentrancyTests.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Spotify AB.
+// Copyright (c) 2020 Spotify AB.
 //
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file

--- a/MobiusCore/Test/TestingUtil.swift
+++ b/MobiusCore/Test/TestingUtil.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Spotify AB.
+// Copyright (c) 2020 Spotify AB.
 //
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file

--- a/MobiusCore/Test/WorkBagTests.swift
+++ b/MobiusCore/Test/WorkBagTests.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Spotify AB.
+// Copyright (c) 2020 Spotify AB.
 //
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file

--- a/MobiusExtras.podspec.json
+++ b/MobiusExtras.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "MobiusExtras",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "summary": "A functional reactive framework for managing state evolution and side-effects: Extra Helpers",
   "authors": "Spotify AB",
   "homepage": "https://github.com/spotify/Mobius.swift/tree/master/MobiusExtras",
@@ -11,7 +11,7 @@
   },
   "source": {
     "git": "https://github.com/spotify/Mobius.swift.git",
-    "tag": "0.2.0"
+    "tag": "0.3.0"
   },
   "platforms": {
     "ios": "10.0"
@@ -21,7 +21,7 @@
   "source_files": "MobiusExtras/Source/**/*.swift",
   "dependencies": {
     "MobiusCore": [
-      "0.2.0"
+      "0.3.0"
     ]
   }
 }

--- a/MobiusExtras/Source/ConnectableClass.swift
+++ b/MobiusExtras/Source/ConnectableClass.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Spotify AB.
+// Copyright (c) 2020 Spotify AB.
 //
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file

--- a/MobiusExtras/Source/ConnectableContramap.swift
+++ b/MobiusExtras/Source/ConnectableContramap.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Spotify AB.
+// Copyright (c) 2020 Spotify AB.
 //
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file

--- a/MobiusExtras/Source/Copyable.swift
+++ b/MobiusExtras/Source/Copyable.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Spotify AB.
+// Copyright (c) 2020 Spotify AB.
 //
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file

--- a/MobiusExtras/Source/EventSource+Extensions.swift
+++ b/MobiusExtras/Source/EventSource+Extensions.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Spotify AB.
+// Copyright (c) 2020 Spotify AB.
 //
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file

--- a/MobiusExtras/Source/SimpleLogger.swift
+++ b/MobiusExtras/Source/SimpleLogger.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Spotify AB.
+// Copyright (c) 2020 Spotify AB.
 //
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file

--- a/MobiusExtras/Test/ConnectableClassTests.swift
+++ b/MobiusExtras/Test/ConnectableClassTests.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Spotify AB.
+// Copyright (c) 2020 Spotify AB.
 //
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file

--- a/MobiusExtras/Test/ConnectableContramapTests.swift
+++ b/MobiusExtras/Test/ConnectableContramapTests.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Spotify AB.
+// Copyright (c) 2020 Spotify AB.
 //
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file

--- a/MobiusExtras/Test/CopyableTests.swift
+++ b/MobiusExtras/Test/CopyableTests.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Spotify AB.
+// Copyright (c) 2020 Spotify AB.
 //
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file

--- a/MobiusExtras/Test/EventSource+ExtensionsTests.swift
+++ b/MobiusExtras/Test/EventSource+ExtensionsTests.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Spotify AB.
+// Copyright (c) 2020 Spotify AB.
 //
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file

--- a/MobiusNimble.podspec.json
+++ b/MobiusNimble.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "MobiusNimble",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "summary": "A functional reactive framework for managing state evolution and side-effects: Nimble Helpers",
   "authors": "Spotify AB",
   "homepage": "https://github.com/spotify/Mobius.swift/tree/master/MobiusNimble",
@@ -11,7 +11,7 @@
   },
   "source": {
     "git": "https://github.com/spotify/Mobius.swift.git",
-    "tag": "0.2.0"
+    "tag": "0.3.0"
   },
   "platforms": {
     "ios": "10.0"
@@ -24,10 +24,10 @@
   ],
   "dependencies": {
     "MobiusCore": [
-      "0.2.0"
+      "0.3.0"
     ],
     "MobiusTest": [
-      "0.2.0"
+      "0.3.0"
     ],
     "Nimble": [
       "~> 8.0.7"

--- a/MobiusNimble/Source/NimbleFirstMatchers.swift
+++ b/MobiusNimble/Source/NimbleFirstMatchers.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Spotify AB.
+// Copyright (c) 2020 Spotify AB.
 //
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file

--- a/MobiusNimble/Source/NimbleNextMatchers.swift
+++ b/MobiusNimble/Source/NimbleNextMatchers.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Spotify AB.
+// Copyright (c) 2020 Spotify AB.
 //
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file

--- a/MobiusNimble/Test/NimbleFirstMatchersTests.swift
+++ b/MobiusNimble/Test/NimbleFirstMatchersTests.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Spotify AB.
+// Copyright (c) 2020 Spotify AB.
 //
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file

--- a/MobiusNimble/Test/NimbleNextMatchersTests.swift
+++ b/MobiusNimble/Test/NimbleNextMatchersTests.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Spotify AB.
+// Copyright (c) 2020 Spotify AB.
 //
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file

--- a/MobiusNimble/Test/TestUtil.swift
+++ b/MobiusNimble/Test/TestUtil.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Spotify AB.
+// Copyright (c) 2020 Spotify AB.
 //
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file

--- a/MobiusTest.podspec.json
+++ b/MobiusTest.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "MobiusTest",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "summary": "A functional reactive framework for managing state evolution and side-effects: Test Helpers",
   "authors": "Spotify AB",
   "homepage": "https://github.com/spotify/Mobius.swift/tree/master/MobiusTest",
@@ -11,7 +11,7 @@
   },
   "source": {
     "git": "https://github.com/spotify/Mobius.swift.git",
-    "tag": "0.2.0"
+    "tag": "0.3.0"
   },
   "platforms": {
     "ios": "10.0"
@@ -24,7 +24,7 @@
   ],
   "dependencies": {
     "MobiusCore": [
-      "0.2.0"
+      "0.3.0"
     ]
   }
 }

--- a/MobiusTest/MobiusTest.playground/Contents.swift
+++ b/MobiusTest/MobiusTest.playground/Contents.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Spotify AB.
+// Copyright (c) 2020 Spotify AB.
 //
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file

--- a/MobiusTest/Source/FirstMatchers.swift
+++ b/MobiusTest/Source/FirstMatchers.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Spotify AB.
+// Copyright (c) 2020 Spotify AB.
 //
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file

--- a/MobiusTest/Source/InitSpec.swift
+++ b/MobiusTest/Source/InitSpec.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Spotify AB.
+// Copyright (c) 2020 Spotify AB.
 //
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file

--- a/MobiusTest/Source/MatcherUtils.swift
+++ b/MobiusTest/Source/MatcherUtils.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Spotify AB.
+// Copyright (c) 2020 Spotify AB.
 //
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file

--- a/MobiusTest/Source/NextMatchers.swift
+++ b/MobiusTest/Source/NextMatchers.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Spotify AB.
+// Copyright (c) 2020 Spotify AB.
 //
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file

--- a/MobiusTest/Source/UpdateSpec.swift
+++ b/MobiusTest/Source/UpdateSpec.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Spotify AB.
+// Copyright (c) 2020 Spotify AB.
 //
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file

--- a/MobiusTest/Test/FirstMatchersTests.swift
+++ b/MobiusTest/Test/FirstMatchersTests.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Spotify AB.
+// Copyright (c) 2020 Spotify AB.
 //
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file

--- a/MobiusTest/Test/InitSpecTests.swift
+++ b/MobiusTest/Test/InitSpecTests.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Spotify AB.
+// Copyright (c) 2020 Spotify AB.
 //
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file

--- a/MobiusTest/Test/NextMatchersTests.swift
+++ b/MobiusTest/Test/NextMatchersTests.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Spotify AB.
+// Copyright (c) 2020 Spotify AB.
 //
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file

--- a/MobiusTest/Test/TestUtil.swift
+++ b/MobiusTest/Test/TestUtil.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Spotify AB.
+// Copyright (c) 2020 Spotify AB.
 //
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file

--- a/MobiusTest/Test/UpdateSpecTests.swift
+++ b/MobiusTest/Test/UpdateSpecTests.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Spotify AB.
+// Copyright (c) 2020 Spotify AB.
 //
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Mobius can be built for all Apple platforms using the Swift Package Manager.
 
 Add the following entry to your `Package.swift`:
 ```swift
-.package(url: "https://github.com/spotify/Mobius.swift.git", .upToNextMajor(from: "0.2.0"))
+.package(url: "https://github.com/spotify/Mobius.swift.git", .upToNextMajor(from: "0.3.0"))
 ```
 </details>
 
@@ -40,14 +40,14 @@ Mobius can only be built for iOS using CocoaPods. For other platforms, please us
 
 Add the following entry in your `Podfile`:
 ```ruby
-pod 'MobiusCore', '0.2.0'
+pod 'MobiusCore', '0.3.0'
 ```
 
 Optionally, you can also choose to integrate `MobiusExtras`, `MobiusNimble` or `MobiusTest`:
 ```ruby
-pod 'MobiusExtras', '0.2.0'
-pod 'MobiusNimble', '0.2.0'
-pod 'MobiusTest', '0.2.0'
+pod 'MobiusExtras', '0.3.0'
+pod 'MobiusNimble', '0.3.0'
+pod 'MobiusTest', '0.3.0'
 ```
 </details>
 
@@ -57,7 +57,7 @@ Mobius can only be built for iOS using Carthage. For other platforms, please use
 
 Add the following entry in your `Cartfile`:
 ```
-github "spotify/Mobius.swift" "0.2.0"
+github "spotify/Mobius.swift" "0.3.0"
 ```
 
 There are some additional steps to take as explained in the [Carthage documentation](https://github.com/Carthage/Carthage#adding-frameworks-to-an-application).
@@ -149,7 +149,7 @@ This covers the fundamentals of Mobius. To learn more, head on over to our [wiki
 
 ## Status
 
-Mobius.swift is in nearing a 1.0 release. We use the framework internally in deployed features, but have recently made a number of breaking changes. The current master branch breaks compatibility with the previous 0.2.0 release and contains deprecated backwards-compatbility wrappers for some of the smaller changes. Once the current development phase is stabilized these deprecated versions will be removed, and that will be Mobius 1.0.
+Mobius.swift is in nearing a 1.0 release. We use the framework internally in deployed features, but have recently made a number of breaking changes. Release 0.3.0 breaks compatibility with the previous 0.2.0 release and contains deprecated backwards-compatbility wrappers for some of the smaller changes. These deprecated versions will be removed, and some other additive changes made, to form Mobius 1.0.
 
 ## Development
 1. Clone


### PR DESCRIPTION
0.3.0 makes many changes from 0.2.0. Where possible, old names and types are available with deprecation attributes; these will soon be removed.

- Updated threading model:
  - `MobiusLoop` is now single-threaded
  - `MobiusController` runs a loop on a single background queue.
  - Fixed several issues around hard-to-avoid assertions in loop teardown.
- New `EffectRouter` and `EffectHandler` replace `EffectRouterBuilder` (which is deprecated along with several helpers).
- Effects in `First` and `Next` are now an array rather than a set. This doesn’t imply an ordering guarantee, but does mean that effects don’t have to be `Hashable`.
- Various things renamed or changed from methods to properties to better conform to Swift API Guidelines and for internal consistency:
  - `Initiator` is now `Initiate`, and is only used with `MobiusController`.
  - `MobiusLoop.getMostRecentModel()` becomes `latestModel`.
  - `MobiusController.getModel()` becomes `model`.
  - `Connectable.InputType` and `OutputType` become `Input` and `Output`; `Connection.ValueType` becomes `Value`.
- `Update` is now a struct. This isn’t leveraged by Mobius itself at the moment, but makes it easier to write transformations on updates in a fluent style.
- For consistency, `MobiusController` is created through a `makeController()` method on `Mobius.Builder` instead of being initialized with a builder argument.
- All methods on `MobiusLogger` now have default do-nothing implementations.
- `ConsoleLogger` has been replaced with `SimpleLogger`, which can take a consumer function to use instead of `print`.
- `NoEffect` and `BrokenConnection` are deprecated.
- `MobiusHooks.ErrorHandler` now returns `Never` rather than `Void`.
- Mobius no longer adds a public extension to `NSRecursiveLock`.
- There are more documentation comments than there used to be.
- Tooling updated to Swift 5.0 and Xcode 11.0.
- Swift Package Manager is explicitly supported for all Apple platforms; Carthage and CocoaPods are supported for iOS only.
