### PR TITLE
Add more specific effect matchers

### DIFF
--- a/MobiusNimble/Source/NimbleFirstMatchers.swift
+++ b/MobiusNimble/Source/NimbleFirstMatchers.swift
@@ -97,3 +97,54 @@ public func haveEffects<Model, Effect: Equatable>(_ effects: [Effect]) -> Nimble
         )
     })
 }
+
+/// Returns a `Predicate` that matches if only the supplied effects are present in the supplied `First`, in any order.
+///
+/// - Parameter effects: the effects to match (possibly empty)
+/// - Returns: a `Predicate` that matches `First` instances that include all the supplied effects
+public func haveOnlyEffects<Model, Effect: Equatable>(_ effects: [Effect]) -> Nimble.Predicate<First<Model, Effect>> {
+    return Nimble.Predicate<First<Model, Effect>>.define(matcher: { actualExpression -> Nimble.PredicateResult in
+        guard let first = try actualExpression.evaluate() else {
+            return unexpectedNilParameterPredicateResult
+        }
+
+        var unmatchedActual = first.effects
+        var unmatchedExpected = effects
+        zip(first.effects, effects).forEach {
+            _ = unmatchedActual.firstIndex(of: $1).map { unmatchedActual.remove(at: $0) }
+            _ = unmatchedExpected.firstIndex(of: $0).map { unmatchedExpected.remove(at: $0) }
+        }
+
+        let expectedDescription = String(describing: effects)
+        let actualDescription = String(describing: first.effects)
+        return PredicateResult(
+            bool: unmatchedActual.isEmpty && unmatchedExpected.isEmpty,
+            message: .expectedCustomValueTo(
+                "contain only <\(expectedDescription)>",
+                actual: "<\(actualDescription)> (order doesn't matter)"
+            )
+        )
+    })
+}
+
+/// Returns a `Predicate` that matches if the supplied effects are equal to the supplied `First`.
+///
+/// - Parameter effects: the effects to match (possibly empty)
+/// - Returns: a `Predicate` that matches `First` instances that include all the supplied effects
+public func haveExactEffects<Model, Effect: Equatable>(_ effects: [Effect]) -> Nimble.Predicate<First<Model, Effect>> {
+    return Nimble.Predicate<First<Model, Effect>>.define(matcher: { actualExpression -> Nimble.PredicateResult in
+        guard let first = try actualExpression.evaluate() else {
+            return unexpectedNilParameterPredicateResult
+        }
+
+        let expectedDescription = String(describing: effects)
+        let actualDescription = String(describing: first.effects)
+        return PredicateResult(
+            bool: effects == first.effects,
+            message: .expectedCustomValueTo(
+                "equal <\(expectedDescription)>",
+                actual: "<\(actualDescription)>"
+            )
+        )
+    })
+}

--- a/MobiusNimble/Source/NimbleNextMatchers.swift
+++ b/MobiusNimble/Source/NimbleNextMatchers.swift
@@ -127,3 +127,54 @@ public func haveEffects<Model, Effect: Equatable>(_ expected: [Effect]) -> Nimbl
         )
     })
 }
+
+/// Constructs a matcher that matches if only the supplied effects are present in the supplied `Next`, in any order.
+///
+/// - Parameter expected: the effects to match (possibly empty)
+/// - Returns: a `Predicate` that matches `Next` instances that include all the supplied effects
+public func haveOnlyEffects<Model, Effect: Equatable>(_ expected: [Effect]) -> Nimble.Predicate<Next<Model, Effect>> {
+    return Nimble.Predicate<Next<Model, Effect>>.define(matcher: { actualExpression in
+        guard let next = try actualExpression.evaluate() else {
+            return unexpectedNilParameterPredicate
+        }
+
+        var unmatchedActual = next.effects
+        var unmatchedExpected = expected
+        zip(next.effects, expected).forEach {
+            _ = unmatchedActual.firstIndex(of: $1).map { unmatchedActual.remove(at: $0) }
+            _ = unmatchedExpected.firstIndex(of: $0).map { unmatchedExpected.remove(at: $0) }
+        }
+
+        let expectedDescription = String(describing: expected)
+        let actualDescription = String(describing: next.effects)
+        return Nimble.PredicateResult(
+            bool: unmatchedActual.isEmpty && unmatchedExpected.isEmpty,
+            message: .expectedCustomValueTo(
+                "contain only <\(expectedDescription)>",
+                actual: "<\(actualDescription)> (order doesn't matter)"
+            )
+        )
+    })
+}
+
+/// Constructs a matcher that matches if the supplied effects are equal to the supplied `Next`.
+///
+/// - Parameter expected: the effects to match (possibly empty)
+/// - Returns: a `Predicate` that matches `Next` instances that include all the supplied effects
+public func haveExactEffects<Model, Effect: Equatable>(_ expected: [Effect]) -> Nimble.Predicate<Next<Model, Effect>> {
+    return Nimble.Predicate<Next<Model, Effect>>.define(matcher: { actualExpression in
+        guard let next = try actualExpression.evaluate() else {
+            return unexpectedNilParameterPredicate
+        }
+
+        let expectedDescription = String(describing: expected)
+        let actualDescription = String(describing: next.effects)
+        return Nimble.PredicateResult(
+            bool: expected == next.effects,
+            message: .expectedCustomValueTo(
+                "equal <\(expectedDescription)>",
+                actual: "<\(actualDescription)>"
+            )
+        )
+    })
+}

