### PR TITLE
Prevent forwarding viewConnectable inputs after dispose

### DIFF
--- a/MobiusCore/Source/Lock.swift
+++ b/MobiusCore/Source/Lock.swift
@@ -56,3 +56,16 @@ final class Synchronized<Value> {
         }
     }
 }
+
+extension Synchronized where Value: Equatable {
+    func compareAndSwap(expected: Value, with newValue: Value) -> Bool {
+        var success = false
+        self.mutate { value in
+            if value == expected {
+                value = newValue
+                success = true
+            }
+        }
+        return success
+    }
+}


### PR DESCRIPTION
Something overlooked in #190 is that the connection disposal was previously executed only _after_ all input forwarding occurred because it was scheduled last.

There needed to be one additional state check in order for the new behavior to also honor the connection contract of not forwarding inputs after dispose. I've added this check and restored a small amount of pre-#190 functionality.

I tested this fix with features that had a number of tests failing as a result of trying to pull in the changes from #190 and it looks to be passing now.