### PR TITLE
Disambiguate Nimble Predicate usage

### DIFF
--- a/MobiusCore/Test/TestingErrorHandler.swift
+++ b/MobiusCore/Test/TestingErrorHandler.swift
@@ -10,7 +10,7 @@ import Quick
 /// for example in `beforeEach`, that will take precedence and this predicate won’t work.
 ///
 /// - Parameter capture: An optional block which is invoked with the message, file and line of the error invocation.
-public func raiseError<Out>(capture: ((String, String, UInt) -> Void)? = nil) -> Predicate<Out> {
+public func raiseError<Out>(capture: ((String, String, UInt) -> Void)? = nil) -> Nimble.Predicate<Out> {
     // This is a simplified version of Nimble’s throwAssertion() that piggybacks on Objective-C exceptions.
     return Predicate { actualExpression in
         let message = ExpectationMessage.expectedTo("throw an assertion")


### PR DESCRIPTION
As of Xcode 15, Foundation now defines its own [`Predicate`](https://developer.apple.com/documentation/foundation/predicate) type so it has become necessary to specify that a function is returning Nimble's type.