### PR TITLE
Add `asDisposable` convenience property to `Task`

### DIFF
--- a/MobiusCore/Source/Disposables/Task+Disposable.swift
+++ b/MobiusCore/Source/Disposables/Task+Disposable.swift
@@ -1,6 +1,28 @@
+// Copyright 2019-2024 Spotify AB.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 public extension Task {
 
+    /// A disposable for use with `EffectHandler` that will cancel the task
+    ///
+    ///     func handle(_ parameters: Void, _ callback: EffectCallback<Event>) -> Disposable {
+    ///         Task {
+    ///
+    ///         }
+    ///        .asDisposable
+    ///     }
     var asDisposable: any Disposable {
         AnonymousDisposable { cancel() }
     }

--- a/MobiusCore/Source/Disposables/Task+Disposable.swift
+++ b/MobiusCore/Source/Disposables/Task+Disposable.swift
@@ -23,7 +23,7 @@ public extension Task {
     ///         }
     ///        .asDisposable
     ///     }
-    var asDisposable: any Disposable {
+    var asDisposable: some Disposable {
         AnonymousDisposable { cancel() }
     }
 }

--- a/MobiusCore/Source/Disposables/Task+Disposable.swift
+++ b/MobiusCore/Source/Disposables/Task+Disposable.swift
@@ -1,0 +1,7 @@
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+public extension Task {
+
+    var asDisposable: any Disposable {
+        AnonymousDisposable { cancel() }
+    }
+}

--- a/MobiusCore/Test/Task+DisposableTests.swift
+++ b/MobiusCore/Test/Task+DisposableTests.swift
@@ -1,0 +1,29 @@
+import MobiusCore
+import Nimble
+import Quick
+
+@available(iOS 13.0, *)
+class TaskDisposableTests: QuickSpec {
+    override func spec() {
+        describe("Task+Disposable") {
+            var task: Task<Void, any Error>!
+            var disposable: Disposable!
+
+            beforeEach {
+                task = Task {
+                    try? await Task.sleep(nanoseconds: 1_000_000_000)
+                }
+                disposable = task.asDisposable
+            }
+
+            it("starts off not cancelled") {
+                expect(task.isCancelled).to(beFalse())
+            }
+
+            it("disposable cancels the task that owns it") {
+                disposable.dispose()
+                expect(task.isCancelled).to(beTrue())
+            }
+        }
+    }
+}


### PR DESCRIPTION
Offers a convenient way to return Tasks as a `Disposable` instead of having to wrap it with `AnonymousDisposable`, for example in an `EffectHandler`

**Example usage**
```
extension LoadLyricsModelEffectHandler: EffectHandler {
    func handle(_ playbackData: PlaybackData, _ callback: EffectCallback<CardViewEvent>) -> Disposable {
        Task {
            do {
                let model = try await dataLoader.fetch(for: playbackData.track)
                callback.send(.receivedLyricsModel(model, for: playbackData))
            } catch {
                callback.send(.receivedError(for: playbackData))
            }
        }
        .asDisposable
    }
}
```