### PR TITLE
Deprecate old EffectRouter options

### DIFF
--- a/MobiusCore/Source/BackwardsCompatibility.swift
+++ b/MobiusCore/Source/BackwardsCompatibility.swift
@@ -113,33 +113,33 @@ public extension MobiusController {
     var isRunning: Bool { return running }
 }
 
-//@available(*, deprecated, message: "use `EffectRouter` instead")
+@available(*, deprecated, message: "use `EffectRouter` instead")
 public protocol EffectPredicate {
     associatedtype Effect
     func canAccept(_ effect: Effect) -> Bool
 }
 
-//@available(*, deprecated, message: "use `EffectRouter` instead")
+@available(*, deprecated, message: "use `EffectRouter` instead")
 public protocol ConnectableWithPredicate: Connectable, EffectPredicate {}
 
-//@available(*, deprecated, message: "use `EffectRouter` instead")
+@available(*, deprecated, message: "use `EffectRouter` instead")
 public protocol ConsumerWithPredicate: EffectPredicate {
     func accept(_ effect: Effect)
 }
 
-//@available(*, deprecated, message: "use `EffectRouter` instead")
+@available(*, deprecated, message: "use `EffectRouter` instead")
 public protocol ActionWithPredicate: EffectPredicate {
     func run()
 }
 
-//@available(*, deprecated, message: "use `EffectRouter` instead")
+@available(*, deprecated, message: "use `EffectRouter` instead")
 public protocol FunctionWithPredicate: EffectPredicate {
     associatedtype Event
 
     func apply(_ effect: Effect) -> Event
 }
 
-//@available(*, deprecated, message: "use `EffectRouter` instead")
+@available(*, deprecated, message: "use `EffectRouter` instead")
 public extension EffectRouterBuilder {
     /// Add a filtered `Connectable` for handling effects of a given type. The `Connectable` `Connection` will be invoked for
     /// each incoming effect object that passes its `canAccept` call.

--- a/MobiusCore/Source/EffectRouterBuilder.swift
+++ b/MobiusCore/Source/EffectRouterBuilder.swift
@@ -34,7 +34,7 @@ private typealias PredicatedConnection<Input> = (connection: Connection<Input>, 
 ///
 /// All the classes that the effect router know about must have a common type T.Effect. Note that
 /// instances of the builder are mutable and not thread-safe.
-//@available(*, deprecated, message: "use `EffectRouter` instead")
+@available(*, deprecated, message: "use `EffectRouter` instead")
 public struct EffectRouterBuilder<Input, Output> {
     private let connectables: [PredicatedConnectable<Input, Output>]
 


### PR DESCRIPTION
It occurred to me at the last minute that we want to do this for 0.3.0. Internally, we’ll need to bump to the version before this until we finish the migration, but we want to drop deprecated stuff on master.

@jeppes 