--- a/MobiusNimble/Test/NimbleFirstMatchersTests.swift
+++ b/MobiusNimble/Test/NimbleFirstMatchersTests.swift
@@ -218,6 +218,150 @@ class NimbleFirstMatchersTests: QuickSpec {
                     }
                 }
             }
+
+            context("when creating a matcher to check that a First has only specific effects") {
+                context("when the First has those effects") {
+                    let expectedEffects = [4, 7, 0]
+
+                    beforeEach {
+                        let first = First<Int, Int>(model: 3, effects: expectedEffects)
+                        expect(first).to(haveOnlyEffects(expectedEffects))
+                    }
+
+                    it("should match") {
+                        assertionHandler.assertExpectationSucceeded()
+                    }
+                }
+
+                context("when the First has those effects out of order") {
+                    let expectedEffects = [4, 7, 0]
+                    let actualEffects = [0, 7, 4]
+
+                    beforeEach {
+                        let first = First<Int, Int>(model: 3, effects: actualEffects)
+                        expect(first).to(haveOnlyEffects(expectedEffects))
+                    }
+
+                    it("should match") {
+                        assertionHandler.assertExpectationSucceeded()
+                    }
+                }
+
+                context("when the First contains the expected effects and a few more") {
+                    let expectedEffects = [4, 7, 0]
+                    let actualEffects = [1, 4, 7, 0]
+
+                    beforeEach {
+                        let first = First<Int, Int>(model: 3, effects: actualEffects)
+                        expect(first).to(haveOnlyEffects(expectedEffects))
+                    }
+
+                    it("should produce an appropriate error message") {
+                        assertionHandler.assertLastErrorMessageContains("contain only <\(expectedEffects)>, got <\(actualEffects)> (order doesn't matter)")
+                    }
+                }
+
+                context("when the First does not contain all the expected effects") {
+                    let expectedEffects = [4, 1]
+                    let actualEffects = [1]
+
+                    beforeEach {
+                        let first = First<Int, Int>(model: 3, effects: actualEffects)
+                        expect(first).to(haveOnlyEffects(expectedEffects))
+                    }
+
+                    it("should produce an appropriate error message") {
+                        assertionHandler.assertLastErrorMessageContains("contain only <\(expectedEffects)>, got <\(actualEffects)> (order doesn't matter)")
+                    }
+                }
+
+                context("when matching nil") {
+                    beforeEach {
+                        let first: First<Int, Int>? = nil
+                        expect(first).to(haveOnlyEffects([1]))
+                    }
+
+                    it("should not match") {
+                        assertionHandler.assertExpectationFailed()
+                    }
+
+                    it("should produce an appropriate error message") {
+                        assertionHandler.assertLastErrorMessageContains(nextBeingNilNotAllowed)
+                    }
+                }
+            }
+
+            context("when creating a matcher to check that a First has exact effects") {
+                context("when the First has those effects") {
+                    let expectedEffects = [4, 7, 0]
+
+                    beforeEach {
+                        let first = First<Int, Int>(model: 3, effects: expectedEffects)
+                        expect(first).to(haveExactEffects(expectedEffects))
+                    }
+
+                    it("should match") {
+                        assertionHandler.assertExpectationSucceeded()
+                    }
+                }
+
+                context("when the First has those effects out of order") {
+                    let expectedEffects = [4, 7, 0]
+                    let actualEffects = [0, 7, 4]
+
+                    beforeEach {
+                        let first = First<Int, Int>(model: 3, effects: actualEffects)
+                        expect(first).to(haveExactEffects(expectedEffects))
+                    }
+
+                    it("should produce an appropriate error message") {
+                        assertionHandler.assertLastErrorMessageContains("equal <\(expectedEffects)>, got <\(actualEffects)>")
+                    }
+                }
+
+                context("when the First contains the expected effects and a few more") {
+                    let expectedEffects = [4, 7, 0]
+                    let actualEffects = [1, 4, 7, 0]
+
+                    beforeEach {
+                        let first = First<Int, Int>(model: 3, effects: actualEffects)
+                        expect(first).to(haveExactEffects(expectedEffects))
+                    }
+
+                    it("should produce an appropriate error message") {
+                        assertionHandler.assertLastErrorMessageContains("equal <\(expectedEffects)>, got <\(actualEffects)>")
+                    }
+                }
+
+                context("when the First does not contain all the expected effects") {
+                    let expectedEffects = [4, 1]
+                    let actualEffects = [1]
+
+                    beforeEach {
+                        let first = First<Int, Int>(model: 3, effects: actualEffects)
+                        expect(first).to(haveExactEffects(expectedEffects))
+                    }
+
+                    it("should produce an appropriate error message") {
+                        assertionHandler.assertLastErrorMessageContains("equal <\(expectedEffects)>, got <\(actualEffects)>")
+                    }
+                }
+
+                context("when matching nil") {
+                    beforeEach {
+                        let first: First<Int, Int>? = nil
+                        expect(first).to(haveExactEffects([1]))
+                    }
+
+                    it("should not match") {
+                        assertionHandler.assertExpectationFailed()
+                    }
+
+                    it("should produce an appropriate error message") {
+                        assertionHandler.assertLastErrorMessageContains(nextBeingNilNotAllowed)
+                    }
+                }
+            }
         }
     }
 }

