### PR TITLE
Bump 0.4.0

### DIFF
--- a/MobiusCore.podspec.json
+++ b/MobiusCore.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "MobiusCore",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "summary": "A functional reactive framework for managing state evolution and side-effects",
   "authors": "Spotify AB",
   "homepage": "https://github.com/spotify/Mobius.swift",
@@ -11,7 +11,7 @@
   },
   "source": {
     "git": "https://github.com/spotify/Mobius.swift.git",
-    "tag": "0.3.0"
+    "tag": "0.4.0"
   },
   "platforms": {
     "ios": "10.0"

--- a/MobiusExtras.podspec.json
+++ b/MobiusExtras.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "MobiusExtras",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "summary": "A functional reactive framework for managing state evolution and side-effects: Extra Helpers",
   "authors": "Spotify AB",
   "homepage": "https://github.com/spotify/Mobius.swift/tree/master/MobiusExtras",
@@ -11,7 +11,7 @@
   },
   "source": {
     "git": "https://github.com/spotify/Mobius.swift.git",
-    "tag": "0.3.0"
+    "tag": "0.4.0"
   },
   "platforms": {
     "ios": "10.0"
@@ -21,7 +21,7 @@
   "source_files": "MobiusExtras/Source/**/*.swift",
   "dependencies": {
     "MobiusCore": [
-      "0.3.0"
+      "0.4.0"
     ]
   }
 }

--- a/MobiusNimble.podspec.json
+++ b/MobiusNimble.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "MobiusNimble",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "summary": "A functional reactive framework for managing state evolution and side-effects: Nimble Helpers",
   "authors": "Spotify AB",
   "homepage": "https://github.com/spotify/Mobius.swift/tree/master/MobiusNimble",
@@ -11,7 +11,7 @@
   },
   "source": {
     "git": "https://github.com/spotify/Mobius.swift.git",
-    "tag": "0.3.0"
+    "tag": "0.4.0"
   },
   "platforms": {
     "ios": "10.0"
@@ -24,10 +24,10 @@
   ],
   "dependencies": {
     "MobiusCore": [
-      "0.3.0"
+      "0.4.0"
     ],
     "MobiusTest": [
-      "0.3.0"
+      "0.4.0"
     ],
     "Nimble": [
       "~> 8.0.7"

--- a/MobiusTest.podspec.json
+++ b/MobiusTest.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "MobiusTest",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "summary": "A functional reactive framework for managing state evolution and side-effects: Test Helpers",
   "authors": "Spotify AB",
   "homepage": "https://github.com/spotify/Mobius.swift/tree/master/MobiusTest",
@@ -11,7 +11,7 @@
   },
   "source": {
     "git": "https://github.com/spotify/Mobius.swift.git",
-    "tag": "0.3.0"
+    "tag": "0.4.0"
   },
   "platforms": {
     "ios": "10.0"
@@ -24,7 +24,7 @@
   ],
   "dependencies": {
     "MobiusCore": [
-      "0.3.0"
+      "0.4.0"
     ]
   }
 }

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Mobius can be built for all Apple platforms using the Swift Package Manager.
 
 Add the following entry to your `Package.swift`:
 ```swift
-.package(url: "https://github.com/spotify/Mobius.swift.git", .upToNextMajor(from: "0.3.0"))
+.package(url: "https://github.com/spotify/Mobius.swift.git", .upToNextMajor(from: "0.4.0"))
 ```
 </details>
 
@@ -40,14 +40,14 @@ Mobius can only be built for iOS using CocoaPods. For other platforms, please us
 
 Add the following entry in your `Podfile`:
 ```ruby
-pod 'MobiusCore', '0.3.0'
+pod 'MobiusCore', '0.4.0'
 ```
 
 Optionally, you can also choose to integrate `MobiusExtras`, `MobiusNimble` or `MobiusTest`:
 ```ruby
-pod 'MobiusExtras', '0.3.0'
-pod 'MobiusNimble', '0.3.0'
-pod 'MobiusTest', '0.3.0'
+pod 'MobiusExtras', '0.4.0'
+pod 'MobiusNimble', '0.4.0'
+pod 'MobiusTest', '0.4.0'
 ```
 </details>
 
@@ -57,7 +57,7 @@ Mobius can only be built for iOS using Carthage. For other platforms, please use
 
 Add the following entry in your `Cartfile`:
 ```
-github "spotify/Mobius.swift" "0.3.0"
+github "spotify/Mobius.swift" "0.4.0"
 ```
 
 There are some additional steps to take as explained in the [Carthage documentation](https://github.com/Carthage/Carthage#adding-frameworks-to-an-application).
@@ -149,7 +149,7 @@ This covers the fundamentals of Mobius. To learn more, head on over to our [wiki
 
 ## Status
 
-Mobius.swift is in nearing a 1.0 release. We use the framework internally in deployed features, but have recently made a number of breaking changes. Release 0.3.0 breaks compatibility with the previous 0.2.0 release and contains deprecated backwards-compatbility wrappers for some of the smaller changes. These deprecated versions will be removed, and some other additive changes made, to form Mobius 1.0.
+Mobius.swift is nearing a 1.0 release. We use the framework internally in deployed features, but have recently made a number of breaking changes. Release 0.3.0 breaks compatibility with the previous 0.2.0 release and contains deprecated backwards-compatbility wrappers for some of the smaller changes. These deprecated versions have been removed in the 0.4.0 release. Other additive changes will be made to form Mobius 1.0.
 
 ## Development
 1. Clone


### PR DESCRIPTION
- #168 Removed strong connectable&#x2194;&#xFE0E;loop reference
- #167 Handled `#file`/`#filePath` distinction for Swift 5.3
- #165 Addressed exclusionary language
- #164 Added visual model diff to test expectation output
- #163 Updated CI to Xcode 11.4.1
- #162 Disabled caching for CI SPM build
- #161 Replaced abstract `ConnectableClass` implementations
- #158 Updated doc comments
- #155, #157 Added ability to specify execution queue for effect handlers
- #154 Cleaned up APIs and implementations
- #153 Fixed and simplified logging adaptors
- #151 Simplified `MobiusLoop` implementation
- #150 Added `Connectable.map` helper for output transformation
- #149 Added `Mobius.beginnerLoop` helper and tests for the [Getting Started](https://github.com/spotify/Mobius.swift/wiki/Creating-a-loop) tutorial
- #148 Removed `MobiusTest` playground
- #147 Removed unnecessary generic arguments
- #146 Removed `initiate` from `Mobius.Builder`
- #145, #166 Removed deprecations introduced in 0.3.0