### PR TITLE
Diff effects in NextPredicate + tests

### DIFF
--- a/MobiusTest/Source/DebugDiff.swift
+++ b/MobiusTest/Source/DebugDiff.swift
@@ -45,9 +45,10 @@ func closestDiff<T, S: Sequence>(
     for value: T,
     in sequence: S,
     predicate: ([Difference]) -> Bool = { _ in true }
-) -> [Difference]? where S.Element == T {
-    var closest: [Difference]?
+) -> ([Difference]?, T?) where S.Element == T {
+    var closestDiff: [Difference]?
     var closestDistance = Int.max
+    var closestCandidate: T?
 
     let unwrappedValue = dumpUnwrapped(value).split(separator: "\n")[...]
 
@@ -57,12 +58,13 @@ func closestDiff<T, S: Sequence>(
 
         let distance = diffList.diffCount
         if distance < closestDistance && predicate(diffList) {
-            closest = diffList
+            closestDiff = diffList
             closestDistance = distance
+            closestCandidate = candidate
         }
     }
 
-    return closest
+    return (closestDiff, closestCandidate)
 }
 
 private extension Array where Element == Difference {

--- a/MobiusTest/Source/DebugDiff.swift
+++ b/MobiusTest/Source/DebugDiff.swift
@@ -17,15 +17,56 @@
 // specific language governing permissions and limitations
 // under the License.
 
+/// Diff two values by comparing their dumps by line by line.
+/// - Parameters:
+///   - lhs: Old value
+///   - rhs: New value
+/// - Returns: formatted diff string
 func dumpDiff<T>(_ lhs: T, _ rhs: T) -> String {
-    let lhsLines = dumpUnwrapped(lhs).split(separator: "\n")
-    let rhsLines = dumpUnwrapped(rhs).split(separator: "\n")
+    let lhsLines = dumpUnwrapped(lhs).lines
+    let rhsLines = dumpUnwrapped(rhs).lines
 
-    let diffList = diff(lhs: ArraySlice(lhsLines), rhs: ArraySlice(rhsLines))
+    let diffList = diff(lhs: lhsLines, rhs: rhsLines)
 
-    return diffList.flatMap { diff in
-        diff.string.map { "\(diff.prefix)\($0)" }
-    }.joined(separator: "\n")
+    return diffList.diffString
+}
+
+/// Diff two collections of items by picking the most similar value from `actual` for each of the items
+/// in `expected`. Matched values are diffed by comparing their dumps line by line.
+///
+/// “Similar” is defined as starting with at least one matching line – in the common case of enums with
+/// associated types, this means the same case. “Best match” is defined as the one with the smallest number of
+/// line differences.
+///
+/// - Parameters:
+///     - expected: Values that are expected to be found in `actual`
+///     - actual: Values that the `expected` values are diffed against
+///     - withUnmatchedActual: Whether the unmatched values from `actual` should be included in the diff
+/// - Returns: formatted diff string
+func dumpDiffFuzzy<T>(expected: [T], actual: [T], withUnmatchedActual: Bool) -> String where T: Equatable {
+    var actual = actual
+
+    let diffItem = { (item: T) -> [Difference] in
+        let closestResult = closestDiff(
+            for: item,
+            in: actual,
+            predicate: { $0.first?.isSame ?? false } // Only use diff if first line (typically case name) matches
+        )
+
+        if let diffList = closestResult.0,
+           let matchedCandidate = closestResult.1,
+           let matchedIndex = actual.firstIndex(of: matchedCandidate) {
+            actual.remove(at: matchedIndex)
+            return diffList
+        } else {
+            return [Difference.delete(dumpUnwrapped(item).lines)]
+        }
+    }
+
+    let expectedDifference = expected.flatMap(diffItem)
+    let unmatchedActualDifference = withUnmatchedActual ? actual.map { Difference.insert(dumpUnwrapped($0).lines) } : []
+
+    return (expectedDifference + unmatchedActualDifference).diffString
 }
 
 func dumpUnwrapped<T>(_ value: T) -> String {
@@ -50,10 +91,10 @@ func closestDiff<T, S: Sequence>(
     var closestDistance = Int.max
     var closestCandidate: T?
 
-    let unwrappedValue = dumpUnwrapped(value).split(separator: "\n")[...]
+    let unwrappedValue = dumpUnwrapped(value).lines
 
     sequence.forEach { candidate in
-        let unwrappedCandidate = dumpUnwrapped(candidate).split(separator: "\n")[...]
+        let unwrappedCandidate = dumpUnwrapped(candidate).lines
         let diffList = diff(lhs: unwrappedValue, rhs: unwrappedCandidate)
 
         let distance = diffList.diffCount
@@ -67,6 +108,12 @@ func closestDiff<T, S: Sequence>(
     return (closestDiff, closestCandidate)
 }
 
+private extension String {
+    var lines: ArraySlice<Substring> {
+        split(separator: "\n")[...]
+    }
+}
+
 private extension Array where Element == Difference {
     // Return the number of entries that are differences
     var diffCount: Int {
@@ -78,5 +125,12 @@ private extension Array where Element == Difference {
                 return count
             }
         }
+    }
+
+    var diffString: String {
+        flatMap { diff in
+            diff.string.map { "\(diff.prefix)\($0)" }
+        }
+        .joined(separator: "\n")
     }
 }

--- a/MobiusTest/Source/DebugDiff.swift
+++ b/MobiusTest/Source/DebugDiff.swift
@@ -129,7 +129,7 @@ private extension Array where Element == Difference {
 
     var diffString: String {
         flatMap { diff in
-            diff.string.map { "\(diff.prefix)\($0)" }
+            diff.string.map { "\(diff.prefix)   \($0)" }
         }
         .joined(separator: "\n")
     }

--- a/MobiusTest/Source/FirstMatchers.swift
+++ b/MobiusTest/Source/FirstMatchers.swift
@@ -93,10 +93,21 @@ public func hasEffects<Model, Effect: Equatable>(
     line: UInt = #line
 ) -> FirstPredicate<Model, Effect> {
     return { (first: First<Model, Effect>) in
-        if !expected.allSatisfy(first.effects.contains) {
-            return .failure(message: "Expected <\(first.effects)> to contain <\(expected)>", file: file, line: line)
-        }
-        return .success
+        let actual = first.effects
+        let unmatchedExpected = expected.filter { !actual.contains($0) }
+        guard !unmatchedExpected.isEmpty else { return .success }
+
+        // Find the effects that were produced but not expected - this is permitted, but there might be a close match
+        // there
+        let unmatchedActual = actual.filter { !expected.contains($0) }
+
+        return .failure(
+            message: "Missing \(countedEffects(unmatchedExpected, label: "expected")) (−), got (+)" +
+                " (with \(countedEffects(unmatchedActual, label: "actual")) unmatched):\n" +
+                dumpDiffFuzzy(expected: unmatchedExpected, actual: unmatchedActual, withUnmatchedActual: false),
+            file: file,
+            line: line
+        )
     }
 }
 
@@ -110,15 +121,25 @@ public func hasOnlyEffects<Model, Effect: Equatable>(
     line: UInt = #line
 ) -> FirstPredicate<Model, Effect> {
     return { (first: First<Model, Effect>) in
-        var unmatchedActual = first.effects
-        var unmatchedExpected = expected
-        zip(first.effects, expected).forEach {
-            _ = unmatchedActual.firstIndex(of: $1).map { unmatchedActual.remove(at: $0) }
-            _ = unmatchedExpected.firstIndex(of: $0).map { unmatchedExpected.remove(at: $0) }
+        let actual = first.effects
+        let unmatchedExpected = expected.filter { !actual.contains($0) }
+        let unmatchedActual = actual.filter { !expected.contains($0) }
+
+        var errorString = [
+            !unmatchedExpected.isEmpty ? "missing \(countedEffects(unmatchedExpected, label: "expected")) (−)" : nil,
+            !unmatchedActual.isEmpty ? "got \(countedEffects(unmatchedActual, label: "actual unmatched")) (+)" : nil
+        ].compactMap { $0 }.joined(separator: ", ")
+        errorString = errorString.prefix(1).capitalized + errorString.dropFirst()
+
+        if !errorString.isEmpty {
+            return .failure(
+                message: "\(errorString):\n" +
+                    dumpDiffFuzzy(expected: unmatchedExpected, actual: unmatchedActual, withUnmatchedActual: true),
+                file: file,
+                line: line
+            )
         }
-        if !unmatchedActual.isEmpty || !unmatchedExpected.isEmpty {
-            return .failure(message: "Expected <\(first.effects)> to contain only <\(expected)>", file: file, line: line)
-        }
+
         return .success
     }
 }
@@ -134,8 +155,18 @@ public func hasExactlyEffects<Model, Effect: Equatable>(
 ) -> FirstPredicate<Model, Effect> {
     return { (first: First<Model, Effect>) in
         if first.effects != expected {
-            return .failure(message: "Expected <\(first.effects)> to equal <\(expected)>", file: file, line: line)
+            return .failure(
+                message: "Different effects than expected (−), got (+): \n" +
+                    "\(dumpDiff(expected, first.effects))",
+                file: file,
+                line: line
+            )
         }
         return .success
     }
+}
+
+private func countedEffects<T>(_ effects: [T], label: String) -> String {
+    let count = effects.count
+    return count == 1 ? "1 \(label) effect" : "\(count) \(label) effects"
 }

--- a/MobiusTest/Source/FirstMatchers.swift
+++ b/MobiusTest/Source/FirstMatchers.swift
@@ -127,7 +127,7 @@ public func hasOnlyEffects<Model, Effect: Equatable>(
 
         var errorString = [
             !unmatchedExpected.isEmpty ? "missing \(countedEffects(unmatchedExpected, label: "expected")) (−)" : nil,
-            !unmatchedActual.isEmpty ? "got \(countedEffects(unmatchedActual, label: "actual unmatched")) (+)" : nil
+            !unmatchedActual.isEmpty ? "got \(countedEffects(unmatchedActual, label: "actual unmatched")) (+)" : nil,
         ].compactMap { $0 }.joined(separator: ", ")
         errorString = errorString.prefix(1).capitalized + errorString.dropFirst()
 

--- a/MobiusTest/Source/NextMatchers.swift
+++ b/MobiusTest/Source/NextMatchers.swift
@@ -171,8 +171,8 @@ public func hasEffects<Model, Effect: Equatable>(
         }
 
         return .failure(
-            message: "Missing \(countedEffects(unhandled, label: "expected"))," +
-                " with \(countedEffects(ignoredActual, label: "actual")) unmatched:" +
+            message: "Missing \(countedEffects(unhandled, label: "expected")) (-), got (+)" +
+                " (with \(countedEffects(ignoredActual, label: "actual")) unmatched):" +
                 unhandled.flatMap(formatEffect).joined(),
             file: file,
             line: line

--- a/MobiusTest/Source/NextMatchers.swift
+++ b/MobiusTest/Source/NextMatchers.swift
@@ -166,7 +166,7 @@ public func hasOnlyEffects<Model, Effect: Equatable>(
 
         var errorString = [
             !unmatchedExpected.isEmpty ? "missing \(countedEffects(unmatchedExpected, label: "expected")) (−)" : nil,
-            !unmatchedActual.isEmpty ? "got \(countedEffects(unmatchedActual, label: "actual unmatched")) (+)" : nil
+            !unmatchedActual.isEmpty ? "got \(countedEffects(unmatchedActual, label: "actual unmatched")) (+)" : nil,
         ].compactMap { $0 }.joined(separator: ", ")
         errorString = errorString.prefix(1).capitalized + errorString.dropFirst()
 

--- a/MobiusTest/Source/NextMatchers.swift
+++ b/MobiusTest/Source/NextMatchers.swift
@@ -164,8 +164,8 @@ public func hasEffects<Model, Effect: Equatable>(
                 }
             } else {
                 return dumpUnwrapped(effect).split(separator: "\n").map {
-                    // Four-space indent
-                    "\n    \($0)"
+                    // Three-space indent with "-" to represent missing effect
+                    "\n   −\($0)"
                 }
             }
         }

--- a/MobiusTest/Source/NextMatchers.swift
+++ b/MobiusTest/Source/NextMatchers.swift
@@ -160,15 +160,25 @@ public func hasOnlyEffects<Model, Effect: Equatable>(
     line: UInt = #line
 ) -> NextPredicate<Model, Effect> {
     return { (next: Next<Model, Effect>) in
-        var unmatchedActual = next.effects
-        var unmatchedExpected = expected
-        zip(next.effects, expected).forEach {
-            _ = unmatchedActual.firstIndex(of: $1).map { unmatchedActual.remove(at: $0) }
-            _ = unmatchedExpected.firstIndex(of: $0).map { unmatchedExpected.remove(at: $0) }
+        let actual = next.effects
+        let unmatchedExpected = expected.filter { !actual.contains($0) }
+        let unmatchedActual = actual.filter { !expected.contains($0) }
+
+        var errorString = [
+            !unmatchedExpected.isEmpty ? "missing \(countedEffects(unmatchedExpected, label: "expected")) (−)" : nil,
+            !unmatchedActual.isEmpty ? "got \(countedEffects(unmatchedActual, label: "actual unmatched")) (+)" : nil
+        ].compactMap { $0 }.joined(separator: ", ")
+        errorString = errorString.prefix(1).capitalized + errorString.dropFirst()
+
+        if !errorString.isEmpty {
+            return .failure(
+                message: "\(errorString):\n" +
+                    dumpDiffFuzzy(expected: unmatchedExpected, actual: unmatchedActual, withUnmatchedActual: true),
+                file: file,
+                line: line
+            )
         }
-        if !unmatchedActual.isEmpty || !unmatchedExpected.isEmpty {
-            return .failure(message: "Expected <\(next.effects)> to contain only <\(expected)>", file: file, line: line)
-        }
+
         return .success
     }
 }
@@ -184,7 +194,12 @@ public func hasExactlyEffects<Model, Effect: Equatable>(
 ) -> NextPredicate<Model, Effect> {
     return { (next: Next<Model, Effect>) in
         if next.effects != expected {
-            return .failure(message: "Expected <\(next.effects)> to equal <\(expected)>", file: file, line: line)
+            return .failure(
+                message: "Different effects than expected (−), got (+): \n" +
+                    "\(dumpDiff(expected, next.effects))",
+                file: file,
+                line: line
+            )
         }
         return .success
     }

--- a/MobiusTest/Source/SimpleDiff.swift
+++ b/MobiusTest/Source/SimpleDiff.swift
@@ -33,6 +33,13 @@ enum Difference: Equatable {
         }
     }
 
+    var isSame: Bool {
+        switch self {
+        case .same: return true
+        default: return false
+        }
+    }
+
     var prefix: String {
         switch self {
         case .insert:

--- a/MobiusTest/Source/SimpleDiff.swift
+++ b/MobiusTest/Source/SimpleDiff.swift
@@ -20,7 +20,7 @@
 //
 // 3. This notice may not be removed or altered from any source distribution.
 
-enum Difference {
+enum Difference: Equatable {
     case insert(ArraySlice<Substring>)
     case delete(ArraySlice<Substring>)
     case same(ArraySlice<Substring>)

--- a/MobiusTest/Test/DebugDiffTests.swift
+++ b/MobiusTest/Test/DebugDiffTests.swift
@@ -218,7 +218,7 @@ class DebugDiffTests: QuickSpec {
                 }
                 return false
             }
-            
+
             context("with no matching predicate") {
                 beforeEach {
                     diffOutput = closestDiff(for: 1, in: [2], predicate: { isSame($0.first) })

--- a/MobiusTest/Test/DebugDiffTests.swift
+++ b/MobiusTest/Test/DebugDiffTests.swift
@@ -31,6 +31,7 @@ enum TestEnum: Equatable {
     case first, second(String), third(Int)
 }
 
+// swiftlint:disable type_body_length
 class DebugDiffTests: QuickSpec {
     // swiftlint:disable function_body_length
     override func spec() {
@@ -254,7 +255,7 @@ class DebugDiffTests: QuickSpec {
                 }
             }
         }
-        
+
         describe("DumpDiffFuzzy") {
             var diff: String?
 

--- a/MobiusTest/Test/DebugDiffTests.swift
+++ b/MobiusTest/Test/DebugDiffTests.swift
@@ -220,18 +220,23 @@ class DebugDiffTests: QuickSpec {
             }
 
             context("with no matching predicate") {
+                var diffCandidate: Int?
+
                 beforeEach {
-                    diffOutput = closestDiff(for: 1, in: [2], predicate: { isSame($0.first) })
+                    (diffOutput, diffCandidate) = closestDiff(for: 1, in: [2], predicate: { isSame($0.first) })
                 }
 
                 it("returns no closest difference") {
                     expect(diffOutput).to(beNil())
+                    expect(diffCandidate).to(beNil())
                 }
             }
 
             context("with matching predicate") {
+                var diffCandidate: [String]?
+
                 beforeEach {
-                    diffOutput = closestDiff(for: ["g", "p", "u"], in: [["g", "c", "c"], ["g", "n", "u"]], predicate: {
+                    (diffOutput, diffCandidate) = closestDiff(for: ["g", "p", "u"], in: [["g", "c", "c"], ["g", "n", "u"]], predicate: {
                         isSame($0.first)
                     })
                 }
@@ -241,6 +246,7 @@ class DebugDiffTests: QuickSpec {
                     let rhs = dumpUnwrapped(["g", "n", "u"]).split(separator: "\n")[...]
                     let closestDiff = diff(lhs: lhs, rhs: rhs)
                     expect(diffOutput).to(equal(closestDiff))
+                    expect(diffCandidate).to(equal(["g", "n", "u"]))
                 }
             }
         }

--- a/MobiusTest/Test/DebugDiffTests.swift
+++ b/MobiusTest/Test/DebugDiffTests.swift
@@ -208,5 +208,41 @@ class DebugDiffTests: QuickSpec {
                 }
             }
         }
+
+        describe("ClosestDiff") {
+            var diffOutput: [Difference]?
+
+            func isSame(_ difference: Difference?) -> Bool {
+                if case .some(Difference.same) = difference {
+                    return true
+                }
+                return false
+            }
+            
+            context("with no matching predicate") {
+                beforeEach {
+                    diffOutput = closestDiff(for: 1, in: [2], predicate: { isSame($0.first) })
+                }
+
+                it("returns no closest difference") {
+                    expect(diffOutput).to(beNil())
+                }
+            }
+
+            context("with matching predicate") {
+                beforeEach {
+                    diffOutput = closestDiff(for: ["g", "p", "u"], in: [["g", "c", "c"], ["g", "n", "u"]], predicate: {
+                        isSame($0.first)
+                    })
+                }
+
+                it("returns closest difference") {
+                    let lhs = dumpUnwrapped(["g", "p", "u"]).split(separator: "\n")[...]
+                    let rhs = dumpUnwrapped(["g", "n", "u"]).split(separator: "\n")[...]
+                    let closestDiff = diff(lhs: lhs, rhs: rhs)
+                    expect(diffOutput).to(equal(closestDiff))
+                }
+            }
+        }
     }
 }

--- a/MobiusTest/Test/DebugDiffTests.swift
+++ b/MobiusTest/Test/DebugDiffTests.swift
@@ -47,10 +47,10 @@ class DebugDiffTests: QuickSpec {
                 it("returns correct diff output") {
                     let expectedDiff =
                     """
-                     ▿ MobiusTestTests.Person
-                       - name: "Joe"
-                       - age: 10
-                       - children: 0 elements
+                        ▿ MobiusTestTests.Person
+                          - name: "Joe"
+                          - age: 10
+                          - children: 0 elements
                     """
 
                     expect(diff).to(equal(expectedDiff))
@@ -67,10 +67,10 @@ class DebugDiffTests: QuickSpec {
                 it("returns correct diff output") {
                     let expectedDiff =
                     """
-                     ▿ MobiusTestTests.Person
-                       - name: "Joe"
-                       - age: 10
-                       - children: 0 elements
+                        ▿ MobiusTestTests.Person
+                          - name: "Joe"
+                          - age: 10
+                          - children: 0 elements
                     """
 
                     expect(diff).to(equal(expectedDiff))
@@ -87,11 +87,11 @@ class DebugDiffTests: QuickSpec {
                 it("returns correct diff output") {
                     let expectedDiff =
                     """
-                     ▿ MobiusTestTests.Person
-                       - name: "Joe"
-                    −  - age: 10
-                    +  - age: 11
-                       - children: 0 elements
+                        ▿ MobiusTestTests.Person
+                          - name: "Joe"
+                    −     - age: 10
+                    +     - age: 11
+                          - children: 0 elements
                     """
 
                     expect(diff).to(equal(expectedDiff))
@@ -108,11 +108,11 @@ class DebugDiffTests: QuickSpec {
                 it("returns correct diff output") {
                     let expectedDiff =
                     """
-                    −- nil
-                    +▿ MobiusTestTests.Person
-                    +  - name: "Joe"
-                    +  - age: 10
-                    +  - children: 0 elements
+                    −   - nil
+                    +   ▿ MobiusTestTests.Person
+                    +     - name: "Joe"
+                    +     - age: 10
+                    +     - children: 0 elements
                     """
 
                     expect(diff).to(equal(expectedDiff))
@@ -129,17 +129,17 @@ class DebugDiffTests: QuickSpec {
                 it("returns correct diff output") {
                     let expectedDiff =
                     """
-                     ▿ MobiusTestTests.Person
-                    −  - name: "Joe"
-                    −  - age: 10
-                    −  - children: 0 elements
-                    +  - name: "Mat"
-                    +  - age: 40
-                    +  ▿ children: 1 element
-                    +    ▿ MobiusTestTests.Person
-                    +      - name: "Pat"
-                    +      - age: 8
-                    +      - children: 0 elements
+                        ▿ MobiusTestTests.Person
+                    −     - name: "Joe"
+                    −     - age: 10
+                    −     - children: 0 elements
+                    +     - name: "Mat"
+                    +     - age: 40
+                    +     ▿ children: 1 element
+                    +       ▿ MobiusTestTests.Person
+                    +         - name: "Pat"
+                    +         - age: 8
+                    +         - children: 0 elements
                     """
 
                     expect(diff).to(endWith(expectedDiff))
@@ -162,22 +162,22 @@ class DebugDiffTests: QuickSpec {
                 it("returns correct diff output") {
                     let expectedDiff =
                     """
-                     ▿ MobiusTestTests.Person
-                       - name: "Joe"
-                       - age: 40
-                       ▿ children: 2 elements
-                         ▿ MobiusTestTests.Person
-                    −      - name: "Mat"
-                    −      - age: 10
-                    −      - children: 0 elements
-                    −    ▿ MobiusTestTests.Person
-                           - name: "Pat"
-                           - age: 8
-                           - children: 0 elements
-                    +    ▿ MobiusTestTests.Person
-                    +      - name: "Mat"
-                    +      - age: 10
-                    +      - children: 0 elements
+                        ▿ MobiusTestTests.Person
+                          - name: "Joe"
+                          - age: 40
+                          ▿ children: 2 elements
+                            ▿ MobiusTestTests.Person
+                    −         - name: "Mat"
+                    −         - age: 10
+                    −         - children: 0 elements
+                    −       ▿ MobiusTestTests.Person
+                              - name: "Pat"
+                              - age: 8
+                              - children: 0 elements
+                    +       ▿ MobiusTestTests.Person
+                    +         - name: "Mat"
+                    +         - age: 10
+                    +         - children: 0 elements
                     """
 
                     expect(diff).to(endWith(expectedDiff))
@@ -195,17 +195,17 @@ class DebugDiffTests: QuickSpec {
                 it("returns correct diff output") {
                     let expectedDiff =
                     """
-                     ▿ MobiusTestTests.Person
-                    −  - name: "Joe"
-                    −  - age: 10
-                    −  - children: 0 elements
-                    +  - name: "Mat"
-                    +  - age: 40
-                    +  ▿ children: 1 element
-                    +    ▿ MobiusTestTests.Person
-                    +      - name: "Pat"
-                    +      - age: 8
-                    +      - children: 0 elements
+                        ▿ MobiusTestTests.Person
+                    −     - name: "Joe"
+                    −     - age: 10
+                    −     - children: 0 elements
+                    +     - name: "Mat"
+                    +     - age: 40
+                    +     ▿ children: 1 element
+                    +       ▿ MobiusTestTests.Person
+                    +         - name: "Pat"
+                    +         - age: 8
+                    +         - children: 0 elements
                     """
 
                     expect(diff).to(endWith(expectedDiff))
@@ -268,10 +268,10 @@ class DebugDiffTests: QuickSpec {
                 it("prints diff of the associated values") {
                     let expectedDiff =
                     """
-                     - MobiusTestTests.TestEnum.first
-                     ▿ MobiusTestTests.TestEnum.second
-                    −  - second: "a"
-                    +  - second: "b"
+                        - MobiusTestTests.TestEnum.first
+                        ▿ MobiusTestTests.TestEnum.second
+                    −     - second: "a"
+                    +     - second: "b"
                     """
 
                     expect(diff).to(equal(expectedDiff))
@@ -288,9 +288,9 @@ class DebugDiffTests: QuickSpec {
                 it("prints unmatched expected effect as deleted") {
                     let expectedDiff =
                     """
-                     - MobiusTestTests.TestEnum.first
-                    −▿ MobiusTestTests.TestEnum.second
-                    −  - second: "a"
+                        - MobiusTestTests.TestEnum.first
+                    −   ▿ MobiusTestTests.TestEnum.second
+                    −     - second: "a"
                     """
 
                     expect(diff).to(equal(expectedDiff))
@@ -307,11 +307,11 @@ class DebugDiffTests: QuickSpec {
                 it("prints unmatched expected effect as deleted and unmatched actual effect as inserted") {
                     let expectedDiff =
                     """
-                     - MobiusTestTests.TestEnum.first
-                    −▿ MobiusTestTests.TestEnum.second
-                    −  - second: "a"
-                    +▿ MobiusTestTests.TestEnum.third
-                    +  - third: 0
+                        - MobiusTestTests.TestEnum.first
+                    −   ▿ MobiusTestTests.TestEnum.second
+                    −     - second: "a"
+                    +   ▿ MobiusTestTests.TestEnum.third
+                    +     - third: 0
                     """
 
                     expect(diff).to(equal(expectedDiff))

--- a/MobiusTest/Test/FirstMatchersTests.swift
+++ b/MobiusTest/Test/FirstMatchersTests.swift
@@ -159,7 +159,9 @@ class FirstMatchersTests: QuickSpec {
                     }
 
                     it("should fail with an appropriate error message") {
-                        expect(result?.failureMessage).to(equal("Expected <\(actualEffects)> to contain <\(expectedEffects)>"))
+                        let expectedError = "Missing 1 expected effect (−), got (+) (with 1 actual effect unmatched):\n"
+                            + dumpDiffFuzzy(expected: expectedEffects, actual: actualEffects, withUnmatchedActual: false)
+                        expect(result?.failureMessage).to(equal(expectedError))
                     }
                 }
             }
@@ -205,7 +207,9 @@ class FirstMatchersTests: QuickSpec {
                     }
 
                     it("should fail with an appropriate error message") {
-                        expect(result?.failureMessage).to(equal("Expected <\(actualEffects)> to contain only <\(expectedEffects)>"))
+                        let expectedError = "Got 1 actual unmatched effect (+):\n" +
+                            dumpDiffFuzzy(expected: [], actual: [1], withUnmatchedActual: true)
+                        expect(result?.failureMessage).to(equal(expectedError))
                     }
                 }
 
@@ -220,7 +224,9 @@ class FirstMatchersTests: QuickSpec {
                     }
 
                     it("should fail with an appropriate error message") {
-                        expect(result?.failureMessage).to(equal("Expected <\(actualEffects)> to contain only <\(expectedEffects)>"))
+                        let expectedError = "Missing 1 expected effect (−), got 1 actual unmatched effect (+):\n" +
+                            dumpDiffFuzzy(expected: expectedEffects, actual: actualEffects, withUnmatchedActual: true)
+                        expect(result?.failureMessage).to(equal(expectedError))
                     }
                 }
             }
@@ -251,7 +257,8 @@ class FirstMatchersTests: QuickSpec {
                     }
 
                     it("should fail with an appropriate error message") {
-                        expect(result?.failureMessage).to(equal("Expected <\(actualEffects)> to equal <\(expectedEffects)>"))
+                        let expectedError = "Different effects than expected (−), got (+): \n\(dumpDiff(expectedEffects, actualEffects))"
+                        expect(result?.failureMessage).to(equal(expectedError))
                     }
                 }
 
@@ -266,7 +273,8 @@ class FirstMatchersTests: QuickSpec {
                     }
 
                     it("should fail with an appropriate error message") {
-                        expect(result?.failureMessage).to(equal("Expected <\(actualEffects)> to equal <\(expectedEffects)>"))
+                        let expectedError = "Different effects than expected (−), got (+): \n\(dumpDiff(expectedEffects, actualEffects))"
+                        expect(result?.failureMessage).to(equal(expectedError))
                     }
                 }
 
@@ -281,7 +289,8 @@ class FirstMatchersTests: QuickSpec {
                     }
 
                     it("should fail with an appropriate error message") {
-                        expect(result?.failureMessage).to(equal("Expected <\(actualEffects)> to equal <\(expectedEffects)>"))
+                        let expectedError = "Different effects than expected (−), got (+): \n\(dumpDiff(expectedEffects, actualEffects))"
+                        expect(result?.failureMessage).to(equal(expectedError))
                     }
                 }
             }

--- a/MobiusTest/Test/NextMatchersTests.swift
+++ b/MobiusTest/Test/NextMatchersTests.swift
@@ -266,11 +266,11 @@ class XCTestNextMatchersTests: QuickSpec {
                 var sut: NextPredicate<String, Int>!
 
                 func formatDump(_ text: String) -> String {
-                    text.split(separator: "\n").map { "\n   −\($0)" }.joined()
+                    text.split(separator: "\n").map { "\n−\($0)" }.joined()
                 }
 
                 func formatDiff(_ value: Difference) -> [String] {
-                    value.string.map { "\n   \(value.prefix)\($0)" }
+                    value.string.map { "\n\(value.prefix)\($0)" }
                 }
 
                 beforeEach {

--- a/MobiusTest/Test/NextMatchersTests.swift
+++ b/MobiusTest/Test/NextMatchersTests.swift
@@ -269,6 +269,10 @@ class XCTestNextMatchersTests: QuickSpec {
                     text.split(separator: "\n").map { "\n   −\($0)" }.joined()
                 }
 
+                func formatDiff(_ value: Difference) -> [String] {
+                    value.string.map { "\n   \(value.prefix)\($0)" }
+                }
+
                 beforeEach {
                     sut = hasEffects(expected)
                 }
@@ -363,10 +367,6 @@ class XCTestNextMatchersTests: QuickSpec {
                     let expected = [[1, 2, 3], [1, 2, 5], [1, 2, 6]]
                     var sut: NextPredicate<String, [Int]>!
 
-                    func formatDiff(_ value: Difference) -> [String] {
-                        value.string.map { "\n   \(value.prefix)\($0)" }
-                    }
-
                     beforeEach {
                         let next = Next<String, [Int]>.dispatchEffects(actual)
                         sut = hasEffects(expected)
@@ -374,15 +374,10 @@ class XCTestNextMatchersTests: QuickSpec {
                     }
 
                     it("should fail with an appropriate error message") {
-                        // Ignore [1, 2, 3] that has been successfully matched
-                        let actualUnmatched = [[1, 2, 4]]
-                        let expectedUnmatched = [[1, 2, 5], [1, 2, 6]]
-
-                        let diffString = expectedUnmatched.compactMap {
-                            closestDiff(for: $0, in: actualUnmatched)?
-                                .flatMap { formatDiff($0) }
-                                .joined()
-                        }.joined()
+                        let diffString = (closestDiff(for: [1, 2, 5], in: [[1, 2, 4]]).0 ?? [])
+                            .flatMap { formatDiff($0) }
+                            .joined()
+                            .appending(formatDump(dumpUnwrapped([1, 2, 6])))
 
                         let expectedError = "Missing 2 expected effects (-), got (+) (with 1 actual effect unmatched):"
                             + diffString

--- a/MobiusTest/Test/NextMatchersTests.swift
+++ b/MobiusTest/Test/NextMatchersTests.swift
@@ -266,7 +266,7 @@ class XCTestNextMatchersTests: QuickSpec {
                 var sut: NextPredicate<String, Int>!
 
                 func formatDump(_ text: String) -> String {
-                    text.split(separator: "\n").map { "\n    \($0)" }.joined()
+                    text.split(separator: "\n").map { "\n   −\($0)" }.joined()
                 }
 
                 beforeEach {

--- a/MobiusTest/Test/NextMatchersTests.swift
+++ b/MobiusTest/Test/NextMatchersTests.swift
@@ -265,14 +265,6 @@ class XCTestNextMatchersTests: QuickSpec {
                 let expected = [1, 2, 3, 4]
                 var sut: NextPredicate<String, Int>!
 
-                func formatDump(_ text: String) -> String {
-                    text.split(separator: "\n").map { "\n−\($0)" }.joined()
-                }
-
-                func formatDiff(_ value: Difference) -> [String] {
-                    value.string.map { "\n\(value.prefix)\($0)" }
-                }
-
                 beforeEach {
                     sut = hasEffects(expected)
                 }
@@ -325,9 +317,8 @@ class XCTestNextMatchersTests: QuickSpec {
                     }
 
                     it("should fail with an appropriate error message") {
-                        let diff = formatDump(dumpUnwrapped(expected.first))
-                        let expectedError = "Missing 1 expected effect (-), got (+) (with 1 actual effect unmatched):"
-                            + diff
+                        let expectedError = "Missing 1 expected effect (−), got (+) (with 1 actual effect unmatched):\n"
+                            + dumpDiffFuzzy(expected: expected, actual: actual, withUnmatchedActual: false)
                         expect(result.failureMessage).to(equal(expectedError))
                     }
                 }
@@ -354,9 +345,8 @@ class XCTestNextMatchersTests: QuickSpec {
                         }
 
                         it("should fail with an appropriate error message") {
-                            let diff = formatDump(dumpUnwrapped(expected.first))
-                            let expectedError = "Missing 1 expected effect (-), got (+) (with 0 actual effects unmatched):"
-                                + diff
+                            let expectedError = "Missing 1 expected effect (−), got (+) (with 0 actual effects unmatched):\n"
+                                + dumpDiffFuzzy(expected: expected, actual: [], withUnmatchedActual: false)
                             expect(result.failureMessage).to(equal(expectedError))
                         }
                     }
@@ -374,13 +364,8 @@ class XCTestNextMatchersTests: QuickSpec {
                     }
 
                     it("should fail with an appropriate error message") {
-                        let diffString = (closestDiff(for: [1, 2, 5], in: [[1, 2, 4]]).0 ?? [])
-                            .flatMap { formatDiff($0) }
-                            .joined()
-                            .appending(formatDump(dumpUnwrapped([1, 2, 6])))
-
-                        let expectedError = "Missing 2 expected effects (-), got (+) (with 1 actual effect unmatched):"
-                            + diffString
+                        let expectedError = "Missing 2 expected effects (−), got (+) (with 1 actual effect unmatched):\n"
+                            + dumpDiffFuzzy(expected: [[1, 2, 5], [1, 2, 6]], actual: [[1, 2, 4]], withUnmatchedActual: false)
                         expect(result.failureMessage).to(equal(expectedError))
                     }
                 }
@@ -429,7 +414,9 @@ class XCTestNextMatchersTests: QuickSpec {
                     }
 
                     it("should fail with an appropriate error message") {
-                        expect(result.failureMessage).to(equal("Expected <\(actual)> to contain only <\(expected)>"))
+                        let expectedError = "Got 2 actual unmatched effects (+):\n" +
+                            dumpDiffFuzzy(expected: [], actual: [5, 0], withUnmatchedActual: true)
+                        expect(result.failureMessage).to(equal(expectedError))
                     }
                 }
 
@@ -444,7 +431,9 @@ class XCTestNextMatchersTests: QuickSpec {
                     }
 
                     it("should fail with an appropriate error message") {
-                        expect(result.failureMessage).to(equal("Expected <\(actual)> to contain only <\(expected)>"))
+                        let expectedError = "Missing 1 expected effect (−), got 1 actual unmatched effect (+):\n" +
+                            dumpDiffFuzzy(expected: expected, actual: actual, withUnmatchedActual: true)
+                        expect(result.failureMessage).to(equal(expectedError))
                     }
                 }
 
@@ -471,7 +460,9 @@ class XCTestNextMatchersTests: QuickSpec {
                         }
 
                         it("should fail with an appropriate error message") {
-                            expect(result.failureMessage).to(equal("Expected <[]> to contain only <\(expected)>"))
+                            let expectedError = "Missing 1 expected effect (−):\n" +
+                                dumpDiffFuzzy(expected: expected, actual: [], withUnmatchedActual: true)
+                            expect(result.failureMessage).to(equal(expectedError))
                         }
                     }
                 }
@@ -506,7 +497,8 @@ class XCTestNextMatchersTests: QuickSpec {
                         }
 
                         it("should fail with an appropriate error message") {
-                            expect(result.failureMessage).to(equal("Expected <\(actual)> to equal <\(expected)>"))
+                            let expectedError = "Different effects than expected (−), got (+): \n\(dumpDiff(expected, actual))"
+                            expect(result.failureMessage).to(equal(expectedError))
                         }
                     }
                 }
@@ -520,7 +512,8 @@ class XCTestNextMatchersTests: QuickSpec {
                     }
 
                     it("should fail with an appropriate error message") {
-                        expect(result.failureMessage).to(equal("Expected <\(actual)> to equal <\(expected)>"))
+                        let expectedError = "Different effects than expected (−), got (+): \n\(dumpDiff(expected, actual))"
+                        expect(result.failureMessage).to(equal(expectedError))
                     }
                 }
 
@@ -535,7 +528,8 @@ class XCTestNextMatchersTests: QuickSpec {
                     }
 
                     it("should fail with an appropriate error message") {
-                        expect(result.failureMessage).to(equal("Expected <\(actual)> to equal <\(expected)>"))
+                        let expectedError = "Different effects than expected (−), got (+): \n\(dumpDiff(expected, actual))"
+                        expect(result.failureMessage).to(equal(expectedError))
                     }
                 }
 
@@ -562,7 +556,8 @@ class XCTestNextMatchersTests: QuickSpec {
                         }
 
                         it("should fail with an appropriate error message") {
-                            expect(result.failureMessage).to(equal("Expected <[]> to equal <\(expected)>"))
+                            let expectedError = "Different effects than expected (−), got (+): \n\(dumpDiff(expected, []))"
+                            expect(result.failureMessage).to(equal(expectedError))
                         }
                     }
                 }


### PR DESCRIPTION
This PR extends existing @JensAyton's draft PR #173 with tests as an aim to productionize it. The intention was to make as minimal changes on top of #173 as possible, but I ended up making two:
- Modified the error message with diff signs explanation, which helps to interpret the error and brings the message closer to the existing one in `hasModel` (62651c7ede15462d00fb0666b3691fcee047f447) 
- Prefixed dump of a missing effect with no closest match with `-` sign to indicate that the effect is missing (f79fd3ba2850887dc1fbf72b1994570c913e7583)

I also discovered one limitation of the implementation that I did not fix (yet?): 

- If one unmatched effect has multiple possible candidates in the expected effects, the diff against the unmatched effect is used on all those candidates repeatedly (visible also on the screenshot below). This does not correspond to how diffing typically works as the chunk shouldn't be used repeatedly.

----------

<img width="852" alt="obrazek" src="https://user-images.githubusercontent.com/1540564/116793830-756a9600-aac9-11eb-9586-2f573475445f.png">
