### PR TITLE
Route enum cases without associated values

### DIFF
--- a/MobiusCore/Source/EffectHandlers/EnumRoute.swift
+++ b/MobiusCore/Source/EffectHandlers/EnumRoute.swift
@@ -19,9 +19,14 @@ public extension EffectRouter {
         _ enumCase: @escaping (EffectParameters) -> Effect
     ) -> _PartialEffectRouter<Effect, EffectParameters, Event> {
         let casePath = /enumCase
-        return routeEffects(withParameters: { effect in
-            casePath.extract(from: effect)
-        })
+        return routeEffects(withParameters: casePath.extract)
+    }
+
+    func routeCase(
+        _ enumCase: Effect
+    ) -> _PartialEffectRouter<Effect, Void, Event> {
+        let casePath = /enumCase
+        return routeEffects(withParameters: casePath.extract)
     }
 }
 
@@ -29,12 +34,6 @@ public extension EffectRouter where Effect: Equatable {
     func routeCase(
         _ enumCase: Effect
     ) -> _PartialEffectRouter<Effect, Void, Event> {
-        return routeEffects(withParameters: { effect in
-            if enumCase == effect {
-                return ()
-            } else {
-                return nil
-            }
-        })
+        return routeEffects(withParameters: { effect in effect == enumCase ? () : nil })
     }
 }

--- a/MobiusCore/Test/EffectHandlers/EnumRouteTests.swift
+++ b/MobiusCore/Test/EffectHandlers/EnumRouteTests.swift
@@ -20,7 +20,7 @@ import Quick
 
 private typealias Event = ()
 
-private enum Effect: Equatable {
+private enum Effect {
     case justEffect
     case effectWithString(String)
     case effectWithTuple(left: String, right: Int)


### PR DESCRIPTION
This resolves a small annoyance with effect enums having to conform to `Equatable` in order to use the `.routeCase(…)` API.

This change is backwards compatible and doesn't affect existing implementations.