### PR TITLE
Bump Nimble to improve Apple Silicon compatibility

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/Quick/Nimble",
         "state": {
           "branch": null,
-          "revision": "c93f16c25af5770f0d3e6af27c9634640946b068",
-          "version": "9.2.1"
+          "revision": "0bf627cd68085345ac52c165ba02d1f73c584eed",
+          "version": null
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/pointfreeco/swift-case-paths", from: "0.8.0"),
-        .package(url: "https://github.com/Quick/Nimble", from: "9.2.1"),
+        .package(url: "https://github.com/Quick/Nimble", .revision("0bf627cd68085345ac52c165ba02d1f73c584eed")),
         .package(url: "https://github.com/Quick/Quick", from: "4.0.0"),
     ],
     targets: [


### PR DESCRIPTION
This PR bumps Nimble to a version that is more Apple Silicon compatible. More details here: https://github.com/Quick/Nimble/pull/948