### PR TITLE
Fix diff failure due to Swift 5.6 Substring hashing change

### DIFF
--- a/MobiusTest/Source/SimpleDiff.swift
+++ b/MobiusTest/Source/SimpleDiff.swift
@@ -53,9 +53,9 @@ enum Difference: Equatable {
 }
 
 func diff(lhs: ArraySlice<Substring>, rhs: ArraySlice<Substring>) -> [Difference] {
-    var lhsIndexMap = [Substring: [Int]]()
+    var lhsIndexMap = [String: [Int]]()
     for (index, value) in zip(lhs.indices, lhs) {
-        lhsIndexMap[value, default: []].append(index)
+        lhsIndexMap[String(value), default: []].append(index)
     }
 
     var lhsSubStart = lhs.startIndex
@@ -66,7 +66,7 @@ func diff(lhs: ArraySlice<Substring>, rhs: ArraySlice<Substring>) -> [Difference
     for (indexRhs, value) in zip(rhs.indices, rhs) {
         var innerOverlap = [Int: Int]()
 
-        for indexLhs in lhsIndexMap[value, default: []] {
+        for indexLhs in lhsIndexMap[String(value), default: []] {
             let innerSubLength = (overlap[indexLhs - 1] ?? 0) + 1
             innerOverlap[indexLhs] = innerSubLength
             if innerSubLength > subLength {


### PR DESCRIPTION
Swift 5.6 appears to have a behavioral change ([bug?](https://bugs.swift.org/browse/SR-15816)) related to generating the `hashValue` for `Substring` instances. This causes dictionary lookups to miss and the resulting debug diff to contain incorrect data.