### PR TITLE
Bump swiftlint action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,6 +23,6 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: GitHub Action for SwiftLint
-      uses: norio-nomura/action-swiftlint@3.0.1
+      uses: norio-nomura/action-swiftlint@3.2.1
       with:
         args: lint --no-cache --strict

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -5,11 +5,9 @@ disabled_rules:
   - superfluous_disable_command # Disabled since we disable some rules pre-emptively to avoid issues in the future
   - todo                        # Disabled while we are filling out the framework; re-enable when we get closer to completion
   - nesting                     # Does not make sense anymore since Swift 4 uses nested `CodingKeys` enums for example
-
   - implicit_return             # Suddenly started firing for existing code on PRs, should investigate later
 
 opt_in_rules:
-  - anyobject_protocol
   - attributes
   - closure_end_indentation
   - closure_spacing
@@ -29,7 +27,6 @@ opt_in_rules:
   - first_where
   - identical_operands
   - implicit_return
-  - inert_defer
   - joined_default_parameter
   - literal_expression_end_indentation
   - legacy_hashing
@@ -55,6 +52,7 @@ opt_in_rules:
   - trailing_whitespace
   - unneeded_parentheses_in_closure_argument
   - vertical_parameter_alignment_on_call
+  - weak_delegate
   - yoda_condition
 
 excluded:
@@ -71,8 +69,8 @@ attributes:
     - "@NSManaged"
     - "@objc"
 closure_spacing: warning
-empty_count: warning
-explicit_init: warning
+empty_count:
+  severity: warning
 fatal_error_message: warning
 file_header:
   severity: warning

