### PR TITLE
Disable caching for SPM build

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,12 +29,6 @@ jobs:
     runs-on: macOS-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/cache@v1
-      with:
-        path: .build
-        key: ${{ runner.os }}-spm-${{ hashFiles('Package.resolved') }}
-        restore-keys: |
-          ${{ runner.os }}-spm-
     - name: Build and Test
       run: Tools/ci-spm.sh
       env:


### PR DESCRIPTION
Regarding the discussion in #160

I think the module cache was barfing because it's not portable from machine-to-machine. Disabling it for now.