### PR TITLE
CI updates

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,7 +22,6 @@ jobs:
     - name: Build and Test
       run: Tools/ci-xcode.sh
       env:
-        DEVELOPER_DIR: /Applications/Xcode_12.4.app/Contents/Developer
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   spm:
@@ -32,7 +31,6 @@ jobs:
     - name: Build and Test
       run: Tools/ci-spm.sh
       env:
-        DEVELOPER_DIR: /Applications/Xcode_12.4.app/Contents/Developer
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   swiftlint:

--- a/Tools/ci-xcode.sh
+++ b/Tools/ci-xcode.sh
@@ -10,13 +10,12 @@ cp "$(dirname "$0")/ZZZ_MOBIUS_ALL.xcscheme" "$(dirname "$0")/../Mobius.xcodepro
 # Only install tools when running in CI
 if [[ "$IS_CI" == "1" ]]; then
   heading "Installing Tools"
-  brew install carthage
-  gem install --no-document xcpretty
+  brew install carthage xcbeautify
   export IS_CI=1
 fi
 
 has_command carthage || fail "Carthage must be installed"
-has_command xcpretty || fail "xcpretty must be installed"
+has_command xcbeautify || fail "xcbeautify must be installed"
 
 #
 # Bootstrap with Carthage
@@ -38,7 +37,7 @@ xcb build \
 heading "Building for Simulator (Release)"
 xcb build \
   -scheme ZZZ_MOBIUS_ALL \
-  -sdk iphonesimulator \
+  -destination "generic/platform=iOS Simulator" \
   -configuration Release \
   -derivedDataPath build/DD/Build || \
   fail "Build for Simulator Failed"

--- a/Tools/helpers.sh
+++ b/Tools/helpers.sh
@@ -22,7 +22,7 @@ xcb() {
   set -o pipefail && xcodebuild \
     -UseSanitizedBuildSystemEnvironment=YES \
     CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY= \
-    "$@" | xcpretty
+    "$@" | xcbeautify
 }
 
 dump_log() {


### PR DESCRIPTION
* Switch from the outdated `xcpretty` to [`xcbeautify`](https://github.com/thii/xcbeautify)
* Use generic destination for simulator build to reduce CI noise
* Point at latest-and-greatest xcode