### PR TITLE
Update Quick to 5.0.1

### DIFF
--- a/MobiusCore/Test/TestingErrorHandler.swift
+++ b/MobiusCore/Test/TestingErrorHandler.swift
@@ -45,7 +45,7 @@ public func raiseError<Out>(capture: ((String, String, UInt) -> Void)? = nil) ->
 private class ErrorHandlerConfiguration: QuickConfiguration {
     /// This is run before any Quick tests and registers `beforeEach`/`afterEach` handlers that run “outside” those
     /// set up by the tests.
-    override class func configure(_ configuration: Configuration) {
+    override class func configure(_ configuration: QCKConfiguration) {
         configuration.beforeEach {
             MobiusHooks.setErrorHandler { message, file, line in
                 MobiusThrowableAssertion(message: message, file: String(file), line: line).throw()

--- a/Package.resolved
+++ b/Package.resolved
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/Quick/Quick",
         "state": {
           "branch": null,
-          "revision": "bd86ca0141e3cfb333546de5a11ede63f0c4a0e6",
-          "version": "4.0.0"
+          "revision": "f9d519828bb03dfc8125467d8f7b93131951124c",
+          "version": "5.0.1"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/pointfreeco/swift-case-paths", from: "0.8.0"),
         .package(url: "https://github.com/Quick/Nimble", from: "10.0.0"),
-        .package(url: "https://github.com/Quick/Quick", from: "4.0.0"),
+        .package(url: "https://github.com/Quick/Quick", from: "5.0.1"),
     ],
     targets: [
         .target(name: "MobiusCore", dependencies: ["CasePaths"], path: "MobiusCore/Source"),


### PR DESCRIPTION
Fixes some issues running tests in Xcode 14 (or really 13.3+, see the Quick 5.0 [release notes](https://github.com/Quick/Quick/releases/tag/v5.0.0))