### PR TITLE
EventSource as Connectable

### DIFF
--- a/MobiusCore/Test/InitializationTests.swift
+++ b/MobiusCore/Test/InitializationTests.swift
@@ -1,0 +1,134 @@
+// Copyright 2019-2024 Spotify AB.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+@testable import MobiusCore
+import Nimble
+import Quick
+
+class InitializationTests: QuickSpec {
+    // swiftlint:disable:next function_body_length
+    override func spec() {
+        describe("Initialization") {
+            var builder: Mobius.Builder<String, String, String>!
+            var updateFunction: Update<String, String, String>!
+            var loop: MobiusLoop<String, String, String>!
+            var receivedModels: [String]!
+            var modelObserver: Consumer<String>!
+            var effectHandler: RecordingTestConnectable!
+            var eventSource: TestEventSource<String>!
+            var connectableEventSource: TestConnectableEventSource<String, String>!
+
+            beforeEach {
+                receivedModels = []
+
+                modelObserver = { receivedModels.append($0) }
+
+                updateFunction = Update<String, String, String> { _, event in
+                    if event == "event that triggers effect" {
+                        return Next.next(event, effects: [event])
+                    } else {
+                        return Next.next(event)
+                    }
+                }
+
+                effectHandler = RecordingTestConnectable()
+                eventSource = TestEventSource()
+                connectableEventSource = .init()
+
+            }
+
+            it("should process init") {
+                builder = Mobius.loop(update: updateFunction, effectHandler: effectHandler)
+
+                loop = builder.start(from: "the first model")
+
+                loop.addObserver(modelObserver)
+
+                expect(receivedModels).to(equal(["the first model"]))
+            }
+
+            it("should process init and then events") {
+                builder = Mobius.loop(update: updateFunction, effectHandler: effectHandler)
+
+                loop = builder.start(from: "the first model")
+
+                loop.addObserver(modelObserver)
+                loop.dispatchEvent("event that triggers effect")
+
+                expect(receivedModels).to(equal(["the first model", "event that triggers effect"]))
+            }
+
+            it("should process init before events from connectable event source") {
+                builder = Mobius.loop(update: updateFunction, effectHandler: effectHandler)
+                    .withEventSource(connectableEventSource)
+
+                connectableEventSource.dispatch("ignored event from connectable event source")
+                loop = builder.start(from: "the first model")
+                loop.addObserver(modelObserver)
+
+                connectableEventSource.dispatch("second event from connectable event source")
+
+                // The first event was sent before the loop started so it should be ignored. The second should go through
+                expect(receivedModels).to(equal(["the first model", "second event from connectable event source"]))
+            }
+
+            it("should process init before events from event source") {
+                builder = Mobius.loop(update: updateFunction, effectHandler: effectHandler)
+                    .withEventSource(eventSource)
+
+                eventSource.dispatch("ignored event from event source")
+                loop = builder.start(from: "the first model")
+                loop.addObserver(modelObserver)
+
+                eventSource.dispatch("second event from event source")
+
+                // The first event was sent before the loop started so it should be ignored. The second should go through
+                expect(receivedModels).to(equal(["the first model", "second event from event source"]))
+            }
+        }
+    }
+}
+
+// Emits values before returning the connection
+class EagerTestConnectable: Connectable {
+    private(set) var consumer: Consumer<String>?
+    private(set) var recorder: Recorder<String>
+    private(set) var eagerValue: String
+
+    private(set) var connection: Connection<String>!
+
+    init(eagerValue: String) {
+        self.recorder = Recorder()
+        self.eagerValue = eagerValue
+    }
+
+    func connect(_ consumer: @escaping (String) -> Void) -> Connection<String> {
+        self.consumer = consumer
+        connection = Connection(acceptClosure: accept, disposeClosure: dispose) // Will retain self
+        connection.accept(eagerValue) // emit before returning
+        return connection
+    }
+
+    func dispatch(_ string: String) {
+        consumer?(string)
+    }
+
+    func accept(_ value: String) {
+        recorder.append(value)
+    }
+
+    func dispose() {
+    }
+}