--- a/MobiusNimble/Test/NimbleNextMatchersTests.swift
+++ b/MobiusNimble/Test/NimbleNextMatchersTests.swift
@@ -425,6 +425,184 @@ class NimbleNextMatchersTests: QuickSpec {
                     }
                 }
             }
+
+            context("when creating a matcher verifying that a Next has only specific effects") {
+                let expected = [1, 2, 3]
+
+                context("when the effects are the same") {
+                    beforeEach {
+                        let next = Next<String, Int>.dispatchEffects(expected)
+                        expect(next).to(haveOnlyEffects(expected))
+                    }
+
+                    it("should match") {
+                        assertionHandler.assertExpectationSucceeded()
+                    }
+                }
+
+                context("when the effects are the same in different order") {
+                    let actual = [3, 2, 1]
+
+                    beforeEach {
+                        let next = Next<String, Int>.dispatchEffects(actual)
+                        expect(next).to(haveOnlyEffects(expected))
+                    }
+
+                    it("should match") {
+                        assertionHandler.assertExpectationSucceeded()
+                    }
+                }
+
+                context("when the Next contains the expected effects and a few more") {
+                    let actual = [1, 2, 3, 4, 5, 0]
+
+                    beforeEach {
+                        let next = Next<String, Int>.dispatchEffects(actual)
+                        expect(next).to(haveOnlyEffects(expected))
+                    }
+
+                    it("should produce an appropriate error message") {
+                        assertionHandler.assertLastErrorMessageContains("contain only <\(expected)>, got <\(actual)>")
+                    }
+                }
+
+                context("when the Next does not contain one or more of the expected effects") {
+                    let actual = [1, 2]
+
+                    beforeEach {
+                        let next = Next<String, Int>.dispatchEffects(actual)
+                        expect(next).to(haveOnlyEffects(expected))
+                    }
+
+                    it("should produce an appropriate error message") {
+                        assertionHandler.assertLastErrorMessageContains("contain only <\(expected)>, got <\(actual)>")
+                    }
+                }
+
+                context("when there are no effects") {
+                    context("when not expecting effects") {
+                        beforeEach {
+                            let next = Next<String, Int>.noChange
+                            expect(next).to(haveOnlyEffects([]))
+                        }
+
+                        it("should match") {
+                            assertionHandler.assertExpectationSucceeded()
+                        }
+                    }
+
+                    context("when expecting effects") {
+                        beforeEach {
+                            let next = Next<String, Int>.noChange
+                            expect(next).to(haveOnlyEffects(expected))
+                        }
+
+                        it("should produce an appropriate error message") {
+                            assertionHandler.assertLastErrorMessageContains("contain only <\(expected)>, got <[]>")
+                        }
+                    }
+                }
+
+                context("when matching nil") {
+                    beforeEach {
+                        let next: Next<String, Int>? = nil
+                        expect(next).to(haveOnlyEffects(expected))
+                    }
+
+                    it("should produce an appropriate error message") {
+                        assertionHandler.assertLastErrorMessageContains(haveNonNilNext)
+                    }
+                }
+            }
+
+            context("when creating a matcher verifying that a Next has exact effects") {
+                let expected = [1, 2, 3]
+
+                context("when the effects are the same") {
+                    beforeEach {
+                        let next = Next<String, Int>.dispatchEffects(expected)
+                        expect(next).to(haveExactEffects(expected))
+                    }
+
+                    it("should match") {
+                        assertionHandler.assertExpectationSucceeded()
+                    }
+                }
+
+                context("when the effects are the same in different order") {
+                    let actual = [3, 2, 1]
+
+                    beforeEach {
+                        let next = Next<String, Int>.dispatchEffects(actual)
+                        expect(next).to(haveExactEffects(expected))
+                    }
+
+                    it("should produce an appropriate error message") {
+                        assertionHandler.assertLastErrorMessageContains("equal <\(expected)>, got <\(actual)>")
+                    }
+                }
+
+                context("when the Next contains the expected effects and a few more") {
+                    let actual = [1, 2, 3, 4, 5, 0]
+
+                    beforeEach {
+                        let next = Next<String, Int>.dispatchEffects(actual)
+                        expect(next).to(haveExactEffects(expected))
+                    }
+
+                    it("should produce an appropriate error message") {
+                        assertionHandler.assertLastErrorMessageContains("equal <\(expected)>, got <\(actual)>")
+                    }
+                }
+
+                context("when the Next does not contain one or more of the expected effects") {
+                    let actual = [1, 2]
+
+                    beforeEach {
+                        let next = Next<String, Int>.dispatchEffects(actual)
+                        expect(next).to(haveExactEffects(expected))
+                    }
+
+                    it("should produce an appropriate error message") {
+                        assertionHandler.assertLastErrorMessageContains("equal <\(expected)>, got <\(actual)>")
+                    }
+                }
+
+                context("when there are no effects") {
+                    context("when not expecting effects") {
+                        beforeEach {
+                            let next = Next<String, Int>.noChange
+                            expect(next).to(haveExactEffects([]))
+                        }
+
+                        it("should match") {
+                            assertionHandler.assertExpectationSucceeded()
+                        }
+                    }
+
+                    context("when expecting effects") {
+                        beforeEach {
+                            let next = Next<String, Int>.noChange
+                            expect(next).to(haveExactEffects(expected))
+                        }
+
+                        it("should produce an appropriate error message") {
+                            assertionHandler.assertLastErrorMessageContains("equal <\(expected)>, got <[]>")
+                        }
+                    }
+                }
+
+                context("when matching nil") {
+                    beforeEach {
+                        let next: Next<String, Int>? = nil
+                        expect(next).to(haveExactEffects(expected))
+                    }
+
+                    it("should produce an appropriate error message") {
+                        assertionHandler.assertLastErrorMessageContains(haveNonNilNext)
+                    }
+                }
+            }
         }
     }
 }

