### PR TITLE
Dispose viewConnectable synchronously

### DIFF
--- a/MobiusCore/Source/Lock.swift
+++ b/MobiusCore/Source/Lock.swift
@@ -56,16 +56,3 @@ final class Synchronized<Value> {
         }
     }
 }
-
-extension Synchronized where Value: Equatable {
-    func compareAndSwap(expected: Value, with newValue: Value) -> Bool {
-        var success = false
-        self.mutate { value in
-            if value == expected {
-                value = newValue
-                success = true
-            }
-        }
-        return success
-    }
-}

--- a/MobiusCore/Test/AsyncDispatchQueueConnectableTests.swift
+++ b/MobiusCore/Test/AsyncDispatchQueueConnectableTests.swift
@@ -1,0 +1,58 @@
+// Copyright 2019-2022 Spotify AB.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+@testable import MobiusCore
+
+import Foundation
+import Nimble
+import Quick
+
+class AsyncDispatchQueueConnectableTests: QuickSpec {
+    private let acceptQueue = DispatchQueue(label: "accept queue")
+
+    override func spec() {
+        describe("AsyncDispatchQueueConnectable") {
+            var connectable: AsyncDispatchQueueConnectable<String, String>!
+            var underlyingConnectable: RecordingTestConnectable!
+
+            beforeEach {
+                underlyingConnectable = RecordingTestConnectable(expectedQueue: self.acceptQueue)
+                connectable = AsyncDispatchQueueConnectable(underlyingConnectable, acceptQueue: self.acceptQueue)
+            }
+
+            context("when connected") {
+                var connection: Connection<String>!
+                var dispatchedValue: String?
+
+                beforeEach {
+                    connection = connectable.connect { dispatchedValue = $0 }
+                }
+
+                afterEach {
+                    dispatchedValue = nil
+                }
+
+                it("should forward inputs to the underlying connectable") {
+                    connection.accept("S")
+                    expect(underlyingConnectable.recorder.items).toEventually(equal(["S"]))
+                }
+
+                it("should forward outputs from the underlying connectable") {
+                    underlyingConnectable.dispatch("S")
+                    expect(dispatchedValue).to(equal("S"))
+                }
+            }
+        }
+    }
+}

--- a/MobiusCore/Test/MobiusControllerTests.swift
+++ b/MobiusCore/Test/MobiusControllerTests.swift
@@ -127,15 +127,6 @@ class MobiusControllerTests: QuickSpec {
                             controller.start()
                             expect(controller.running).to(beTrue())
                         }
-                        it("should ignore events sent while view disposal is pending") {
-                            self.viewQueue.sync {
-                                controller.stop()
-                                // Sending an event via the view connection here is valid, because the view connection has
-                                // not yet been disposed; that disposal is pending in a block enqueued on the view queue by
-                                // AsyncDispatchQueueConnectable’s asynchronous disposal block
-                                view.dispatchSameQueue("late event")
-                            }
-                        }
                     }
                 }
 
@@ -153,12 +144,12 @@ class MobiusControllerTests: QuickSpec {
                         controller.start()
                     }
 
-                    it("Should dispose any listeners of the model") {
+                    it("should dispose any listeners of the model") {
                         controller.stop()
                         expect(modelObserver.disposed).toEventually(beTrue())
                     }
 
-                    it("Should dispose any effect handlers") {
+                    it("should dispose any effect handlers") {
                         controller.stop()
                         expect(effectObserver.disposed).to(beTrue())
                     }

--- a/MobiusCore/Test/TestingUtil.swift
+++ b/MobiusCore/Test/TestingUtil.swift
@@ -64,8 +64,6 @@ class RecordingTestConnectable: Connectable {
     }
 
     func dispose() {
-        verifyQueue()
-
         disposed = true
     }
 


### PR DESCRIPTION
Asynchronously disposing the controller view connection can lead to unexpected behavior (and ultimately crashes) in certain scenarios. It also differs from how other types (effect handler, event source, loop) are disposed: synchronously on the loop queue.

This contrived example demonstrates how the current implementation will lead to a crash:
```swift
// scenario: executing on main queue, ConnectableClass previously attached via .connectView()
loopController.start()

// queues work for next loop pass
DispatchQueue.main.async {
    // crashes in ConnectableClass .connect() because it executes before the queued dispose
    loopController.start()
}

// stops loop but queues ConnectableClass connection dispose on the acceptQueue (main)
loopController.stop()
```

As I wasn't involved in the original design it's possible I'm missing some important context, but I've attempted to annotate my reasoning for the changes as review comments.