### PR TITLE
Update SwiftLint file_header configuration

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -57,11 +57,10 @@ opt_in_rules:
 
 excluded:
   - .build
-  - build
-  - Carthage
-  - Other
   - Tools
   - Templates
+  - Package.swift
+  - MobiusTest/Source/SimpleDiff.swift
 
 attributes:
   always_on_same_line:
@@ -73,15 +72,9 @@ empty_count:
   severity: warning
 fatal_error_message: warning
 file_header:
-  severity: warning
-  forbidden_pattern: |
-                     \/\/
-                     \/\/  .*?\..*
-                     \/\/  .*
-                     \/\/
-                     \/\/  Created by .*? on .*\.
-                     \/\/  Copyright © \d{4} .*\. All rights reserved\.
-                     \/\/
+  required_pattern: |
+    \/\/ Copyright Spotify AB.
+    \/\/ SPDX-License-Identifier: Apache-2.0
 force_cast: warning
 force_try: warning
 implicit_getter: warning

--- a/MobiusCore/Test/InitializationTests.swift
+++ b/MobiusCore/Test/InitializationTests.swift
@@ -1,16 +1,5 @@
-// Copyright 2019-2024 Spotify AB.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright Spotify AB.
+// SPDX-License-Identifier: Apache-2.0
 
 import Foundation
 @testable import MobiusCore


### PR DESCRIPTION
This was missing from #212, and #211 (which was merged after) contained a file with a conflicting header.

To verify that these differences should be caught in the future, I'm opening this PR without updating [InitializationTests.swift](https://github.com/spotify/Mobius.swift/blob/8bc883f91d63a007a2ad4cbdb902648e36261a08/MobiusCore/Test/InitializationTests.swift) to confirm that the build fails with the violation. I'll then add a commit with the updated header to get the build passing.