--- a/MobiusTest/Source/NextMatchers.swift
+++ b/MobiusTest/Source/NextMatchers.swift
@@ -132,9 +132,48 @@ public func hasEffects<Model, Effect: Equatable>(
     line: UInt = #line
 ) -> NextPredicate<Model, Effect> {
     return { (next: Next<Model, Effect>) in
-        let actual = next.effects
-        if !expected.allSatisfy(actual.contains) {
-            return .failure(message: "Expected <\(actual)> to contain <\(expected)>", file: file, line: line)
+        if !expected.allSatisfy(next.effects.contains) {
+            return .failure(message: "Expected <\(next.effects)> to contain <\(expected)>", file: file, line: line)
+        }
+        return .success
+    }
+}
+
+/// Constructs a matcher that matches if only the supplied effects are present in the supplied `Next`, in any order.
+///
+/// - Parameter expected: the effects to match (possibly empty)
+/// - Returns: a `Predicate` that matches `Next` instances that include all the supplied effects
+public func hasOnlyEffects<Model, Effect: Equatable>(
+    _ expected: [Effect],
+    file: StaticString = #file,
+    line: UInt = #line
+) -> NextPredicate<Model, Effect> {
+    return { (next: Next<Model, Effect>) in
+        var unmatchedActual = next.effects
+        var unmatchedExpected = expected
+        zip(next.effects, expected).forEach {
+            _ = unmatchedActual.firstIndex(of: $1).map { unmatchedActual.remove(at: $0) }
+            _ = unmatchedExpected.firstIndex(of: $0).map { unmatchedExpected.remove(at: $0) }
+        }
+        if !unmatchedActual.isEmpty || !unmatchedExpected.isEmpty {
+            return .failure(message: "Expected <\(next.effects)> to contain only <\(expected)>", file: file, line: line)
+        }
+        return .success
+    }
+}
+
+/// Constructs a matcher that matches if the supplied effects are equal to the supplied `Next`.
+///
+/// - Parameter expected: the effects to match (possibly empty)
+/// - Returns: a `Predicate` that matches `Next` instances that include all the supplied effects
+public func hasExactEffects<Model, Effect: Equatable>(
+    _ expected: [Effect],
+    file: StaticString = #file,
+    line: UInt = #line
+) -> NextPredicate<Model, Effect> {
+    return { (next: Next<Model, Effect>) in
+        if next.effects != expected {
+            return .failure(message: "Expected <\(next.effects)> to equal <\(expected)>", file: file, line: line)
         }
         return .success
     }

--- a/MobiusTest/Test/FirstMatchersTests.swift
+++ b/MobiusTest/Test/FirstMatchersTests.swift
@@ -159,7 +159,129 @@ class FirstMatchersTests: QuickSpec {
                     }
 
                     it("should fail with an appropriate error message") {
-                        expect(result?.failureMessage).to(equal("Expected effects <\(actualEffects)> to contain <\(expectedEffects)>"))
+                        expect(result?.failureMessage).to(equal("Expected <\(actualEffects)> to contain <\(expectedEffects)>"))
+                    }
+                }
+            }
+
+            context("when creating a matcher to check that a First has only specific effects") {
+                context("when the First has those effects") {
+                    let expectedEffects = [4, 7, 0]
+
+                    beforeEach {
+                        let first = First<Int, Int>(model: 3, effects: expectedEffects)
+                        let sut: FirstPredicate<Int, Int> = hasOnlyEffects(expectedEffects)
+                        result = sut(first)
+                    }
+
+                    it("should match") {
+                        expect(result?.wasSuccessful).to(beTrue())
+                    }
+                }
+
+                context("when the First has those effects in different order") {
+                    let expectedEffects = [4, 7, 0]
+                    let actualEffects = [0, 7, 4]
+
+                    beforeEach {
+                        let first = First<Int, Int>(model: 3, effects: actualEffects)
+                        let sut: FirstPredicate<Int, Int> = hasOnlyEffects(expectedEffects)
+                        result = sut(first)
+                    }
+
+                    it("should match") {
+                        expect(result?.wasSuccessful).to(beTrue())
+                    }
+                }
+
+                context("when the First contains the expected effects and a few more") {
+                    let expectedEffects = [4, 7, 0]
+                    let actualEffects = [1, 4, 7, 0]
+
+                    beforeEach {
+                        let first = First<Int, Int>(model: 3, effects: actualEffects)
+                        let sut: FirstPredicate<Int, Int> = hasOnlyEffects(expectedEffects)
+                        result = sut(first)
+                    }
+
+                    it("should fail with an appropriate error message") {
+                        expect(result?.failureMessage).to(equal("Expected <\(actualEffects)> to contain only <\(expectedEffects)>"))
+                    }
+                }
+
+                context("when the First does not contain all the expected effects") {
+                    let expectedEffects = [10]
+                    let actualEffects = [4]
+
+                    beforeEach {
+                        let first = First<Int, Int>(model: 3, effects: actualEffects)
+                        let sut: FirstPredicate<Int, Int> = hasOnlyEffects(expectedEffects)
+                        result = sut(first)
+                    }
+
+                    it("should fail with an appropriate error message") {
+                        expect(result?.failureMessage).to(equal("Expected <\(actualEffects)> to contain only <\(expectedEffects)>"))
+                    }
+                }
+            }
+
+            context("when creating a matcher to check that a First has exact effects") {
+                context("when the First has those effects") {
+                    let expectedEffects = [4, 7, 0]
+
+                    beforeEach {
+                        let first = First<Int, Int>(model: 3, effects: expectedEffects)
+                        let sut: FirstPredicate<Int, Int> = hasExactEffects(expectedEffects)
+                        result = sut(first)
+                    }
+
+                    it("should match") {
+                        expect(result?.wasSuccessful).to(beTrue())
+                    }
+                }
+
+                context("when the First has those effects in different order") {
+                    let expectedEffects = [4, 7, 0]
+                    let actualEffects = [0, 7, 4]
+
+                    beforeEach {
+                        let first = First<Int, Int>(model: 3, effects: actualEffects)
+                        let sut: FirstPredicate<Int, Int> = hasExactEffects(expectedEffects)
+                        result = sut(first)
+                    }
+
+                    it("should fail with an appropriate error message") {
+                        expect(result?.failureMessage).to(equal("Expected <\(actualEffects)> to equal <\(expectedEffects)>"))
+                    }
+                }
+
+                context("when the First contains the expected effects and a few more") {
+                    let expectedEffects = [4, 7, 0]
+                    let actualEffects = [1, 4, 7, 0]
+
+                    beforeEach {
+                        let first = First<Int, Int>(model: 3, effects: actualEffects)
+                        let sut: FirstPredicate<Int, Int> = hasExactEffects(expectedEffects)
+                        result = sut(first)
+                    }
+
+                    it("should fail with an appropriate error message") {
+                        expect(result?.failureMessage).to(equal("Expected <\(actualEffects)> to equal <\(expectedEffects)>"))
+                    }
+                }
+
+                context("when the First does not contain all the expected effects") {
+                    let expectedEffects = [10]
+                    let actualEffects = [4]
+
+                    beforeEach {
+                        let first = First<Int, Int>(model: 3, effects: actualEffects)
+                        let sut: FirstPredicate<Int, Int> = hasExactEffects(expectedEffects)
+                        result = sut(first)
+                    }
+
+                    it("should fail with an appropriate error message") {
+                        expect(result?.failureMessage).to(equal("Expected <\(actualEffects)> to equal <\(expectedEffects)>"))
                     }
                 }
             }