--- a/MobiusCore/Test/MobiusControllerTests.swift
+++ b/MobiusCore/Test/MobiusControllerTests.swift
@@ -28,8 +28,11 @@ class MobiusControllerTests: QuickSpec {
     override func spec() {
         describe("MobiusController") {
             var controller: MobiusController<String, String, String>!
+            var updateFunction: Update<String, String, String>!
+            var initiate: Initiate<String, String>!
             var view: RecordingTestConnectable!
             var eventSource: TestEventSource<String>!
+            var connectableEventSource: TestConnectableEventSource<String, String>!
             var effectHandler: RecordingTestConnectable!
             var activateInitiator: Bool!
 
@@ -42,13 +45,13 @@ class MobiusControllerTests: QuickSpec {
                 view = RecordingTestConnectable(expectedQueue: self.viewQueue)
                 let loopQueue = self.loopQueue
 
-                let updateFunction = Update<String, String, String> { model, event in
+                updateFunction = .init { model, event in
                     dispatchPrecondition(condition: .onQueue(loopQueue))
                     return .next("\(model)-\(event)")
                 }
 
                 activateInitiator = false
-                let initiate: Initiate<String, String> = { model in
+                initiate = .init { model in
                     if activateInitiator {
                         return First(model: "\(model)-init", effects: ["initEffect"])
                     } else {
@@ -57,6 +60,7 @@ class MobiusControllerTests: QuickSpec {
                 }
 
                 eventSource = TestEventSource()
+
                 effectHandler = RecordingTestConnectable()
 
                 controller = Mobius.loop(update: updateFunction, effectHandler: effectHandler)
@@ -354,6 +358,46 @@ class MobiusControllerTests: QuickSpec {
 
                     expect(view.recorder.items).toEventually(equal(["S", "S-event source event"]))
                 }
+            }
+
+            describe("dispatching events using a connectable") {
+                beforeEach {
+                    // Rebuild the controller but use the Connectable instead of plain EventSource
+                    connectableEventSource = .init()
+
+                    controller = Mobius.loop(update: updateFunction, effectHandler: effectHandler)
+                        .withEventSource(connectableEventSource)
+                        .makeController(
+                            from: "S",
+                            initiate: initiate,
+                            loopQueue: self.loopQueue,
+                            viewQueue: self.viewQueue
+                        )
+                    controller.connectView(view)
+                    controller.start()
+                }
+
+                it("should dispatch events from the event source") {
+                    connectableEventSource.dispatch("event source event")
+
+                    expect(view.recorder.items).toEventually(equal(["S", "S-event source event"]))
+                }
+
+                it("should receive models from the event source") {
+                    view.dispatch("new model")
+                    expect(connectableEventSource.models).toEventually(equal(["S", "S-new model"]))
+                }
+
+                it("should allow the event source to change with model updates") {
+                    connectableEventSource.modelSwitch = { model in
+                        model != "S-stop"
+                    }
+
+                    view.dispatch("stop")
+                    view.dispatch("new model 2")
+                    expect(connectableEventSource.models).toEventually(equal(["S", "S-new model 2"]))
+                }
+
             }
 
             describe("deallocating") {

--- a/MobiusCore/Test/TestingUtil.swift
+++ b/MobiusCore/Test/TestingUtil.swift
@@ -205,7 +205,7 @@ class TestConnectableEventSource<Model, Event>: Connectable {
     private(set) var connections: [Connection] = []
     private(set) var models: [Model] = []
     private var pendingEvent: Event?
-    var modelSwitch: ((Model) -> Bool)?
+    var shouldProcessModel: ((Model) -> Bool) = { _ in true }
 
     var activeConnections: [Consumer<Event>] {
         return connections.compactMap {
@@ -233,9 +233,9 @@ class TestConnectableEventSource<Model, Event>: Connectable {
 
         return .init(
             acceptClosure: { [weak self] model in
-                let shouldProcessModel = self?.modelSwitch?(model) ?? false
-                if shouldProcessModel {
-                    self?.models.append(model)
+                guard let self else { return }
+                if shouldProcessModel(model) {
+                    models.append(model)
                 }
             }, disposeClosure: { [weak self] in
                 self?.connections[index] = .disposed


### PR DESCRIPTION
### What
Added a way to inject an eventSource of type `Connectable<Model, Event>`
Made it backwards compatible with existing API

### Why
Allow for conditional subscriptions based on the state of the loop

### Reference
Inspired by [these changes](https://github.com/spotify/mobius/pull/67)