### PR TITLE
MobiusCore: Add connect to MobiusLoop

### DIFF
--- a/MobiusCore/Test/MobiusLoopTests.swift
+++ b/MobiusCore/Test/MobiusLoopTests.swift
@@ -115,7 +115,7 @@ class MobiusLoopTests: QuickSpec {
 
                     _ = loop.connect(modelConnectable)
                     let subscription = loop.connect(
-                        AnyConnectable({ consumer in
+                        AnyConnectable({ _ in
                             Connection(
                                 acceptClosure: { model in secondModelSet.append(model) },
                                 disposeClosure: {}


### PR DESCRIPTION
Adds a `connect` function to MobiusLoop that can be used to connect a `Connectable` to the loop.