--- a/MobiusTest/Test/NextMatchersTests.swift
+++ b/MobiusTest/Test/NextMatchersTests.swift
@@ -348,6 +348,188 @@ class XCTestNextMatchersTests: QuickSpec {
                     }
                 }
             }
+
+            context("when creating a matcher verifying that a Next has only specific effects") {
+                let expected = [1, 2, 3, 4]
+                var sut: NextPredicate<String, Int>!
+
+                beforeEach {
+                    sut = hasOnlyEffects(expected)
+                }
+
+                context("when the effects are the same") {
+                    context("when the effects are in order") {
+                        beforeEach {
+                            let next = Next<String, Int>.dispatchEffects(expected)
+                            result = sut(next)
+                        }
+
+                        it("should match") {
+                            expect(result.wasSuccessful).to(beTrue())
+                        }
+                    }
+
+                    context("when the effects are out of order") {
+                        beforeEach {
+                            var actual = expected
+                            actual.append(actual.removeFirst())
+                            let next = Next<String, Int>.dispatchEffects(actual)
+                            result = sut(next)
+                        }
+
+                        it("should match") {
+                            expect(result.wasSuccessful).to(beTrue())
+                        }
+                    }
+                }
+
+                context("when the Next contains the expected effects and a few more") {
+                    let actual = [1, 2, 3, 4, 5, 0]
+
+                    beforeEach {
+                        let next = Next<String, Int>.dispatchEffects(actual)
+                        result = sut(next)
+                    }
+
+                    it("should fail with an appropriate error message") {
+                        expect(result.failureMessage).to(equal("Expected <\(actual)> to contain only <\(expected)>"))
+                    }
+                }
+
+                context("when the Next does not contain one or more of the expected effects") {
+                    let actual = [1]
+                    let expected = [3]
+
+                    beforeEach {
+                        let next = Next<String, Int>.dispatchEffects(actual)
+                        sut = hasOnlyEffects(expected)
+                        result = sut(next)
+                    }
+
+                    it("should fail with an appropriate error message") {
+                        expect(result.failureMessage).to(equal("Expected <\(actual)> to contain only <\(expected)>"))
+                    }
+                }
+
+                context("when there are no effects") {
+                    context("when not expecting effects") {
+                        beforeEach {
+                            let next = Next<String, String>.noChange
+                            let sut: NextPredicate<String, String> = hasOnlyEffects([])
+                            result = sut(next)
+                        }
+
+                        it("should match") {
+                            expect(result.wasSuccessful).to(beTrue())
+                        }
+                    }
+
+                    context("when expecting effects") {
+                        let expected = [88]
+
+                        beforeEach {
+                            let next = Next<String, Int>.noChange
+                            sut = hasOnlyEffects(expected)
+                            result = sut(next)
+                        }
+
+                        it("should fail with an appropriate error message") {
+                            expect(result.failureMessage).to(equal("Expected <[]> to contain only <\(expected)>"))
+                        }
+                    }
+                }
+            }
+
+            context("when creating a matcher verifying that a Next has exact effects") {
+                let expected = [1, 2, 3, 4]
+                var sut: NextPredicate<String, Int>!
+
+                beforeEach {
+                    sut = hasExactEffects(expected)
+                }
+
+                context("when the effects are the same") {
+                    context("when the effects are in order") {
+                        beforeEach {
+                            let next = Next<String, Int>.dispatchEffects(expected)
+                            result = sut(next)
+                        }
+
+                        it("should match") {
+                            expect(result.wasSuccessful).to(beTrue())
+                        }
+                    }
+
+                    context("when the effects are out of order") {
+                        let actual = [4, 3, 2, 1]
+
+                        beforeEach {
+                            let next = Next<String, Int>.dispatchEffects(actual)
+                            result = sut(next)
+                        }
+
+                        it("should fail with an appropriate error message") {
+                            expect(result.failureMessage).to(equal("Expected <\(actual)> to equal <\(expected)>"))
+                        }
+                    }
+                }
+
+                context("when the Next contains the expected effects and a few more") {
+                    let actual = [1, 2, 3, 4, 5, 0]
+
+                    beforeEach {
+                        let next = Next<String, Int>.dispatchEffects(actual)
+                        result = sut(next)
+                    }
+
+                    it("should fail with an appropriate error message") {
+                        expect(result.failureMessage).to(equal("Expected <\(actual)> to equal <\(expected)>"))
+                    }
+                }
+
+                context("when the Next does not contain one or more of the expected effects") {
+                    let actual = [1]
+                    let expected = [3]
+
+                    beforeEach {
+                        let next = Next<String, Int>.dispatchEffects(actual)
+                        sut = hasExactEffects(expected)
+                        result = sut(next)
+                    }
+
+                    it("should fail with an appropriate error message") {
+                        expect(result.failureMessage).to(equal("Expected <\(actual)> to equal <\(expected)>"))
+                    }
+                }
+
+                context("when there are no effects") {
+                    context("when not expecting effects") {
+                        beforeEach {
+                            let next = Next<String, String>.noChange
+                            let sut: NextPredicate<String, String> = hasExactEffects([])
+                            result = sut(next)
+                        }
+
+                        it("should match") {
+                            expect(result.wasSuccessful).to(beTrue())
+                        }
+                    }
+
+                    context("when expecting effects") {
+                        let expected = [88]
+
+                        beforeEach {
+                            let next = Next<String, Int>.noChange
+                            sut = hasExactEffects(expected)
+                            result = sut(next)
+                        }
+
+                        it("should fail with an appropriate error message") {
+                            expect(result.failureMessage).to(equal("Expected <[]> to equal <\(expected)>"))
+                        }
+                    }
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Introduces a few additional effect matchers to `MobiusTest` and `MobiusNimble`:
- `hasOnlyEffects` / `haveOnlyEffects`: Enforces that _only_ the expected effects are present, regardless of order
- `hasExactEffects` / `haveExactEffects`: Enforces that _only_ the expected effects are present, in the specified order