### PR TITLE
Adjust CasePaths dependency version requirement

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
         .library(name: "MobiusTest", targets: ["MobiusTest"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/pointfreeco/swift-case-paths", from: "0.10.1"),
+        .package(url: "https://github.com/pointfreeco/swift-case-paths", .upToNextMinor(from: "0.10.1")),
         .package(url: "https://github.com/Quick/Nimble", from: "10.0.0"),
         .package(url: "https://github.com/Quick/Quick", from: "5.0.1"),
     ],


### PR DESCRIPTION
Using `.package(url:from:)` is allowing the dependency to resolve newer, incompatible releases — [`0.11.0`](https://github.com/pointfreeco/swift-case-paths/compare/0.10.1...0.11.0) introduced OS version requirements that differ from those of this library.

Fixes https://github.com/spotify/Mobius.swift/issues/198