### PR TITLE
Add label to `.on(queue:)`

### DIFF
--- a/MobiusCore/Source/EffectHandlers/EffectRouter.swift
+++ b/MobiusCore/Source/EffectHandlers/EffectRouter.swift
@@ -107,8 +107,13 @@ public struct _PartialEffectRouter<Effect, EffectParameters, Event> {
 
     /// Handle an the current `Effect` asynchronously on the provided `DispatchQueue`
     ///
+    /// Warning: Dispatching events to a loop from a different queue is not a thread-safe operation and will require
+    /// manual synchronization unless the loop is run in a `MobiusController`.
+    /// See: [Using MobiusController](https://github.com/spotify/Mobius.swift/wiki/Using-MobiusController).
+    ///
+    ///
     /// - Parameter queue: The `DispatchQueue` that the current `Effect` should be handled on.
-    public func on(_ queue: DispatchQueue) -> Self {
+    public func on(queue: DispatchQueue) -> Self {
         return Self(routes: routes, path: path, queue: queue)
     }
 }

--- a/MobiusCore/Test/EffectHandlers/EffectRouterTests.swift
+++ b/MobiusCore/Test/EffectHandlers/EffectRouterTests.swift
@@ -212,7 +212,7 @@ class EffectRouterTests: QuickSpec {
                 var ranOnTestQueue = false
                 let connection = EffectRouter<Effect, Event>()
                     .routeCase(.effect1)
-                    .on(testQueue)
+                    .on(queue: testQueue)
                     .to {
                         dispatchPrecondition(condition: .onQueue(testQueue))
                         ranOnTestQueue = true


### PR DESCRIPTION
- Add label: `.on(.main)` --> `on(queue: .main)`
- Add warning about using this function in raw loops.

@JensAyton 