### PR TITLE
Update CasePaths to 0.10.1

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -42,8 +42,8 @@
         "repositoryURL": "https://github.com/pointfreeco/swift-case-paths",
         "state": {
           "branch": null,
-          "revision": "241301b67d8551c26d8f09bd2c0e52cc49f18007",
-          "version": "0.8.0"
+          "revision": "bb436421f57269fbcfe7360735985321585a86e5",
+          "version": "0.10.1"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
         .library(name: "MobiusTest", targets: ["MobiusTest"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/pointfreeco/swift-case-paths", from: "0.8.0"),
+        .package(url: "https://github.com/pointfreeco/swift-case-paths", from: "0.10.1"),
         .package(url: "https://github.com/Quick/Nimble", from: "10.0.0"),
         .package(url: "https://github.com/Quick/Quick", from: "5.0.1"),
     ],


### PR DESCRIPTION
Includes a few bugfixes as well as Concurrency compatibility.

[Full Changelog](https://github.com/pointfreeco/swift-case-paths/compare/0.8.0...0.10.1)