--- a/MobiusCore/Test/AnonymousDisposableTests.swift
+++ b/MobiusCore/Test/AnonymousDisposableTests.swift
@@ -17,7 +17,7 @@ import Nimble
 import Quick
 
 class AnonymousDisposableTests: QuickSpec {
-    // swiftlint:disable function_body_length
+    // swiftlint:disable:next function_body_length
     override func spec() {
         describe("AnonymousDisposable") {
             var disposable: AnonymousDisposable!

--- a/MobiusCore/Test/ConnectablePublisherTests.swift
+++ b/MobiusCore/Test/ConnectablePublisherTests.swift
@@ -18,7 +18,7 @@ import Nimble
 import Quick
 
 class ConnectablePublisherTests: QuickSpec {
-    // swiftlint:disable function_body_length
+    // swiftlint:disable:next function_body_length
     override func spec() {
         describe("ConnectablePublisher") {
             var publisher: ConnectablePublisher<String>!

--- a/MobiusCore/Test/EffectHandlers/AnyEffectHandlerTests.swift
+++ b/MobiusCore/Test/EffectHandlers/AnyEffectHandlerTests.swift
@@ -20,7 +20,7 @@ private typealias Effect = String
 private typealias Event = String
 
 class AnyEffectHandlerTests: QuickSpec {
-    // swiftlint:disable function_body_length
+    // swiftlint:disable:next function_body_length
     override func spec() {
         describe("AnyEffectHandler") {
             var effectHandler: AnyEffectHandler<Effect, Event>!

--- a/MobiusCore/Test/EffectHandlers/CallbackTests.swift
+++ b/MobiusCore/Test/EffectHandlers/CallbackTests.swift
@@ -17,7 +17,7 @@ import Nimble
 import Quick
 
 class CallbackTests: QuickSpec {
-    // swiftlint:disable function_body_length
+    // swiftlint:disable:next function_body_length
     override func spec() {
         describe("Callbacks") {
             context("Ending a Callback") {

--- a/MobiusCore/Test/EffectHandlers/EffectHandlerTests.swift
+++ b/MobiusCore/Test/EffectHandlers/EffectHandlerTests.swift
@@ -27,10 +27,7 @@ private enum Event {
     case eventForEffect1
 }
 
-// swiftlint:disable type_body_length file_length
-
 class EffectHandlerTests: QuickSpec {
-    // swiftlint:disable function_body_length
     override func spec() {
         describe("Handling effects with EffectHandler") {
             var effectHandler: AnyEffectHandler<Effect, Event>!
@@ -63,6 +60,7 @@ class EffectHandlerTests: QuickSpec {
                 }
             }
         }
+
         describe("Disposing EffectHandler") {
             it("calls the returned disposable when disposing") {
                 var disposed = false

--- a/MobiusCore/Test/EffectHandlers/EffectRouterDSLTests.swift
+++ b/MobiusCore/Test/EffectHandlers/EffectRouterDSLTests.swift
@@ -16,8 +16,6 @@ import MobiusCore
 import Nimble
 import Quick
 
-// swiftlint:disable type_body_length file_length
-
 private enum Effect: Equatable {
     case effect1
     case effect2
@@ -29,7 +27,7 @@ private enum Event: Equatable {
 }
 
 class EffectRouterDSLTests: QuickSpec {
-    // swiftlint:disable function_body_length
+    // swiftlint:disable:next function_body_length
     override func spec() {
         context("An EffectHandler which always ends as soon as it is called") {
             var wasDisposed: Bool!

--- a/MobiusCore/Test/EffectHandlers/EffectRouterTests.swift
+++ b/MobiusCore/Test/EffectHandlers/EffectRouterTests.swift
@@ -17,8 +17,6 @@ import MobiusCore
 import Nimble
 import Quick
 
-// swiftlint:disable type_body_length file_length
-
 private enum Effect {
     case effect1
     case effect2
@@ -32,7 +30,7 @@ private enum Event {
 }
 
 class EffectRouterTests: QuickSpec {
-    // swiftlint:disable function_body_length
+    // swiftlint:disable:next function_body_length
     override func spec() {
         context("Router happy paths") {
             var receivedEvents: [Event]!

--- a/MobiusCore/Test/EffectHandlers/EnumRouteTests.swift
+++ b/MobiusCore/Test/EffectHandlers/EnumRouteTests.swift
@@ -16,8 +16,6 @@ import MobiusCore
 import Nimble
 import Quick
 
-// swiftlint:disable type_body_length file_length
-
 private typealias Event = ()
 
 private enum Effect {
@@ -48,7 +46,6 @@ private func unwrap<Input, Parameters, Output>(
 }
 
 class ParameterExtractionRouteTests: QuickSpec {
-    // swiftlint:disable function_body_length
     override func spec() {
         context("Different types of enums being unwrapped") {
             it("supports routing to an effect with nothing to unwrap") {

--- a/MobiusCore/Test/EventSources/CompositeEventSourceBuilderTests.swift
+++ b/MobiusCore/Test/EventSources/CompositeEventSourceBuilderTests.swift
@@ -17,7 +17,7 @@ import Nimble
 import Quick
 
 class CompositeEventSourceBuilderTest: QuickSpec {
-    // swiftlint:disable function_body_length
+    // swiftlint:disable:next function_body_length
     override func spec() {
         var eventsReceived: [Int]!
         var compositeEventSource: AnyEventSource<Int>!

--- a/MobiusCore/Test/MobiusControllerTests.swift
+++ b/MobiusCore/Test/MobiusControllerTests.swift
@@ -18,13 +18,13 @@ import Foundation
 import Nimble
 import Quick
 
-// swiftlint:disable type_body_length file_length
-
+// swiftlint:disable file_length
+// swiftlint:disable:next type_body_length
 class MobiusControllerTests: QuickSpec {
     let loopQueue = DispatchQueue(label: "loop queue")
     let viewQueue = DispatchQueue(label: "view queue")
 
-    // swiftlint:disable function_body_length
+    // swiftlint:disable:next function_body_length
     override func spec() {
         describe("MobiusController") {
             var controller: MobiusController<String, String, String>!

--- a/MobiusCore/Test/MobiusIntegrationTests.swift
+++ b/MobiusCore/Test/MobiusIntegrationTests.swift
@@ -19,7 +19,7 @@ import Quick
 
 // Should only test public APIs
 class MobiusIntegrationTests: QuickSpec {
-    // swiftlint:disable function_body_length
+    // swiftlint:disable:next function_body_length
     override func spec() {
         describe("Mobius integration tests") {
             let update = Update<String, String, String> { _, event in

--- a/MobiusCore/Test/MobiusLoopTests.swift
+++ b/MobiusCore/Test/MobiusLoopTests.swift
@@ -18,7 +18,7 @@ import Nimble
 import Quick
 
 class MobiusLoopTests: QuickSpec {
-    // swiftlint:disable function_body_length
+    // swiftlint:disable:next function_body_length
     override func spec() {
         describe("MobiusLoop") {
             var builder: Mobius.Builder<String, String, String>!

--- a/MobiusCore/Test/NonReentrancyTests.swift
+++ b/MobiusCore/Test/NonReentrancyTests.swift
@@ -37,7 +37,7 @@ private enum Effect: String, CustomStringConvertible, Equatable {
 }
 
 class NonReentrancyTests: QuickSpec {
-    // swiftlint:disable function_body_length
+    // swiftlint:disable:next function_body_length
     override func spec() {
         describe("MobiusLoop") {
             var loop: MobiusLoop<Model, Event, Effect>!

--- a/MobiusCore/Test/WorkBagTests.swift
+++ b/MobiusCore/Test/WorkBagTests.swift
@@ -17,7 +17,7 @@ import Nimble
 import Quick
 
 class WorkBagTests: QuickSpec {
-    // swiftlint:disable function_body_length
+    // swiftlint:disable:next function_body_length
     override func spec() {
         describe("WorkBag") {
             var workBag: WorkBag!

--- a/MobiusExtras/Test/ConnectableClassTests.swift
+++ b/MobiusExtras/Test/ConnectableClassTests.swift
@@ -20,7 +20,7 @@ import Quick
 @testable import MobiusExtras
 
 class ConnectableTests: QuickSpec {
-    // swiftlint:disable function_body_length
+    // swiftlint:disable:next function_body_length
     override func spec() {
         describe("ConnectableClass") {
             beforeEach {

--- a/MobiusExtras/Test/WikiTutorialTest.swift
+++ b/MobiusExtras/Test/WikiTutorialTest.swift
@@ -18,8 +18,7 @@ import XCTest
 
 /// Test cases that reproduce the Getting Started section of the GitHub wiki
 class WikiTutorialTest: XCTestCase {
-    // swiftlint:disable function_body_length
-
+    // swiftlint:disable:next function_body_length
     func testWikiCreatingALoop() {
         // Standin implementation of print()
         var printedValues: [String] = []
@@ -62,6 +61,7 @@ class WikiTutorialTest: XCTestCase {
         XCTAssertEqual(printedValues, ["2", "1", "0", "0", "1", "2", "1"])
     }
 
+    // swiftlint:disable:next function_body_length
     func testWikiCreatingALoop_addingEffects() {
         // Standin implementation of print()
         var printedValues: [String] = []

--- a/MobiusNimble/Test/NimbleFirstMatchersTests.swift
+++ b/MobiusNimble/Test/NimbleFirstMatchersTests.swift
@@ -19,8 +19,9 @@ import Nimble
 import Quick
 import XCTest
 
+// swiftlint:disable:next type_body_length
 class NimbleFirstMatchersTests: QuickSpec {
-    // swiftlint:disable function_body_length
+    // swiftlint:disable:next function_body_length
     override func spec() {
         let assertionHandler = AssertionRecorder()
         var defaultHandler: AssertionHandler?

--- a/MobiusNimble/Test/NimbleNextMatchersTests.swift
+++ b/MobiusNimble/Test/NimbleNextMatchersTests.swift
@@ -23,9 +23,9 @@ import XCTest
 // is replaced in order to be inspected
 
 // swiftlint:disable file_length
-// swiftlint:disable type_body_length
+// swiftlint:disable:next type_body_length
 class NimbleNextMatchersTests: QuickSpec {
-    // swiftlint:disable function_body_length
+    // swiftlint:disable:next function_body_length
     override func spec() {
         let assertionHandler = AssertionRecorder()
         var defaultHandler: AssertionHandler?

--- a/MobiusTest/Test/DebugDiffTests.swift
+++ b/MobiusTest/Test/DebugDiffTests.swift
@@ -26,9 +26,9 @@ enum TestEnum: Equatable {
     case first, second(String), third(Int)
 }
 
-// swiftlint:disable type_body_length
+// swiftlint:disable:next type_body_length
 class DebugDiffTests: QuickSpec {
-    // swiftlint:disable function_body_length
+    // swiftlint:disable:next function_body_length
     override func spec() {
         describe("DumpDiff") {
             var diff: String?

--- a/MobiusTest/Test/FirstMatchersTests.swift
+++ b/MobiusTest/Test/FirstMatchersTests.swift
@@ -18,7 +18,7 @@ import Nimble
 import Quick
 
 class FirstMatchersTests: QuickSpec {
-    // swiftlint:disable function_body_length
+    // swiftlint:disable:next function_body_length
     override func spec() {
         describe("assertThatFirst") {
             var failureMessages: [String] = []

--- a/MobiusTest/Test/NextMatchersTests.swift
+++ b/MobiusTest/Test/NextMatchersTests.swift
@@ -22,9 +22,9 @@ import XCTest
 // is replaced in order to be inspected
 
 // swiftlint:disable file_length
-// swiftlint:disable type_body_length
+// swiftlint:disable:next type_body_length
 class XCTestNextMatchersTests: QuickSpec {
-    // swiftlint:disable function_body_length
+    // swiftlint:disable:next function_body_length
     override func spec() {
         describe("AssertThatNext") {
             var failMessages: [String] = []

--- a/MobiusTest/Test/UpdateSpecTests.swift
+++ b/MobiusTest/Test/UpdateSpecTests.swift
@@ -36,7 +36,7 @@ enum MyEffect {
 }
 
 class UpdateSpecTests: QuickSpec {
-    // swiftlint:disable function_body_length
+    // swiftlint:disable:next function_body_length
     override func spec() {
         let updateSpec = UpdateSpec(myUpdate)
 


### PR DESCRIPTION
The version that's currently in use [points to a docker image](https://github.com/norio-nomura/action-swiftlint/blob/3c67ce2e382be797d968883944140ffa0113f737/Dockerfile#L1) that [hasn't been updated in 3 years](https://hub.docker.com/r/norionomura/swiftlint/tags?name=swift-5.1).

This change uses the latest version (and should fix the invalid linter errors found in #206).